### PR TITLE
Add Currency tests

### DIFF
--- a/consensus/scratch_test.go
+++ b/consensus/scratch_test.go
@@ -32,7 +32,7 @@ func mineBlock(vc ValidationContext, parent types.Block, txns ...types.Transacti
 }
 
 func TestScratchChain(t *testing.T) {
-	pubkey, privkey := testingKeypair()
+	pubkey, privkey := testingKeypair(0)
 	ourAddr := types.StandardAddress(pubkey)
 
 	b := genesisWithBeneficiaries([]types.Beneficiary{

--- a/types/currency.go
+++ b/types/currency.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math/big"
 	"math/bits"
 	"strings"
@@ -23,6 +24,20 @@ func Siafunds(n uint16) Currency { return NewCurrency64(uint64(n)) }
 // Currency represents a quantity of hastings as an unsigned 128-bit number.
 type Currency struct {
 	Lo, Hi uint64
+}
+
+// Format implements fmt.Formatter. It accepts the formats
+// 's', 'v' (Siacoin representation - rounded to 3 decimal places), or
+// 'd' (exact value, useful for outputing Siafunds or Hastings).
+func (c Currency) Format(f fmt.State, v rune) {
+	switch v {
+	case 's', 'v':
+		f.Write([]byte(c.String()))
+	case 'd':
+		f.Write([]byte(c.ExactString()))
+	default:
+		fmt.Fprintf(f, "%%!%c(unsupported,Currency=%d)", v, c)
+	}
 }
 
 // IsZero returns true if c == 0.

--- a/types/currency_test.go
+++ b/types/currency_test.go
@@ -1,0 +1,481 @@
+package types
+
+import (
+	"math"
+	"testing"
+)
+
+var maxCurrency = NewCurrency(math.MaxUint64, math.MaxUint64)
+
+func mustParseCurrency(s string) Currency {
+	c, err := ParseCurrency(s)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func TestCurrencyCmp(t *testing.T) {
+	tests := []struct {
+		a, b Currency
+		want int
+	}{
+		{
+			ZeroCurrency,
+			ZeroCurrency,
+			0,
+		},
+		{
+			ZeroCurrency,
+			NewCurrency64(5),
+			-1,
+		},
+		{
+			NewCurrency64(5),
+			ZeroCurrency,
+			1,
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(0, 1),
+			0,
+		},
+		{
+			NewCurrency(math.MaxUint64, 0),
+			NewCurrency(0, 1),
+			-1,
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(math.MaxUint64, 0),
+			1,
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.a.Cmp(tt.b); got != tt.want {
+			t.Errorf("Currency.Cmp(%d, %d) expected = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCurrencyAdd(t *testing.T) {
+	tests := []struct {
+		a, b, want Currency
+	}{
+		{
+			ZeroCurrency,
+			ZeroCurrency,
+			ZeroCurrency,
+		},
+		{
+			NewCurrency(1, 0),
+			NewCurrency(1, 0),
+			NewCurrency(2, 0),
+		},
+		{
+			NewCurrency(200, 0),
+			NewCurrency(50, 0),
+			NewCurrency(250, 0),
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(0, 1),
+			NewCurrency(0, 2),
+		},
+		{
+			NewCurrency(0, 71),
+			NewCurrency(math.MaxUint64, 0),
+			NewCurrency(math.MaxUint64, 71),
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.a.Add(tt.b); !got.Equals(tt.want) {
+			t.Errorf("Currency.Add(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCurrencyAddWithOverflow(t *testing.T) {
+	tests := []struct {
+		a, b, want Currency
+		overflows  bool
+	}{
+		{
+			ZeroCurrency,
+			ZeroCurrency,
+			ZeroCurrency,
+			false,
+		},
+		{
+			NewCurrency(1, 0),
+			NewCurrency(1, 0),
+			NewCurrency(2, 0),
+			false,
+		},
+		{
+			NewCurrency(200, 0),
+			NewCurrency(50, 0),
+			NewCurrency(250, 0),
+			false,
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(0, 1),
+			NewCurrency(0, 2),
+			false,
+		},
+		{
+			NewCurrency(0, 71),
+			NewCurrency(math.MaxUint64, 0),
+			NewCurrency(math.MaxUint64, 71),
+			false,
+		},
+		{
+			maxCurrency,
+			NewCurrency64(1),
+			ZeroCurrency,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		got, overflows := tt.a.AddWithOverflow(tt.b)
+		if tt.overflows != overflows {
+			t.Errorf("Currency.AddWithOverflow(%d, %d) overflow %t, want %t", tt.a, tt.b, overflows, tt.overflows)
+		} else if !got.Equals(tt.want) {
+			t.Errorf("Currency.AddWithOverflow(%d, %d) expected = %v, got %v", tt.a, tt.b, tt.want, got)
+		}
+	}
+}
+
+func TestCurrencySub(t *testing.T) {
+	tests := []struct {
+		a, b, want Currency
+	}{
+		{
+			ZeroCurrency,
+			ZeroCurrency,
+			ZeroCurrency,
+		},
+		{
+			NewCurrency(1, 0),
+			NewCurrency(1, 0),
+			ZeroCurrency,
+		},
+		{
+			NewCurrency(1, 0),
+			ZeroCurrency,
+			NewCurrency(1, 0),
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(math.MaxUint64, 0),
+			NewCurrency(1, 0),
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(1, 0),
+			NewCurrency(math.MaxUint64, 0),
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.a.Sub(tt.b); !got.Equals(tt.want) {
+			t.Errorf("Currency.Sub(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCurrencyMul64(t *testing.T) {
+	tests := []struct {
+		a    Currency
+		b    uint64
+		want Currency
+	}{
+		{
+			ZeroCurrency,
+			0,
+			ZeroCurrency,
+		},
+		{
+			NewCurrency(1, 0),
+			1,
+			NewCurrency(1, 0),
+		},
+		{
+			NewCurrency(0, 1),
+			1,
+			NewCurrency(0, 1),
+		},
+		{
+			NewCurrency(0, 1),
+			math.MaxUint64,
+			NewCurrency(0, math.MaxUint64),
+		},
+		{
+			Siacoins(30),
+			50,
+			Siacoins(1500),
+		},
+		{
+			NewCurrency(math.MaxUint64, 0),
+			2,
+			NewCurrency(math.MaxUint64-1, 1),
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.a.Mul64(tt.b); !got.Equals(tt.want) {
+			t.Errorf("Currency.Mul64(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCurrencyDiv(t *testing.T) {
+	tests := []struct {
+		a, b, want Currency
+	}{
+		{
+			ZeroCurrency,
+			NewCurrency64(1),
+			ZeroCurrency,
+		},
+		{
+			NewCurrency(1, 0),
+			NewCurrency(1, 0),
+			NewCurrency(1, 0),
+		},
+		{
+			Siacoins(156),
+			NewCurrency(2, 0),
+			Siacoins(78),
+		},
+		{
+			Siacoins(300),
+			Siacoins(2),
+			NewCurrency(150, 0),
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(1, 0),
+			NewCurrency(0, 1),
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(0, 1),
+			NewCurrency(1, 0),
+		},
+		{
+			NewCurrency(0, 1),
+			NewCurrency(2, 0),
+			NewCurrency(math.MaxUint64/2+1, 0),
+		},
+		{
+			NewCurrency(8262254095159001088, 2742357),
+			NewCurrency64(2),
+			NewCurrency(13354499084434276352, 1371178),
+		},
+		{
+			maxCurrency,
+			NewCurrency64(2),
+			NewCurrency(math.MaxUint64, math.MaxUint64/2),
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.a.Div(tt.b); !got.Equals(tt.want) {
+			t.Errorf("Currency.Div(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCurrencyDiv64(t *testing.T) {
+	tests := []struct {
+		a    Currency
+		b    uint64
+		want Currency
+	}{
+		{
+			ZeroCurrency,
+			1,
+			ZeroCurrency,
+		},
+		{
+			NewCurrency64(1),
+			1,
+			NewCurrency64(1),
+		},
+		{
+			Siacoins(156),
+			2,
+			Siacoins(78),
+		},
+		{
+			maxCurrency,
+			2,
+			NewCurrency(math.MaxUint64, math.MaxUint64/2),
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.a.Div64(tt.b); !got.Equals(tt.want) {
+			t.Errorf("Currency.Div64(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCurrencyExactString(t *testing.T) {
+	tests := []struct {
+		val  Currency
+		want string
+	}{
+		{
+			ZeroCurrency,
+			"0",
+		},
+		{
+			Siacoins(128),
+			"128000000000000000000000000",
+		},
+		{
+			NewCurrency64(math.MaxUint64),
+			"18446744073709551615",
+		},
+		{
+			NewCurrency(8262254095159001088, 2742357),
+			"50587566000000000000000000",
+		},
+		{
+			maxCurrency,
+			"340282366920938463463374607431768211455",
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.val.ExactString(); got != tt.want {
+			t.Errorf("Currency.ExactString() = %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestCurrencyString(t *testing.T) {
+	tests := []struct {
+		val  Currency
+		want string
+	}{
+		{
+			ZeroCurrency,
+			"0",
+		},
+		{
+			NewCurrency64(10000),
+			"0",
+		},
+		{
+			NewCurrency(8262254095159001088, 2742357),
+			"50.588",
+		},
+		{
+			NewCurrency(2174395257947586975, 137),
+			"0.003",
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.val.String(); got != tt.want {
+			t.Errorf("Currency.String() = %v (%d), want %v", got, tt.val, tt.want)
+		}
+	}
+}
+
+func TestCurrencyJSON(t *testing.T) {
+	tests := []struct {
+		val  Currency
+		want string
+	}{
+		{
+			ZeroCurrency,
+			`"0"`,
+		},
+		{
+			NewCurrency64(10000),
+			`"10000"`,
+		},
+		{
+			mustParseCurrency("50587566000000000000000000"),
+			`"50587566000000000000000000"`,
+		},
+		{
+			mustParseCurrency("2529378333356156158367"),
+			`"2529378333356156158367"`,
+		},
+	}
+	for _, tt := range tests {
+		// MarshalJSON cannot error
+		buf, _ := tt.val.MarshalJSON()
+		if string(buf) != tt.want {
+			t.Errorf("Currency.MarshalJSON(%d) = %v, want %v", tt.val, buf, tt.want)
+			continue
+		}
+
+		var c Currency
+		if err := c.UnmarshalJSON(buf); err != nil {
+			t.Errorf("Currency.UnmarshalJSON(%s) err = %v", buf, err)
+		} else if !c.Equals(tt.val) {
+			t.Errorf("Currency.UnmarshalJSON(%s) = %d, want %d", buf, c, tt.val)
+		}
+	}
+}
+
+func TestParseCurrency(t *testing.T) {
+	tests := []struct {
+		desc    string
+		s       string
+		want    Currency
+		wantErr bool
+	}{
+		{
+			"empty value",
+			"",
+			ZeroCurrency,
+			true,
+		},
+		{
+			"negative value",
+			"-1",
+			ZeroCurrency,
+			true,
+		},
+		{
+			"overflow",
+			"340282366920938463463374607431768211456",
+			ZeroCurrency,
+			true,
+		},
+		{
+			"0 SC",
+			"0",
+			ZeroCurrency,
+			false,
+		},
+		{
+			"10000 H",
+			"10000",
+			NewCurrency64(10000),
+			false,
+		},
+		{
+			"50.587566 SC",
+			"50587566000000000000000000",
+			NewCurrency(8262254095159001088, 2742357),
+			false,
+		},
+		{
+			"0.00252934 SC",
+			"2529378333356156158367",
+			NewCurrency(2174395257947586975, 137),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		got, err := ParseCurrency(tt.s)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseCurrency(%v) error = %v, wantErr %v", tt.s, err, tt.wantErr)
+		} else if !got.Equals(tt.want) {
+			t.Errorf("ParseCurrency(%v) = %d, want %d", tt.s, got, tt.want)
+		}
+	}
+}

--- a/types/policy_test.go
+++ b/types/policy_test.go
@@ -1,0 +1,93 @@
+package types
+
+import (
+	"testing"
+)
+
+func mustParsePublicKey(s string) (pk PublicKey) {
+	err := pk.UnmarshalJSON([]byte(`"` + s + `"`))
+	if err != nil {
+		panic(err)
+	}
+	return
+}
+
+func TestPolicyAddressString(t *testing.T) {
+	publicKeys := []PublicKey{
+		mustParsePublicKey("ed25519:42d33219eb9e7d52d4a4edff215e36535d9d82c9439497a05ab7712193d43282"),
+		mustParsePublicKey("ed25519:b908477c624679a2dc934a662e43c22844595902f1c8dc29b7f8caf2e0369cc9"),
+		mustParsePublicKey("ed25519:11aa63482223329fb8b8313da78cc58820f2933cc621e0ef275c305092ea3704"),
+	}
+
+	tests := []struct {
+		policy SpendPolicy
+		want   string
+	}{
+		{
+			PolicyAbove(50),
+			"addr:e38c9fe65f9297af77381dc718b1c8a775262cfdde08dc3da1116dee081fadf26ca7e015dd71",
+		},
+		{
+			PolicyPublicKey(publicKeys[0]),
+			"addr:e4b6f506599b1fdc27545f5d3cfd0bcd2fed2940bc9aaa74142d3279c0687b529e1d70be6def",
+		},
+		{
+			AnyoneCanSpend(),
+			"addr:d0f42fc75e6d3c7b21429ab2f60c78a04f8a599bf8d5a89ca6a299c6f88b738d671c9d57183a",
+		},
+		{
+			PolicyThreshold{},
+			"addr:d0f42fc75e6d3c7b21429ab2f60c78a04f8a599bf8d5a89ca6a299c6f88b738d671c9d57183a",
+		},
+		{
+			PolicyThreshold{
+				N: 1,
+				Of: []SpendPolicy{
+					PolicyPublicKey(publicKeys[0]),
+				},
+			},
+			"addr:36375ad986e8c064a5c3a73ade03c72da0f3b4cacfb69eef39fe3c115c4ac4c63299c631a5b4",
+		},
+		{
+			PolicyThreshold{
+				N: 1,
+				Of: []SpendPolicy{
+					PolicyPublicKey(publicKeys[0]),
+					PolicyThreshold{
+						N: 2,
+						Of: []SpendPolicy{
+							PolicyAbove(50),
+							PolicyPublicKey(publicKeys[1]),
+						},
+					},
+				},
+			},
+			"addr:5ce2aadfd0c5c5009491974960938ba2e19260110394d10a26578d8c3fcd7f0976d0b369a732",
+		},
+		{
+			PolicyThreshold{
+				N: 2,
+				Of: []SpendPolicy{
+					PolicyPublicKey(publicKeys[0]),
+					PolicyPublicKey(publicKeys[1]),
+					PolicyPublicKey(publicKeys[2]),
+				},
+			},
+			"addr:c186c3563a4c6a98343a64c0f4981d809fd95f2630df15cb266e809424ec11f44de4a902c222",
+		},
+		{
+			policy: PolicyUnlockConditions{
+				PublicKeys: []PublicKey{
+					publicKeys[0],
+				},
+				SignaturesRequired: 1,
+			},
+			want: "addr:2f4a4a64712545bde8d38776377da2794d54685284a3768f78884643dad33a9a3822a0f4dc39",
+		},
+	}
+	for _, tt := range tests {
+		if got := PolicyAddress(tt.policy).String(); got != tt.want {
+			t.Errorf("wrong address for %T(%v)", tt.policy, tt.policy)
+		}
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -19,9 +19,10 @@ import (
 )
 
 var (
-	// ErrAddressLength is returned when parsing an address that is not the
-	// correct length.
-	ErrAddressLength = fmt.Errorf("address must be 32 bytes")
+	// ErrInvalidLength is returned when parsing a string that is not the correct length.
+	ErrInvalidLength = fmt.Errorf("invalid length")
+	// ErrInvalidFormat is returned when a parsed string is not in the correct format.
+	ErrInvalidFormat = errors.New("invalid format")
 )
 
 // EphemeralLeafIndex is used as the LeafIndex of Outputs that are created and
@@ -490,8 +491,8 @@ func (a *Address) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// NewAddressFromString parses an address from a prefixed hex encoded string.
-func NewAddressFromString(s string) (a Address, err error) {
+// ParseAddress parses an address from a prefixed hex encoded string.
+func ParseAddress(s string) (a Address, err error) {
 	err = a.UnmarshalJSON([]byte(`"` + s + `"`))
 	return
 }


### PR DESCRIPTION
The legacy address test is currently failing because of the `addr:` prefix,  I wasn't sure if that was intentional or not.
```
addr:2f4a4a64712545bde8d38776377da2794d54685284a3768f78884643dad33a9a3822a0f4dc39
```
```
2f4a4a64712545bde8d38776377da2794d54685284a3768f78884643dad33a9a3822a0f4dc39
```