### PR TITLE
consensus: use parent when reverting revisions

### DIFF
--- a/merkle/accumulator.go
+++ b/merkle/accumulator.go
@@ -308,7 +308,6 @@ func (acc *ElementAccumulator) ApplyBlock(updated, added []ElementLeaf) (eau Ele
 func (acc *ElementAccumulator) RevertBlock(updated []ElementLeaf) (eru ElementRevertUpdate) {
 	eru.numLeaves = acc.NumLeaves
 	for _, l := range updated {
-		l.Spent = false
 		eru.updated[len(l.MerkleProof)] = append(eru.updated[len(l.MerkleProof)], l)
 	}
 	return

--- a/merkle/accumulator_test.go
+++ b/merkle/accumulator_test.go
@@ -190,7 +190,7 @@ func TestApplyBlock(t *testing.T) {
 		SiafundLeaf(sfes[0], true),
 		FileContractLeaf(fces[0], true),
 	}
-	// ApplyBlock will modify both acc and spent; save copies for later
+	// acc and elements will be modified; save copies for later
 	oldAcc := acc
 	oldSpent := append([]ElementLeaf(nil), spent...)
 	for i := range oldSpent {
@@ -237,6 +237,9 @@ func TestApplyBlock(t *testing.T) {
 	// restore old copies and revert the block
 	acc = oldAcc
 	spent = oldSpent
+	for i := range spent {
+		spent[i].Spent = false
+	}
 	eru := acc.RevertBlock(spent)
 	// update proofs
 	for i := range sces {


### PR DESCRIPTION
A block revert should ideally return the prior revision instead of returning the reverted revision