### PR TITLE
fuzz: fuzz CompressedBlock decoding

### DIFF
--- a/merkle/multiproof_corpusgen.go
+++ b/merkle/multiproof_corpusgen.go
@@ -1,0 +1,62 @@
+// +build ignore
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"math/rand"
+	"os"
+	"reflect"
+	"strconv"
+	"testing/quick"
+
+	"go.sia.tech/core/merkle"
+	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
+)
+
+func main() {
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+
+	const outputDirectory = "corpus"
+	if err := os.Mkdir(outputDirectory, 0755); err != nil && !errors.Is(err, os.ErrExist) {
+		panic(err)
+	}
+
+	randomTxn := func() types.Transaction {
+		var valueFn func(t reflect.Type, r *rand.Rand) reflect.Value
+		valueFn = func(t reflect.Type, r *rand.Rand) reflect.Value {
+			if t.String() == "types.SpendPolicy" {
+				return reflect.ValueOf(types.AnyoneCanSpend())
+			}
+			v := reflect.New(t).Elem()
+			switch t.Kind() {
+			default:
+				v, _ = quick.Value(t, r)
+			case reflect.Slice:
+				// 3 elements per slice to prevent generating giant objects
+				v.Set(reflect.MakeSlice(t, 3, 3))
+				for i := 0; i < v.Len(); i++ {
+					v.Index(i).Set(valueFn(t.Elem(), r))
+				}
+			case reflect.Struct:
+				for i := 0; i < v.NumField(); i++ {
+					v.Field(i).Set(valueFn(t.Field(i).Type, r))
+				}
+			}
+			return v
+		}
+		r := rand.New(frand.NewSource())
+		txn := valueFn(reflect.TypeOf(types.Transaction{}), r)
+		return txn.Interface().(types.Transaction)
+	}
+
+	for i := 0; i < 10; i++ {
+		merkle.CompressedBlock(types.Block{Transactions: []types.Transaction{randomTxn(), randomTxn(), randomTxn()}}).EncodeTo(e)
+		e.Flush()
+		os.WriteFile(outputDirectory+"/"+strconv.Itoa(i), buf.Bytes(), 0664)
+		buf.Reset()
+	}
+}

--- a/merkle/multiproof_fuzz.go
+++ b/merkle/multiproof_fuzz.go
@@ -1,0 +1,16 @@
+//go:build gofuzz
+// +build gofuzz
+
+package merkle
+
+import "go.sia.tech/core/types"
+
+func Fuzz(data []byte) int {
+	var block CompressedBlock
+	d := types.NewBufDecoder(data)
+	block.DecodeFrom(d)
+	if d.Err() != nil {
+		return -1
+	}
+	return 0
+}


### PR DESCRIPTION
This adds a fuzzer targeting the `CompressedBlock.DecodeFrom` method.

Within a couple of minutes (beginning with the generated corpus) it was able to identify the bounds problem in MultiproofSize:

```
panic: runtime error: index out of range [768] with length 64

goroutine 1 [running]:
go.sia.tech/core/merkle.leavesByTree.func1(...)
    /home/christopher/prog/go/src/go.sia.tech/core/merkle/multiproof.go:18
go.sia.tech/core/merkle.leavesByTree(0xc00028e000, 0x300, 0x300, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /home/christopher/prog/go/src/go.sia.tech/core/merkle/multiproof.go:23 +0xe45
go.sia.tech/core/merkle.MultiproofSize(0xc00028e000, 0x300, 0x300, 0xc00028e000)
    /home/christopher/prog/go/src/go.sia.tech/core/merkle/multiproof.go:60 +0xe9
go.sia.tech/core/merkle.(*CompressedBlock).DecodeFrom(0xc0000ade00, 0xc00009c460)
    /home/christopher/prog/go/src/go.sia.tech/core/merkle/multiproof.go:165 +0x176
go.sia.tech/core/merkle.Fuzz(0x7f2a1318d000, 0x3c0, 0x3c0, 0x3)
    /home/christopher/prog/go/src/go.sia.tech/core/merkle/multiproof_fuzz.go:11 +0x171
go-fuzz-dep.Main(0xc0000adf70, 0x1, 0x1)
    go-fuzz-dep/main.go:36 +0x1b8
main.main()
    go.sia.tech/core/merkle/go.fuzz.main/main.go:15 +0x52
exit status 2
```