### PR TITLE
net/gateway: Refactor Header

### DIFF
--- a/net/gateway/peer_test.go
+++ b/net/gateway/peer_test.go
@@ -33,12 +33,7 @@ func TestHandshake(t *testing.T) {
 				return err
 			}
 			defer conn.Close()
-			h := Header{
-				GenesisID:  genesisID,
-				UniqueID:   [8]byte{0},
-				NetAddress: l.Addr().String(),
-			}
-			sess, err := AcceptSession(conn, h)
+			sess, err := AcceptSession(conn, genesisID, UniqueID{0})
 			if err != nil {
 				return err
 			}
@@ -72,12 +67,7 @@ func TestHandshake(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer conn.Close()
-	h := Header{
-		GenesisID:  genesisID,
-		UniqueID:   [8]byte{1},
-		NetAddress: conn.LocalAddr().String(),
-	}
-	sess, err := DialSession(conn, h)
+	sess, err := DialSession(conn, genesisID, UniqueID{1})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`Header` is no longer an exported type, and no longer includes a `NetAddress` field. In fact, this address is no longer exchanged during the handshake at all. The reason we originally included it was so that the accepting peer could learn the dialing peer's listen address and add it to their list of potentially-connectable addresses. But we already call the `GetPeers` RPC on new pees immediately after connecting to them; so why not simply have the recipient include their own address in the response? (This is implemented in a soon-to-follow `siad` PR.) Furthermore, sometimes the dialing peer may not wish their listen address to be known; or they might not have a listen address at all, e.g. when downloading a checkpoint.

Still, there *are* reasons why we would want to know the network address of our peer, regardless of whether we accepted or dialed; to that end, I added a `RemoteAddr` field to `gateway.Session`.