### PR TITLE
merkle: expand test coverage

### DIFF
--- a/merkle/accumulator_test.go
+++ b/merkle/accumulator_test.go
@@ -8,7 +8,7 @@ import (
 	"lukechampine.com/frand"
 )
 
-func TestUpdateLeaves(t *testing.T) {
+func TestUpdateLeavesSiacoin(t *testing.T) {
 	outputs := make([]types.SiacoinElement, 8)
 	leaves := make([]ElementLeaf, len(outputs))
 	for i := range outputs {
@@ -18,6 +18,11 @@ func TestUpdateLeaves(t *testing.T) {
 	acc.addLeaves(leaves)
 	for i := range outputs {
 		outputs[i].StateElement = leaves[i].StateElement
+	}
+	for _, leaf := range leaves {
+		if !acc.containsLeaf(leaf) {
+			t.Fatal("accumulator missing leaf that was added to it")
+		}
 	}
 
 	updated := []ElementLeaf{
@@ -45,8 +50,14 @@ func TestUpdateLeaves(t *testing.T) {
 		switch i {
 		case 0, 2, 3, 5, 6:
 			addOutput(o, true)
+			if !acc.ContainsSpentSiacoinElement(o) {
+				t.Fatal("accumulator missing spent siacoin element")
+			}
 		default:
 			addOutput(o, false)
+			if acc.ContainsSpentSiacoinElement(o) {
+				t.Fatal("accumulator missing unspent siacoin element")
+			}
 		}
 	}
 	for i := range acc2.Trees {
@@ -56,6 +67,255 @@ func TestUpdateLeaves(t *testing.T) {
 			}
 			if acc2.Trees[i] != acc.Trees[i] {
 				t.Fatal("mismatch")
+			}
+		}
+	}
+}
+
+func TestUpdateLeavesSiafund(t *testing.T) {
+	outputs := make([]types.SiafundElement, 8)
+	leaves := make([]ElementLeaf, len(outputs))
+	for i := range outputs {
+		leaves[i] = SiafundLeaf(outputs[i], false)
+	}
+	var acc ElementAccumulator
+	acc.addLeaves(leaves)
+	for i := range outputs {
+		outputs[i].StateElement = leaves[i].StateElement
+	}
+	for _, leaf := range leaves {
+		if !acc.containsLeaf(leaf) {
+			t.Fatal("accumulator missing leaf that was added to it")
+		}
+	}
+
+	updated := []ElementLeaf{
+		SiafundLeaf(outputs[0], true),
+		SiafundLeaf(outputs[2], true),
+		SiafundLeaf(outputs[3], true),
+		SiafundLeaf(outputs[5], true),
+		SiafundLeaf(outputs[6], true),
+	}
+
+	acc.updateLeaves(updated)
+
+	var acc2 Accumulator
+	addOutput := func(o types.SiafundElement, spent bool) {
+		// seek to first open slot, merging nodes as we go
+		root := SiafundLeaf(o, spent).Hash()
+		i := 0
+		for ; acc2.hasTreeAtHeight(i); i++ {
+			root = NodeHash(acc2.Trees[i], root)
+		}
+		acc2.Trees[i] = root
+		acc2.NumLeaves++
+	}
+	for i, o := range outputs {
+		switch i {
+		case 0, 2, 3, 5, 6:
+			addOutput(o, true)
+			if !acc.ContainsSpentSiafundElement(o) {
+				t.Fatal("accumulator missing spent siafund element")
+			}
+		default:
+			addOutput(o, false)
+			if acc.ContainsSpentSiafundElement(o) {
+				t.Fatal("accumulator missing unspent siafund element")
+			}
+		}
+	}
+	for i := range acc2.Trees {
+		if acc2.hasTreeAtHeight(i) {
+			if !acc2.hasTreeAtHeight(i) {
+				t.Fatal("mismatch")
+			}
+			if acc2.Trees[i] != acc.Trees[i] {
+				t.Fatal("mismatch")
+			}
+		}
+	}
+}
+
+func TestApplyBlock(t *testing.T) {
+	// create some elements and add them to the initial accumulator
+	sces := make([]types.SiacoinElement, 7)
+	sfes := make([]types.SiafundElement, 7)
+	fces := make([]types.FileContractElement, 7)
+	leaves := make([]ElementLeaf, 0, len(sces)+len(sfes)+len(fces))
+	for i := range sces {
+		sces[i].ID.Index = uint64(len(leaves))
+		leaves = append(leaves, SiacoinLeaf(sces[i], false))
+	}
+	for i := range sfes {
+		sfes[i].ID.Index = uint64(len(leaves))
+		leaves = append(leaves, SiafundLeaf(sfes[i], false))
+	}
+	for i := range fces {
+		fces[i].ID.Index = uint64(len(leaves))
+		leaves = append(leaves, FileContractLeaf(fces[i], false))
+	}
+	var acc ElementAccumulator
+	acc.NumLeaves = 6
+	acc.ApplyBlock(nil, leaves)
+	for i := range sces {
+		sces[i].StateElement = leaves[i].StateElement
+	}
+	for i := range sfes {
+		sfes[i].StateElement = leaves[len(sces)+i].StateElement
+	}
+	for i := range fces {
+		fces[i].StateElement = leaves[len(sces)+len(sfes)+i].StateElement
+	}
+	// all leaves should be present in the accumulator
+	for _, sce := range sces {
+		if !acc.ContainsUnspentSiacoinElement(sce) || acc.ContainsSpentSiacoinElement(sce) {
+			t.Fatal("unspent siacoin element should be reflected in accumulator")
+		}
+	}
+	for _, sfe := range sfes {
+		if !acc.ContainsUnspentSiafundElement(sfe) || acc.ContainsSpentSiafundElement(sfe) {
+			t.Fatal("unspent siafund element should be reflected in accumulator")
+		}
+	}
+	for _, fce := range fces {
+		if !acc.ContainsUnresolvedFileContractElement(fce) || acc.ContainsResolvedFileContractElement(fce) {
+			t.Fatal("unresolved file contract should be reflected in accumulator")
+		}
+	}
+
+	// mark some of the leaves as spent
+	spent := []ElementLeaf{
+		SiacoinLeaf(sces[0], true),
+		SiafundLeaf(sfes[0], true),
+		FileContractLeaf(fces[0], true),
+	}
+	// ApplyBlock will modify both acc and spent; save copies for later
+	oldAcc := acc
+	oldSpent := append([]ElementLeaf(nil), spent...)
+	for i := range oldSpent {
+		oldSpent[i].MerkleProof = append([]types.Hash256(nil), oldSpent[i].MerkleProof...)
+	}
+	eau := acc.ApplyBlock(spent, nil)
+	// update proofs
+	for i := range sces {
+		eau.UpdateElementProof(&sces[i].StateElement)
+	}
+	for i := range sfes {
+		eau.UpdateElementProof(&sfes[i].StateElement)
+	}
+	for i := range fces {
+		eau.UpdateElementProof(&fces[i].StateElement)
+	}
+	// the spent leaves should be marked as such in the accumulator
+	if !acc.ContainsSpentSiacoinElement(sces[0]) || acc.ContainsUnspentSiacoinElement(sces[0]) {
+		t.Fatal("spent siacoin element should be reflected in accumulator")
+	}
+	if !acc.ContainsSpentSiafundElement(sfes[0]) || acc.ContainsUnspentSiafundElement(sfes[0]) {
+		t.Fatal("spent siafund element should be reflected in accumulator")
+	}
+	if !acc.ContainsResolvedFileContractElement(fces[0]) || acc.ContainsUnresolvedFileContractElement(fces[0]) {
+		t.Fatal("resolved file contract should be reflected in accumulator")
+	}
+	// other leaves should still be unspent
+	for _, sce := range sces[1:] {
+		if !acc.ContainsUnspentSiacoinElement(sce) || acc.ContainsSpentSiacoinElement(sce) {
+			t.Fatal("unspent siacoin element should be reflected in accumulator")
+		}
+	}
+	for _, sfe := range sfes[1:] {
+		if !acc.ContainsUnspentSiafundElement(sfe) || acc.ContainsSpentSiafundElement(sfe) {
+			t.Fatal("unspent siafund element should be reflected in accumulator")
+		}
+	}
+	for _, fce := range fces[1:] {
+		if !acc.ContainsUnresolvedFileContractElement(fce) || acc.ContainsResolvedFileContractElement(fce) {
+			t.Fatal("unresolved file contract should be reflected in accumulator")
+		}
+	}
+
+	// restore old copies and revert the block
+	acc = oldAcc
+	spent = oldSpent
+	eru := acc.RevertBlock(spent)
+	// update proofs
+	for i := range sces {
+		eru.UpdateElementProof(&sces[i].StateElement)
+	}
+	for i := range sfes {
+		eru.UpdateElementProof(&sfes[i].StateElement)
+	}
+	for i := range fces {
+		eru.UpdateElementProof(&fces[i].StateElement)
+	}
+
+	// all leaves should be unspent again
+	for _, sce := range sces {
+		if !acc.ContainsUnspentSiacoinElement(sce) || acc.ContainsSpentSiacoinElement(sce) {
+			t.Fatal("unspent siacoin element should be reflected in accumulator")
+		}
+	}
+	for _, sfe := range sfes {
+		if !acc.ContainsUnspentSiafundElement(sfe) || acc.ContainsSpentSiafundElement(sfe) {
+			t.Fatal("unspent siafund element should be reflected in accumulator")
+		}
+	}
+	for _, fce := range fces {
+		if !acc.ContainsUnresolvedFileContractElement(fce) || acc.ContainsResolvedFileContractElement(fce) {
+			t.Fatal("unresolved file contract should be reflected in accumulator")
+		}
+	}
+}
+
+func TestHistoryAccumulator(t *testing.T) {
+	blocks := make([]types.ChainIndex, 16)
+	for i := range blocks {
+		blocks[i].Height = uint64(i)
+		frand.Read(blocks[i].ID[:])
+	}
+
+	// test every subset of blocks 0..n
+	for n := 1; n < len(blocks); n++ {
+		// insert blocks into accumulator
+		var acc HistoryAccumulator
+		var accs []HistoryAccumulator
+		proofs := make([][]types.Hash256, n)
+		for i, index := range blocks[:n] {
+			accs = append(accs, acc)
+			hau := acc.ApplyBlock(index)
+			proofs[i] = hau.HistoryProof()
+			for j := 0; j < i; j++ {
+				hau.UpdateProof(&proofs[j])
+			}
+		}
+		// check that all blocks are present
+		for i, index := range blocks[:n] {
+			if !acc.Contains(index, proofs[i]) {
+				t.Fatal("history accumulator missing block")
+			}
+		}
+		// check that using the wrong proof doesn't work
+		for _, proof := range proofs[1:] {
+			if acc.Contains(blocks[0], proof) {
+				t.Fatal("history accumulator claims to contain block with wrong proof")
+			}
+		}
+
+		// revert each block
+		for i := n - 1; i >= 0; i-- {
+			// revert latest block
+			acc := accs[i]
+			eru := acc.RevertBlock(blocks[i])
+			// update proofs of remaining blocks
+			for j := 0; j < i; j++ {
+				eru.UpdateProof(uint64(j), &proofs[j])
+			}
+			// check that blocks < i are still present, and blocks >= i are not
+			for j, index := range blocks[:n] {
+				if j < i && !acc.Contains(index, proofs[j]) {
+					t.Fatal("history accumulator missing block")
+				} else if acc.Contains(index, proofs[i]) {
+					t.Fatal("history accumulator contains reverted block")
+				}
 			}
 		}
 	}

--- a/merkle/multiproof_test.go
+++ b/merkle/multiproof_test.go
@@ -1,0 +1,65 @@
+package merkle
+
+import (
+	"bytes"
+	"go.sia.tech/core/types"
+	"io"
+	"math"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+)
+
+func TestEncoding(t *testing.T) {
+	var quickValue func(t reflect.Type, rand *rand.Rand) reflect.Value
+	quickValue = func(t reflect.Type, rand *rand.Rand) reflect.Value {
+		if t.String() == "types.SpendPolicy" {
+			return reflect.ValueOf(types.PolicyAbove(0))
+		}
+
+		v := reflect.New(t).Elem()
+		switch t.Kind() {
+		default:
+			v, _ = quick.Value(t, rand)
+		case reflect.Slice:
+			v.Set(reflect.MakeSlice(t, 1, 1))
+			for i := 0; i < v.Len(); i++ {
+				v.Index(i).Set(quickValue(t.Elem(), rand))
+			}
+		case reflect.Struct:
+			for i := 0; i < v.NumField(); i++ {
+				if t.Field(i).Name == "MerkleProof" {
+					// compressed versions don't have MerkleProofs
+					v.Field(i).Set(reflect.ValueOf(make([]types.Hash256, 0)))
+				} else {
+					v.Field(i).Set(quickValue(t.Field(i).Type, rand))
+				}
+			}
+		}
+		return v
+	}
+
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+	d := types.NewDecoder(io.LimitedReader{R: &buf, N: math.MaxInt64})
+
+	var block CompressedBlock
+	for i := 0; i < 10; i++ {
+		block.Transactions = append(block.Transactions, quickValue(reflect.TypeOf(types.Transaction{}), rand.New(rand.NewSource(0))).Interface().(types.Transaction))
+	}
+	block.EncodeTo(e)
+	if err := e.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	var read CompressedBlock
+	read.DecodeFrom(d)
+	if err := d.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(block, read) {
+		t.Fatalf("CompressedBlock did not survive roundtrip: expected %v, got %v", block, read)
+	}
+}

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -197,7 +197,7 @@ func (d *Decoder) ReadPrefix() int {
 }
 
 // ReadTime reads a time.Time from the underlying stream.
-func (d *Decoder) ReadTime() time.Time { return time.Unix(int64(d.ReadUint64()), 0) }
+func (d *Decoder) ReadTime() time.Time { return time.Unix(int64(d.ReadUint64()), 0).UTC() }
 
 // ReadBytes reads a length-prefixed []byte from the underlying stream.
 func (d *Decoder) ReadBytes() []byte {

--- a/types/types.go
+++ b/types/types.go
@@ -301,8 +301,9 @@ func (h BlockHeader) ID() BlockID {
 	return BlockID(HashBytes(buf))
 }
 
-// CurrentTimestamp returns the current time, rounded to the nearest second.
-func CurrentTimestamp() time.Time { return time.Now().Round(time.Second) }
+// CurrentTimestamp returns the current time, rounded to the nearest second. The
+// time zone is set to UTC.
+func CurrentTimestamp() time.Time { return time.Now().Round(time.Second).UTC() }
 
 // A Block is a set of transactions grouped under a header.
 type Block struct {


### PR DESCRIPTION
This PR expands test coverage in merkle to about 80%.  Still need to add coverage relating to RevertBlock but that should probably bring it around 90.