### PR TITLE
consensus: add more descriptive error messages for transaction validation

### DIFF
--- a/consensus/accumulator.go
+++ b/consensus/accumulator.go
@@ -198,22 +198,46 @@ func (sa *StateAccumulator) containsObject(so stateObject) bool {
 	return false
 }
 
-// ContainsUnspentSiacoinOutput returns true if o is a valid unspent output in
-// the accumulator.
+// ContainsUnspentSiacoinOutput returns true if the accumulator contains o as an
+// unspent output.
 func (sa *StateAccumulator) ContainsUnspentSiacoinOutput(o types.SiacoinOutput) bool {
 	return sa.containsObject(siacoinOutputStateObject(o, 0))
 }
 
-// ContainsUnspentSiafundOutput returns true if o is a valid unspent output in
-// the accumulator.
+// ContainsSpentSiacoinOutput returns true if the accumulator contains o as a
+// spent output.
+func (sa *StateAccumulator) ContainsSpentSiacoinOutput(o types.SiacoinOutput) bool {
+	return sa.containsObject(siacoinOutputStateObject(o, flagSpent))
+}
+
+// ContainsUnspentSiafundOutput returns true if the accumulator contains o as an
+// unspent output.
 func (sa *StateAccumulator) ContainsUnspentSiafundOutput(o types.SiafundOutput) bool {
 	return sa.containsObject(siafundOutputStateObject(o, 0))
 }
 
-// ContainsUnresolvedFileContract returns true if fc is a valid unresolved file
-// contract in the accumulator.
+// ContainsSpentSiafundOutput returns true if the accumulator contains o as a
+// spent output.
+func (sa *StateAccumulator) ContainsSpentSiafundOutput(o types.SiafundOutput) bool {
+	return sa.containsObject(siafundOutputStateObject(o, flagSpent))
+}
+
+// ContainsUnresolvedFileContract returns true if the accumulator contains fc as an
+// unresolved file contract.
 func (sa *StateAccumulator) ContainsUnresolvedFileContract(fc types.FileContract) bool {
 	return sa.containsObject(fileContractStateObject(fc, 0))
+}
+
+// ContainsValidFileContract returns true if the accumulator contains fc as a
+// resolved-valid file contract.
+func (sa *StateAccumulator) ContainsValidFileContract(fc types.FileContract) bool {
+	return sa.containsObject(fileContractStateObject(fc, flagSpent))
+}
+
+// ContainsMissedFileContract returns true if the accumulator contains fc as a
+// resolved-missed file contract.
+func (sa *StateAccumulator) ContainsMissedFileContract(fc types.FileContract) bool {
+	return sa.containsObject(fileContractStateObject(fc, flagSpent|flagExpired))
 }
 
 // addNewObjects adds the supplied objects to the accumulator, filling in their

--- a/types/types.go
+++ b/types/types.go
@@ -572,6 +572,11 @@ func (ci ChainIndex) String() string {
 }
 
 // String implements fmt.Stringer.
+func (oid OutputID) String() string {
+	return fmt.Sprintf("%v:%v", oid.TransactionID, oid.Index)
+}
+
+// String implements fmt.Stringer.
 func (a Address) String() string { return stringerHex("addr", a[:]) }
 
 // MarshalJSON implements json.Marshaler.


### PR DESCRIPTION
This patch provides more specific error messages for the various transaction validation checks.  I erred on the side of verbosity but we may not need that much verbosity for some things like the overflow checks in outputsEqualInputs.