### PR TITLE
all: Add domain-separation prefixes to most hashes

### DIFF
--- a/chain/manager.go
+++ b/chain/manager.go
@@ -293,7 +293,7 @@ func (m *Manager) AddBlocks(blocks []types.Block) (*consensus.ScratchChain, erro
 	for _, b := range blocks {
 		c, err := chain.ApplyBlock(b)
 		if err != nil {
-			return nil, fmt.Errorf("invalid block %v: %w", chain.UnvalidatedBase(), err)
+			return nil, fmt.Errorf("invalid block %v: %w", b.Index(), err)
 		} else if err := m.store.AddCheckpoint(c); err != nil {
 			return nil, fmt.Errorf("couldn't store block: %w", err)
 		} else if c.Context.TotalWork.Cmp(m.vc.TotalWork) <= 0 {

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -214,6 +214,7 @@ func (vc *ValidationContext) Commitment(minerAddr types.Address, txns []types.Tr
 
 	// concatenate the hashes and the miner address
 	h.Reset()
+	h.E.WriteString("sia/commitment")
 	ctxHash.EncodeTo(h.E)
 	minerAddr.EncodeTo(h.E)
 	txnsHash.EncodeTo(h.E)
@@ -225,6 +226,7 @@ func (vc *ValidationContext) SigHash(txn types.Transaction) types.Hash256 {
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
+	h.E.WriteString("sia/sig/transaction")
 	h.E.WritePrefix(len(txn.SiacoinInputs))
 	for _, in := range txn.SiacoinInputs {
 		in.Parent.ID.EncodeTo(h.E)
@@ -266,6 +268,7 @@ func (vc *ValidationContext) ContractSigHash(fc types.FileContract) types.Hash25
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
+	h.E.WriteString("sia/sig/filecontract")
 	fc.EncodeTo(h.E)
 	return h.Sum()
 }
@@ -275,6 +278,7 @@ func (vc *ValidationContext) AttestationSigHash(a types.Attestation) types.Hash2
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
+	h.E.WriteString("sia/sig/attestation")
 	a.PublicKey.EncodeTo(h.E)
 	h.E.WriteString(a.Key)
 	h.E.WriteBytes(a.Value)

--- a/merkle/accumulator.go
+++ b/merkle/accumulator.go
@@ -44,7 +44,7 @@ func SiacoinLeaf(e types.SiacoinElement, spent bool) ElementLeaf {
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
-
+	h.E.WriteString("sia/leaf/siacoin")
 	e.ID.EncodeTo(h.E)
 	e.SiacoinOutput.EncodeTo(h.E)
 	h.E.WriteUint64(e.Timelock)
@@ -60,7 +60,7 @@ func SiafundLeaf(e types.SiafundElement, spent bool) ElementLeaf {
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
-
+	h.E.WriteString("sia/leaf/siafund")
 	e.ID.EncodeTo(h.E)
 	e.SiafundOutput.EncodeTo(h.E)
 	e.ClaimStart.EncodeTo(h.E)
@@ -76,7 +76,7 @@ func FileContractLeaf(e types.FileContractElement, spent bool) ElementLeaf {
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
-
+	h.E.WriteString("sia/leaf/filecontract")
 	e.ID.EncodeTo(h.E)
 	e.FileContract.EncodeTo(h.E)
 	return ElementLeaf{

--- a/types/policy.go
+++ b/types/policy.go
@@ -95,7 +95,10 @@ func PolicyAddress(p SpendPolicy) Address {
 		// derivation code for these policies
 		return Address(unlockConditionsRoot(uc))
 	}
-	h := NewHasher()
+	h := hasherPool.Get().(*Hasher)
+	defer hasherPool.Put(h)
+	h.Reset()
+	h.E.WriteString("sia/address")
 	h.E.WritePolicy(p)
 	return Address(h.Sum())
 }

--- a/types/policy_test.go
+++ b/types/policy_test.go
@@ -25,19 +25,19 @@ func TestPolicyAddressString(t *testing.T) {
 	}{
 		{
 			PolicyAbove(50),
-			"addr:e38c9fe65f9297af77381dc718b1c8a775262cfdde08dc3da1116dee081fadf26ca7e015dd71",
+			"addr:f0e864efc7226eb90f79f71caf1d839daf11d1c7f0fb7e25abc3cedd38637f32954986043e6a",
 		},
 		{
 			PolicyPublicKey(publicKeys[0]),
-			"addr:e4b6f506599b1fdc27545f5d3cfd0bcd2fed2940bc9aaa74142d3279c0687b529e1d70be6def",
+			"addr:4c9de1b2775091af2be8f427b1886f2120cdfe074fb3bc3b6011e281f36309e2468424667b70",
 		},
 		{
 			AnyoneCanSpend(),
-			"addr:d0f42fc75e6d3c7b21429ab2f60c78a04f8a599bf8d5a89ca6a299c6f88b738d671c9d57183a",
+			"addr:a1b418e9905dd086e2d0c25ec3675568f849c18f401512d704eceafe1574ee19c48049c5f2b3",
 		},
 		{
 			PolicyThreshold{},
-			"addr:d0f42fc75e6d3c7b21429ab2f60c78a04f8a599bf8d5a89ca6a299c6f88b738d671c9d57183a",
+			"addr:a1b418e9905dd086e2d0c25ec3675568f849c18f401512d704eceafe1574ee19c48049c5f2b3",
 		},
 		{
 			PolicyThreshold{
@@ -46,7 +46,7 @@ func TestPolicyAddressString(t *testing.T) {
 					PolicyPublicKey(publicKeys[0]),
 				},
 			},
-			"addr:36375ad986e8c064a5c3a73ade03c72da0f3b4cacfb69eef39fe3c115c4ac4c63299c631a5b4",
+			"addr:88a889bd46420209db5a41b164956e53ff3da9c4b3d1491d81f9c374f742dd3b0a7c72f58aff",
 		},
 		{
 			PolicyThreshold{
@@ -62,7 +62,7 @@ func TestPolicyAddressString(t *testing.T) {
 					},
 				},
 			},
-			"addr:5ce2aadfd0c5c5009491974960938ba2e19260110394d10a26578d8c3fcd7f0976d0b369a732",
+			"addr:2ce609abbd8bc26d0f22c8f6447d3144bc2ae2391f9b09685aca03237329c339ba3ec4a35133",
 		},
 		{
 			PolicyThreshold{
@@ -73,7 +73,7 @@ func TestPolicyAddressString(t *testing.T) {
 					PolicyPublicKey(publicKeys[2]),
 				},
 			},
-			"addr:c186c3563a4c6a98343a64c0f4981d809fd95f2630df15cb266e809424ec11f44de4a902c222",
+			"addr:0ca4d365f06ebf0de342ed617498521f0c0bcdc133c414428480e8826875c0a565ccaee80fb6",
 		},
 		{
 			policy: PolicyUnlockConditions{

--- a/types/types.go
+++ b/types/types.go
@@ -279,6 +279,7 @@ func (txn *Transaction) ID() TransactionID {
 	h := hasherPool.Get().(*Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
+	h.E.WriteString("sia/id/transaction")
 	h.E.WritePrefix(len(txn.SiacoinInputs))
 	for _, in := range txn.SiacoinInputs {
 		in.Parent.ID.EncodeTo(h.E)
@@ -425,6 +426,7 @@ func (h BlockHeader) ID() BlockID {
 	// must ensure compatibility with existing Sia mining hardware, which
 	// expects an 80-byte buffer with the nonce at [32:40].
 	buf := make([]byte, 32+8+8+32)
+	copy(buf[0:], "sia/id/block")
 	binary.LittleEndian.PutUint64(buf[32:], h.Nonce)
 	binary.LittleEndian.PutUint64(buf[40:], uint64(h.Timestamp.Unix()))
 	copy(buf[48:], h.Commitment[:])
@@ -449,9 +451,9 @@ func (b *Block) ID() BlockID { return b.Header.ID() }
 func (b *Block) Index() ChainIndex { return b.Header.Index() }
 
 // MinerOutputID returns the output ID of the miner payout.
-func (b Block) MinerOutputID() ElementID {
+func (b *Block) MinerOutputID() ElementID {
 	return ElementID{
-		Source: Hash256(b.Header.ID()),
+		Source: Hash256(b.ID()),
 		Index:  0,
 	}
 }
@@ -459,9 +461,9 @@ func (b Block) MinerOutputID() ElementID {
 // FoundationOutputID returns the output ID of the foundation payout. A
 // Foundation subsidy output is only created every 4380 blocks after the
 // hardfork at block 298000.
-func (b Block) FoundationOutputID() ElementID {
+func (b *Block) FoundationOutputID() ElementID {
 	return ElementID{
-		Source: Hash256(b.Header.ID()),
+		Source: Hash256(b.ID()),
 		Index:  1,
 	}
 }


### PR DESCRIPTION
Domain separation prevents signatures from being reused in different contexts. This is important because objects in different domains can sometimes serialize to the same bytes. For example, a transaction might encode to the same bytes as an attestation; consequently, the same signature could be used to sign both objects. An attacker could exploit this in two ways: by tricking you into signing something innocuous, then reusing that signature to steal your coins; or by observing one of your publicly-broadcasted signatures, and then crafting a different object with the same encoding (e.g. an attestation) and broadcasting it with your signature attached.

The fix is simple: just add a unique prefix to every sighash. I went a bit further and added prefixes to other hashes as well, like block IDs and transaction IDs, but I'm not sure if these are strictly necessary. I imagine this is the sort of thing that we'll review as part of a security audit prior to release.