### PR TITLE
tests: use tb.TempDir()

### DIFF
--- a/chain/manager_test.go
+++ b/chain/manager_test.go
@@ -1,7 +1,6 @@
 package chain_test
 
 import (
-	"os"
 	"reflect"
 	"testing"
 
@@ -12,12 +11,7 @@ import (
 )
 
 func newTestStore(tb testing.TB, checkpoint consensus.Checkpoint) *chainutil.FlatStore {
-	dir, err := os.MkdirTemp("", tb.Name())
-	if err != nil {
-		tb.Fatal(err)
-	}
-	tb.Cleanup(func() { os.RemoveAll(dir) })
-	fs, _, err := chainutil.NewFlatStore(dir, checkpoint)
+	fs, _, err := chainutil.NewFlatStore(tb.TempDir(), checkpoint)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/internal/chainutil/store_test.go
+++ b/internal/chainutil/store_test.go
@@ -11,12 +11,7 @@ import (
 )
 
 func TestFlatStoreRecovery(t *testing.T) {
-	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	sim := NewChainSim()
 	fs, _, err := NewFlatStore(dir, sim.Genesis)
 	if err != nil {
@@ -96,17 +91,8 @@ func TestFlatStoreRecovery(t *testing.T) {
 }
 
 func TestEphemeralStore(t *testing.T) {
-	dir, err := os.MkdirTemp(os.TempDir(), t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	sim := NewChainSim()
 	es := NewEphemeralStore(sim.Genesis)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// add some blocks
 	blocks := sim.MineBlocks(5)
@@ -146,12 +132,7 @@ func TestEphemeralStore(t *testing.T) {
 }
 
 func BenchmarkFlatStore(b *testing.B) {
-	dir, err := os.MkdirTemp(os.TempDir(), b.Name())
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	fs, _, err := NewFlatStore(dir, consensus.Checkpoint{})
+	fs, _, err := NewFlatStore(b.TempDir(), consensus.Checkpoint{})
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Changes tests to use `TempDir()` instead of `os.MkdirTemp()`