### PR TITLE
types,consensus: Implement Attestations

### DIFF
--- a/merkle/multiproof.go
+++ b/merkle/multiproof.go
@@ -326,6 +326,10 @@ func (txn compressedTransaction) EncodeTo(e *types.Encoder) {
 	for _, res := range txn.FileContractResolutions {
 		(compressedFileContractResolution)(res).EncodeTo(e)
 	}
+	e.WritePrefix(len(txn.Attestations))
+	for _, a := range txn.Attestations {
+		a.EncodeTo(e)
+	}
 	e.WritePrefix(len(txn.ArbitraryData))
 	e.Write(txn.ArbitraryData)
 	txn.NewFoundationAddress.EncodeTo(e)
@@ -360,6 +364,10 @@ func (txn *compressedTransaction) DecodeFrom(d *types.Decoder) {
 	txn.FileContractResolutions = make([]types.FileContractResolution, d.ReadPrefix())
 	for i := range txn.FileContractResolutions {
 		(*compressedFileContractResolution)(&txn.FileContractResolutions[i]).DecodeFrom(d)
+	}
+	txn.Attestations = make([]types.Attestation, d.ReadPrefix())
+	for i := range txn.Attestations {
+		txn.Attestations[i].DecodeFrom(d)
 	}
 	txn.ArbitraryData = make([]byte, d.ReadPrefix())
 	d.Read(txn.ArbitraryData)

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -412,6 +412,14 @@ func (res FileContractResolution) EncodeTo(e *Encoder) {
 	res.StorageProof.EncodeTo(e)
 }
 
+// EncodeTo implements types.EncoderTo.
+func (a Attestation) EncodeTo(e *Encoder) {
+	a.PublicKey.EncodeTo(e)
+	e.WriteString(a.Key)
+	e.WriteBytes(a.Value)
+	a.Signature.EncodeTo(e)
+}
+
 const (
 	opInvalid = iota
 	opAbove
@@ -487,6 +495,10 @@ func (txn Transaction) EncodeTo(e *Encoder) {
 	e.WritePrefix(len(txn.FileContractResolutions))
 	for _, res := range txn.FileContractResolutions {
 		res.EncodeTo(e)
+	}
+	e.WritePrefix(len(txn.Attestations))
+	for _, a := range txn.Attestations {
+		a.EncodeTo(e)
 	}
 	e.WriteBytes(txn.ArbitraryData)
 	txn.NewFoundationAddress.EncodeTo(e)
@@ -711,6 +723,14 @@ func (res *FileContractResolution) DecodeFrom(d *Decoder) {
 }
 
 // DecodeFrom implements types.DecoderFrom.
+func (a *Attestation) DecodeFrom(d *Decoder) {
+	a.PublicKey.DecodeFrom(d)
+	a.Key = d.ReadString()
+	a.Value = d.ReadBytes()
+	a.Signature.DecodeFrom(d)
+}
+
+// DecodeFrom implements types.DecoderFrom.
 func (txn *Transaction) DecodeFrom(d *Decoder) {
 	txn.SiacoinInputs = make([]SiacoinInput, d.ReadPrefix())
 	for i := range txn.SiacoinInputs {
@@ -739,6 +759,10 @@ func (txn *Transaction) DecodeFrom(d *Decoder) {
 	txn.FileContractResolutions = make([]FileContractResolution, d.ReadPrefix())
 	for i := range txn.FileContractResolutions {
 		txn.FileContractResolutions[i].DecodeFrom(d)
+	}
+	txn.Attestations = make([]Attestation, d.ReadPrefix())
+	for i := range txn.Attestations {
+		txn.Attestations[i].DecodeFrom(d)
 	}
 	txn.ArbitraryData = d.ReadBytes()
 	txn.NewFoundationAddress.DecodeFrom(d)

--- a/types/types.go
+++ b/types/types.go
@@ -209,6 +209,19 @@ type FileContractElement struct {
 	FileContract
 }
 
+// An Attestation associates a key-value pair with an identity. For example,
+// hosts attest to their network address by setting Key to "HostAnnouncement"
+// and Value to their address, thereby allowing renters to discover them.
+// Generally, an attestation for a particular key is considered to overwrite any
+// previous attestations with the same key. (This allows hosts to announce a new
+// network address, for example.)
+type Attestation struct {
+	PublicKey PublicKey
+	Key       string
+	Value     []byte
+	Signature Signature
+}
+
 // A Transaction transfers value by consuming existing Outputs and creating new
 // Outputs.
 type Transaction struct {
@@ -219,6 +232,7 @@ type Transaction struct {
 	FileContracts           []FileContract
 	FileContractRevisions   []FileContractRevision
 	FileContractResolutions []FileContractResolution
+	Attestations            []Attestation
 	ArbitraryData           []byte
 	NewFoundationAddress    Address
 	MinerFee                Currency
@@ -258,6 +272,9 @@ func (txn *Transaction) DeepCopy() Transaction {
 		c.FileContractResolutions[i].Parent.MerkleProof = append([]Hash256(nil), c.FileContractResolutions[i].Parent.MerkleProof...)
 		c.FileContractResolutions[i].StorageProof.WindowProof = append([]Hash256(nil), c.FileContractResolutions[i].StorageProof.WindowProof...)
 		c.FileContractResolutions[i].StorageProof.SegmentProof = append([]Hash256(nil), c.FileContractResolutions[i].StorageProof.SegmentProof...)
+	}
+	for i := range c.Attestations {
+		c.Attestations[i].Value = append([]byte(nil), c.Attestations[i].Value...)
 	}
 	c.ArbitraryData = append([]byte(nil), c.ArbitraryData...)
 	return c


### PR DESCRIPTION
This implements the "dumb" version of attestations; basically just better-structured ArbitraryData. See #17 for discussion.

In this PR, all attestations are validated by consensus. It hadn't occurred to me until just now that perhaps attestations should be validated "lazily;" that is, the consumer of the attestation (e.g. a renter looking for host announcements) should be responsible for validating it. The rationale here is that verifying signatures is slow, so if you don't care about a particular attestation, why should you have to spend CPU cycles validating it?

A counterargument is that enforcing valid signatures in consensus is "safe by default;" no one can accidentally forget to check the signature. Equivalently, invalid signatures are prevented from ever making it on-chain in the first place, which is a nice invariant.

Given that attestations will be comparatively uncommon (evidence: on the current chain, there are ~25x more TransactionSignatures than there are ArbitraryData entries), I'm leaning towards enforcing signatures in consensus. But I'm interested to hear other people's thoughts on this.