### PR TITLE
Early contract resolution

### DIFF
--- a/consensus/update.go
+++ b/consensus/update.go
@@ -217,9 +217,9 @@ func createdInBlock(vc ValidationContext, b types.Block) (sces []types.SiacoinEl
 		}
 		for _, fcr := range txn.FileContractResolutions {
 			fce := fcr.Parent
-			renter, host := fce.ValidRenterOutput, fce.ValidRenterOutput
+			renter, host := fce.ValidRenterOutput, fce.ValidHostOutput
 			if fcr.HasStorageProof() {
-				renter, host = fce.MissedRenterOutput, fce.MissedRenterOutput
+				renter, host = fce.MissedRenterOutput, fce.MissedHostOutput
 			}
 			addSiacoinElement(types.SiacoinElement{
 				StateElement:  nextElement(),

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -235,7 +235,7 @@ func createdInBlock(vc ValidationContext, b types.Block) (sces []types.SiacoinEl
 		for _, fcr := range txn.FileContractResolutions {
 			fce := fcr.Parent
 			renter, host := fce.ValidRenterOutput, fce.ValidHostOutput
-			if fcr.HasStorageProof() {
+			if !fcr.HasStorageProof() {
 				renter, host = fce.MissedRenterOutput, fce.MissedHostOutput
 			}
 			addSiacoinElement(types.SiacoinElement{

--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -491,11 +491,11 @@ func TestFileContracts(t *testing.T) {
 		},
 		MissedRenterOutput: types.SiacoinOutput{
 			Address: types.StandardAddress(renterPubkey),
-			Value:   types.Siacoins(58),
+			Value:   types.Siacoins(60),
 		},
 		MissedHostOutput: types.SiacoinOutput{
 			Address: types.StandardAddress(renterPubkey),
-			Value:   types.Siacoins(19),
+			Value:   types.Siacoins(17),
 		},
 		RenterPublicKey: renterPubkey,
 		HostPublicKey:   hostPubkey,
@@ -661,11 +661,11 @@ func TestEarlyContractResolution(t *testing.T) {
 		},
 		MissedRenterOutput: types.SiacoinOutput{
 			Address: types.StandardAddress(renterPubkey),
-			Value:   types.Siacoins(58),
+			Value:   types.Siacoins(60),
 		},
 		MissedHostOutput: types.SiacoinOutput{
 			Address: types.StandardAddress(renterPubkey),
-			Value:   types.Siacoins(19),
+			Value:   types.Siacoins(17),
 		},
 		RenterPublicKey: renterPubkey,
 		HostPublicKey:   hostPubkey,

--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -596,6 +596,10 @@ func TestFileContracts(t *testing.T) {
 	validSAU := ApplyBlock(sau.Context, validBlock)
 	if len(validSAU.NewSiacoinElements) != 3 {
 		t.Fatal("expected three new siacoin outputs")
+	} else if validSAU.NewSiacoinElements[1].SiacoinOutput != finalRev.Revision.ValidRenterOutput {
+		t.Fatal("expected valid renter output to be created")
+	} else if validSAU.NewSiacoinElements[2].SiacoinOutput != finalRev.Revision.ValidHostOutput {
+		t.Fatal("expected valid host output to be created")
 	}
 
 	// revert the block and instead mine past the proof window
@@ -619,6 +623,10 @@ func TestFileContracts(t *testing.T) {
 
 	if len(sau.NewSiacoinElements) != 3 {
 		t.Fatal("expected three new siacoin outputs")
+	} else if sau.NewSiacoinElements[1].SiacoinOutput != finalRev.Revision.MissedRenterOutput {
+		t.Fatal("expected missed renter output to be created")
+	} else if sau.NewSiacoinElements[2].SiacoinOutput != finalRev.Revision.MissedHostOutput {
+		t.Fatal("expected missed host output to be created")
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -32,6 +32,12 @@ var (
 // into the state accumulator when the block is processed.
 const EphemeralLeafIndex = math.MaxUint64
 
+// MaxRevisionNumber is used to finalize a FileContract. When a contract's
+// RevisionNumber is set to this value, no further revisions are possible. This
+// allows contracts to be resolved "early" in some cases; see
+// (FileContract).CanResolveEarly.
+const MaxRevisionNumber = math.MaxUint64
+
 // A Hash256 is a generic 256-bit cryptographic hash.
 type Hash256 [32]byte
 
@@ -128,6 +134,16 @@ type FileContract struct {
 	RenterPublicKey    PublicKey
 	HostPublicKey      PublicKey
 	RevisionNumber     uint64
+}
+
+// CanResolveEarly returns true if fc cannot be revised and its valid resolution
+// is equivalent to its missed resolution. When these conditions are met, the
+// funds locked in the contract can be released immediately and without the need
+// for a storage proof.
+func (fc *FileContract) CanResolveEarly() bool {
+	return fc.RevisionNumber == MaxRevisionNumber &&
+		fc.ValidRenterOutput == fc.MissedRenterOutput &&
+		fc.ValidHostOutput == fc.MissedHostOutput
 }
 
 // A SiacoinInput spends an unspent SiacoinElement in the state accumulator by


### PR DESCRIPTION
This adds a new rule to consensus: If a contract is revised such that its revision number is `MaxRevisionNumber` (i.e. it cannot be revised further) and its valid outputs equal its missed outputs (i.e. the outcome will be the same whether a storage proof is provided or not), then the contract is resolved immediately.

Essentially, this reifies the "renew and clear" pattern established in v1, wherein a renter and host would "finalize" an old contract while simultaneously forming a new contract that inherits the old Merkle root. A big problem with this pattern was that the funds locked in the old contract would remain locked until the original `WindowEnd` height. With early resolution, we can fix this by releasing the locked funds immediately once it's clear that only one outcome is possible. This means that the old contract funds can even be used to fund the new contract: a setup txn finalizes the old contract, creating new outputs controlled by the renter and host; then the renewal txn creates the new contract, funded by the ephemeral outputs created in the setup txn. This makes it possible to repeatedly renew a contract without forcing the renter or host to lock up tons of SC.