### PR TITLE
Encoding overhaul

### DIFF
--- a/consensus/accumulator.go
+++ b/consensus/accumulator.go
@@ -76,8 +76,10 @@ func siacoinOutputStateObject(o types.SiacoinOutput, flags uint64) stateObject {
 	defer hasherPool.Put(h)
 	h.Reset()
 
-	h.EncodeAll(o.ID, o.Value, o.Address)
-	h.WriteUint64(o.Timelock)
+	o.ID.EncodeTo(h.E)
+	o.Value.EncodeTo(h.E)
+	o.Address.EncodeTo(h.E)
+	h.E.WriteUint64(o.Timelock)
 	return stateObject{
 		objHash:   h.Sum(),
 		leafIndex: o.LeafIndex,
@@ -91,7 +93,10 @@ func siafundOutputStateObject(o types.SiafundOutput, flags uint64) stateObject {
 	defer hasherPool.Put(h)
 	h.Reset()
 
-	h.EncodeAll(o.ID, o.Value, o.Address, o.ClaimStart)
+	o.ID.EncodeTo(h.E)
+	o.Value.EncodeTo(h.E)
+	o.Address.EncodeTo(h.E)
+	o.ClaimStart.EncodeTo(h.E)
 	return stateObject{
 		objHash:   h.Sum(),
 		leafIndex: o.LeafIndex,
@@ -104,7 +109,9 @@ func fileContractStateObject(fc types.FileContract, flags uint64) stateObject {
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
-	h.EncodeAll(fc.ID, fc.State)
+
+	fc.ID.EncodeTo(h.E)
+	fc.State.EncodeTo(h.E)
 	return stateObject{
 		objHash:   h.Sum(),
 		leafIndex: fc.LeafIndex,

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -37,10 +37,10 @@ func TestEncoderRoundtrip(t *testing.T) {
 	for _, val := range tests {
 		var buf bytes.Buffer
 		e := NewEncoder(&buf)
-		e.Encode(val)
+		val.EncodeTo(e)
 		e.Flush()
 		decptr := reflect.New(reflect.TypeOf(val))
-		NewBufDecoder(buf.Bytes()).Decode(decptr.Interface().(DecoderFrom))
+		decptr.Interface().(DecoderFrom).DecodeFrom(NewBufDecoder(buf.Bytes()))
 		dec := decptr.Elem().Interface()
 		if !reflect.DeepEqual(dec, val) {
 			t.Fatalf("value did not survive roundtrip: expected %v, got %v", val, dec)
@@ -119,10 +119,10 @@ func TestEncoderCompleteness(t *testing.T) {
 	checkFn := func(txn Transaction) bool {
 		var buf bytes.Buffer
 		e := NewEncoder(&buf)
-		e.Encode(txn)
+		txn.EncodeTo(e)
 		e.Flush()
 		var decTxn Transaction
-		NewBufDecoder(buf.Bytes()).Decode(&decTxn)
+		decTxn.DecodeFrom(NewBufDecoder(buf.Bytes()))
 		return reflect.DeepEqual(txn, decTxn)
 	}
 

--- a/types/policy.go
+++ b/types/policy.go
@@ -95,9 +95,9 @@ func PolicyAddress(p SpendPolicy) Address {
 		// derivation code for these policies
 		return Address(unlockConditionsRoot(uc))
 	}
-	e := NewHasher()
-	e.WritePolicy(p)
-	return Address(e.Sum())
+	h := NewHasher()
+	h.E.WritePolicy(p)
+	return Address(h.Sum())
 }
 
 // StandardAddress computes the address for a single public key policy.

--- a/types/types.go
+++ b/types/types.go
@@ -212,7 +212,7 @@ func (txn *Transaction) ID() TransactionID {
 	h := hasherPool.Get().(*Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
-	h.Encode(*txn)
+	txn.EncodeTo(h.E)
 	return TransactionID(h.Sum())
 }
 


### PR DESCRIPTION
Some big changes here...

`Decoder` now takes a `LimitedReader`. This is part of a long struggle to prevent adversarial inputs from triggering an out-of-memory panic during decoding. Whereas the original Sia decoder requires an "allocation limit," the new decoder makes things a little friendlier by requiring the length of the stream. In fact, the new decoder doesn't (directly) concern itself with allocation at all, only stream length; its `ReadPrefix` takes no `elemSize` argument. In effect, it treats all slices the same as `[]byte`: 1 byte per element. The upside is that clients no longer need to worry about supplying an accurate `elemSize` (which often involves calls to `unsafe.Sizeof`, which technically isn't even correct). The downside is that adversaries can cause the new decoder to allocate much more memory than the old decoder. What saves us is that it's only *linear* increase; a factor of 40, for example. (I think the worst is something like 320.) Say you're decoding a 2 MB block; an adversary can insert a length prefix that causes you to allocate 40 x 2 MB = 80 MB, or at worst, 320 x 2 MB = 640 MB. A few microseconds later, you hit EOF, decoding fails, you ban the peer, and the memory is quickly freed. Big whoop. As long as all of the types involved are reasonably sized, we should never have to worry about panics.

A more conservative approach would be to stop pre-allocating slices entirely. That is:
```go
// instead of this:
foos := make([]Foo, d.ReadPrefix())
for i := range foos {
    foos[i] = // ...
}

// do this:
var foos []Foo
for n := d.ReadPrefix(); n > 0; n-- {
    foos = append(foos, // ...
}
```
This feels a bit awkward though, so maybe only use it for large types? Alternatively, we could add a `ReadSizedPrefix` method that takes an `elemSize`. Clearly there's a lot of room for improvement here, but at least switching to `LimitedReader` is a step in the right direction.

Moving on: types can now implement `EncoderTo` and `DecoderFrom` interfaces. Tying the encoding to the type itself still doesn't sit quite right with me, but none of the alternatives seem much better. However, the core types (e.g. `Transaction`) do *not* implement these interfaces; instead, `Encoder` and `Decoder` provide specialized methods for all core types. Is this a good approach? I don't know. Clearly there must be specialized methods for *some* types, like `uint64` and `time.Time`; and for trivial types like `Hash256` and `InputSignature`,  implementing `EncoderTo` would feel kinda silly. But where do we draw the line? Unclear.

Lastly, I went ahead and embedded `Encoder` in `Hasher`, removing the need for all those redundant methods. Over the years, I've come to believe that embedding is *almost never* the right decision, but in this case I'm making a rare exception. Hopefully I don't end up regretting it.