### PR TITLE
types: Use bitfield to reduce encoded txn size

### DIFF
--- a/types/encoding.go
+++ b/types/encoding.go
@@ -468,41 +468,83 @@ func (e *Encoder) WritePolicy(p SpendPolicy) {
 
 // EncodeTo implements types.EncoderTo.
 func (txn Transaction) EncodeTo(e *Encoder) {
-	e.WritePrefix(len(txn.SiacoinInputs))
-	for _, in := range txn.SiacoinInputs {
-		in.EncodeTo(e)
+	var fields uint64
+	for i, b := range [...]bool{
+		len(txn.SiacoinInputs) != 0,
+		len(txn.SiacoinOutputs) != 0,
+		len(txn.SiafundInputs) != 0,
+		len(txn.SiafundOutputs) != 0,
+		len(txn.FileContracts) != 0,
+		len(txn.FileContractRevisions) != 0,
+		len(txn.FileContractResolutions) != 0,
+		len(txn.Attestations) != 0,
+		len(txn.ArbitraryData) != 0,
+		txn.NewFoundationAddress != VoidAddress,
+		!txn.MinerFee.IsZero(),
+	} {
+		if b {
+			fields |= 1 << i
+		}
 	}
-	e.WritePrefix(len(txn.SiacoinOutputs))
-	for _, out := range txn.SiacoinOutputs {
-		out.EncodeTo(e)
+	e.WriteUint64(fields)
+
+	if fields&(1<<0) != 0 {
+		e.WritePrefix(len(txn.SiacoinInputs))
+		for _, in := range txn.SiacoinInputs {
+			in.EncodeTo(e)
+		}
 	}
-	e.WritePrefix(len(txn.SiafundInputs))
-	for _, in := range txn.SiafundInputs {
-		in.EncodeTo(e)
+	if fields&(1<<1) != 0 {
+		e.WritePrefix(len(txn.SiacoinOutputs))
+		for _, out := range txn.SiacoinOutputs {
+			out.EncodeTo(e)
+		}
 	}
-	e.WritePrefix(len(txn.SiafundOutputs))
-	for _, out := range txn.SiafundOutputs {
-		out.EncodeTo(e)
+	if fields&(1<<2) != 0 {
+		e.WritePrefix(len(txn.SiafundInputs))
+		for _, in := range txn.SiafundInputs {
+			in.EncodeTo(e)
+		}
 	}
-	e.WritePrefix(len(txn.FileContracts))
-	for _, fc := range txn.FileContracts {
-		fc.EncodeTo(e)
+	if fields&(1<<3) != 0 {
+		e.WritePrefix(len(txn.SiafundOutputs))
+		for _, out := range txn.SiafundOutputs {
+			out.EncodeTo(e)
+		}
 	}
-	e.WritePrefix(len(txn.FileContractRevisions))
-	for _, rev := range txn.FileContractRevisions {
-		rev.EncodeTo(e)
+	if fields&(1<<4) != 0 {
+		e.WritePrefix(len(txn.FileContracts))
+		for _, fc := range txn.FileContracts {
+			fc.EncodeTo(e)
+		}
 	}
-	e.WritePrefix(len(txn.FileContractResolutions))
-	for _, res := range txn.FileContractResolutions {
-		res.EncodeTo(e)
+	if fields&(1<<5) != 0 {
+		e.WritePrefix(len(txn.FileContractRevisions))
+		for _, rev := range txn.FileContractRevisions {
+			rev.EncodeTo(e)
+		}
 	}
-	e.WritePrefix(len(txn.Attestations))
-	for _, a := range txn.Attestations {
-		a.EncodeTo(e)
+	if fields&(1<<6) != 0 {
+		e.WritePrefix(len(txn.FileContractResolutions))
+		for _, res := range txn.FileContractResolutions {
+			res.EncodeTo(e)
+		}
 	}
-	e.WriteBytes(txn.ArbitraryData)
-	txn.NewFoundationAddress.EncodeTo(e)
-	txn.MinerFee.EncodeTo(e)
+	if fields&(1<<7) != 0 {
+		e.WritePrefix(len(txn.Attestations))
+		for _, a := range txn.Attestations {
+			a.EncodeTo(e)
+		}
+	}
+	if fields&(1<<8) != 0 {
+		e.WriteBytes(txn.ArbitraryData)
+	}
+	if fields&(1<<9) != 0 {
+		txn.NewFoundationAddress.EncodeTo(e)
+	}
+	if fields&(1<<10) != 0 {
+		txn.MinerFee.EncodeTo(e)
+	}
 }
 
 // DecodeFrom implements types.DecoderFrom.
@@ -732,39 +774,63 @@ func (a *Attestation) DecodeFrom(d *Decoder) {
 
 // DecodeFrom implements types.DecoderFrom.
 func (txn *Transaction) DecodeFrom(d *Decoder) {
-	txn.SiacoinInputs = make([]SiacoinInput, d.ReadPrefix())
-	for i := range txn.SiacoinInputs {
-		txn.SiacoinInputs[i].DecodeFrom(d)
+	fields := d.ReadUint64()
+
+	if fields&(1<<0) != 0 {
+		txn.SiacoinInputs = make([]SiacoinInput, d.ReadPrefix())
+		for i := range txn.SiacoinInputs {
+			txn.SiacoinInputs[i].DecodeFrom(d)
+		}
 	}
-	txn.SiacoinOutputs = make([]SiacoinOutput, d.ReadPrefix())
-	for i := range txn.SiacoinOutputs {
-		txn.SiacoinOutputs[i].DecodeFrom(d)
+	if fields&(1<<1) != 0 {
+		txn.SiacoinOutputs = make([]SiacoinOutput, d.ReadPrefix())
+		for i := range txn.SiacoinOutputs {
+			txn.SiacoinOutputs[i].DecodeFrom(d)
+		}
 	}
-	txn.SiafundInputs = make([]SiafundInput, d.ReadPrefix())
-	for i := range txn.SiafundInputs {
-		txn.SiafundInputs[i].DecodeFrom(d)
+	if fields&(1<<2) != 0 {
+		txn.SiafundInputs = make([]SiafundInput, d.ReadPrefix())
+		for i := range txn.SiafundInputs {
+			txn.SiafundInputs[i].DecodeFrom(d)
+		}
 	}
-	txn.SiafundOutputs = make([]SiafundOutput, d.ReadPrefix())
-	for i := range txn.SiafundOutputs {
-		txn.SiafundOutputs[i].DecodeFrom(d)
+	if fields&(1<<3) != 0 {
+		txn.SiafundOutputs = make([]SiafundOutput, d.ReadPrefix())
+		for i := range txn.SiafundOutputs {
+			txn.SiafundOutputs[i].DecodeFrom(d)
+		}
 	}
-	txn.FileContracts = make([]FileContract, d.ReadPrefix())
-	for i := range txn.FileContracts {
-		txn.FileContracts[i].DecodeFrom(d)
+	if fields&(1<<4) != 0 {
+		txn.FileContracts = make([]FileContract, d.ReadPrefix())
+		for i := range txn.FileContracts {
+			txn.FileContracts[i].DecodeFrom(d)
+		}
 	}
-	txn.FileContractRevisions = make([]FileContractRevision, d.ReadPrefix())
-	for i := range txn.FileContractRevisions {
-		txn.FileContractRevisions[i].DecodeFrom(d)
+	if fields&(1<<5) != 0 {
+		txn.FileContractRevisions = make([]FileContractRevision, d.ReadPrefix())
+		for i := range txn.FileContractRevisions {
+			txn.FileContractRevisions[i].DecodeFrom(d)
+		}
 	}
-	txn.FileContractResolutions = make([]FileContractResolution, d.ReadPrefix())
-	for i := range txn.FileContractResolutions {
-		txn.FileContractResolutions[i].DecodeFrom(d)
+	if fields&(1<<6) != 0 {
+		txn.FileContractResolutions = make([]FileContractResolution, d.ReadPrefix())
+		for i := range txn.FileContractResolutions {
+			txn.FileContractResolutions[i].DecodeFrom(d)
+		}
 	}
-	txn.Attestations = make([]Attestation, d.ReadPrefix())
-	for i := range txn.Attestations {
-		txn.Attestations[i].DecodeFrom(d)
+	if fields&(1<<7) != 0 {
+		txn.Attestations = make([]Attestation, d.ReadPrefix())
+		for i := range txn.Attestations {
+			txn.Attestations[i].DecodeFrom(d)
+		}
 	}
-	txn.ArbitraryData = d.ReadBytes()
-	txn.NewFoundationAddress.DecodeFrom(d)
-	txn.MinerFee.DecodeFrom(d)
+	if fields&(1<<8) != 0 {
+		txn.ArbitraryData = d.ReadBytes()
+	}
+	if fields&(1<<9) != 0 {
+		txn.NewFoundationAddress.DecodeFrom(d)
+	}
+	if fields&(1<<10) != 0 {
+		txn.MinerFee.DecodeFrom(d)
+	}
 }


### PR DESCRIPTION
Basically: instead of unconditionally writing the length-prefix for every field (and the `NewFoundationAddress`), we prefix the encoding with a bitfield, where a 1 bit means "this field is present." Most transactions only include inputs, outputs, and a miner fee, so on average this optimization saves about 100 bytes per txn. We only "pay the cost" of the bitfield when encoding a transaction that has *all* fields present, which pretty much never happens.