### PR TITLE
types: Move signatures into FileContract type

### DIFF
--- a/merkle/multiproof.go
+++ b/merkle/multiproof.go
@@ -281,15 +281,11 @@ type compressedFileContractRevision types.FileContractRevision
 func (rev compressedFileContractRevision) EncodeTo(e *types.Encoder) {
 	(compressedFileContractElement)(rev.Parent).EncodeTo(e)
 	rev.Revision.EncodeTo(e)
-	rev.RenterSignature.EncodeTo(e)
-	rev.HostSignature.EncodeTo(e)
 }
 
 func (rev *compressedFileContractRevision) DecodeFrom(d *types.Decoder) {
 	(*compressedFileContractElement)(&rev.Parent).DecodeFrom(d)
 	rev.Revision.DecodeFrom(d)
-	rev.RenterSignature.DecodeFrom(d)
-	rev.HostSignature.DecodeFrom(d)
 }
 
 type compressedFileContractResolution types.FileContractResolution

--- a/net/rhp/contracts.go
+++ b/net/rhp/contracts.go
@@ -16,18 +16,16 @@ var (
 
 // A Contract pairs the latest revision with signatures from both parties.
 type Contract struct {
-	ID              types.ElementID
-	Revision        types.FileContract
-	HostSignature   types.Signature
-	RenterSignature types.Signature
+	ID       types.ElementID
+	Revision types.FileContract
 }
 
 // ValidateSignatures checks that the renter and host signatures are valid.
 func (c *Contract) ValidateSignatures(vc consensus.ValidationContext) (err error) {
 	hash := vc.ContractSigHash(c.Revision)
-	if !c.Revision.HostPublicKey.VerifyHash(hash, c.HostSignature) {
+	if !c.Revision.HostPublicKey.VerifyHash(hash, c.Revision.HostSignature) {
 		err = fmt.Errorf("failed to validate host signature: %w", ErrInvalidSignature)
-	} else if !c.Revision.RenterPublicKey.VerifyHash(hash, c.RenterSignature) {
+	} else if !c.Revision.RenterPublicKey.VerifyHash(hash, c.Revision.RenterSignature) {
 		err = fmt.Errorf("failed to validate renter signature: %w", ErrInvalidSignature)
 	}
 	return
@@ -37,16 +35,12 @@ func (c *Contract) ValidateSignatures(vc consensus.ValidationContext) (err error
 func (c *Contract) EncodeTo(enc *types.Encoder) {
 	c.ID.EncodeTo(enc)
 	c.Revision.EncodeTo(enc)
-	c.HostSignature.EncodeTo(enc)
-	c.RenterSignature.EncodeTo(enc)
 }
 
 // DecodeFrom implements types.DecoderFrom.
 func (c *Contract) DecodeFrom(dec *types.Decoder) {
 	c.ID.DecodeFrom(dec)
 	c.Revision.DecodeFrom(dec)
-	c.HostSignature.DecodeFrom(dec)
-	c.RenterSignature.DecodeFrom(dec)
 }
 
 // MaxLen implements rpc.Object.

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -382,6 +382,8 @@ func (fc FileContract) EncodeTo(e *Encoder) {
 	fc.RenterPublicKey.EncodeTo(e)
 	fc.HostPublicKey.EncodeTo(e)
 	e.WriteUint64(fc.RevisionNumber)
+	fc.RenterSignature.EncodeTo(e)
+	fc.HostSignature.EncodeTo(e)
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -394,8 +396,6 @@ func (fce FileContractElement) EncodeTo(e *Encoder) {
 func (rev FileContractRevision) EncodeTo(e *Encoder) {
 	rev.Parent.EncodeTo(e)
 	rev.Revision.EncodeTo(e)
-	rev.RenterSignature.EncodeTo(e)
-	rev.HostSignature.EncodeTo(e)
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -734,6 +734,8 @@ func (fc *FileContract) DecodeFrom(d *Decoder) {
 	fc.RenterPublicKey.DecodeFrom(d)
 	fc.HostPublicKey.DecodeFrom(d)
 	fc.RevisionNumber = d.ReadUint64()
+	fc.RenterSignature.DecodeFrom(d)
+	fc.HostSignature.DecodeFrom(d)
 }
 
 // DecodeFrom implements types.DecoderFrom.
@@ -746,8 +748,6 @@ func (fce *FileContractElement) DecodeFrom(d *Decoder) {
 func (rev *FileContractRevision) DecodeFrom(d *Decoder) {
 	rev.Parent.DecodeFrom(d)
 	rev.Revision.DecodeFrom(d)
-	rev.RenterSignature.DecodeFrom(d)
-	rev.HostSignature.DecodeFrom(d)
 }
 
 // DecodeFrom implements types.DecoderFrom.

--- a/types/types.go
+++ b/types/types.go
@@ -134,6 +134,10 @@ type FileContract struct {
 	RenterPublicKey    PublicKey
 	HostPublicKey      PublicKey
 	RevisionNumber     uint64
+
+	// signatures cover above fields
+	RenterSignature Signature
+	HostSignature   Signature
 }
 
 // CanResolveEarly returns true if fc cannot be revised and its valid resolution
@@ -167,10 +171,8 @@ type SiafundInput struct {
 
 // A FileContractRevision updates the state of an existing file contract.
 type FileContractRevision struct {
-	Parent          FileContractElement
-	Revision        FileContract
-	RenterSignature Signature
-	HostSignature   Signature
+	Parent   FileContractElement
+	Revision FileContract
 }
 
 // A FileContractResolution closes a file contract's payment channel. If a valid


### PR DESCRIPTION
This brings `FileContract` into parity with other signed types, like `Attestation`. It will also make the upcoming contract renewal changes a bit cleaner.

Historically, the initial file contract hasn't been signed because it's redundant: each party is supplying inputs to the contract transaction, and they have to sign those inputs. But it bugs me that someone could broadcast a transaction that *claims* to form a contract with a particular host (by using their public key), even though the host actually knew nothing about it. Obviously, the host would then "fail" the storage proof, so these phony contracts could negatively impact a host's reputation. Requiring signatures on the initial contract prevents this.