### PR TITLE
types: Make 'early close' an explicit form of contract resolution

### DIFF
--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -638,7 +638,7 @@ func TestFileContracts(t *testing.T) {
 	}
 }
 
-func TestEarlyContractResolution(t *testing.T) {
+func TestContractFinalization(t *testing.T) {
 	renterPubkey, renterPrivkey := testingKeypair(0)
 	hostPubkey, hostPrivkey := testingKeypair(1)
 	b := genesisWithSiacoinOutputs(types.SiacoinOutput{
@@ -708,7 +708,7 @@ func TestEarlyContractResolution(t *testing.T) {
 		t.Fatal("expected siafund pool to increase")
 	}
 
-	// revise the contract such that it can be resolved early
+	// finalize the contract
 	finalRev := fc.FileContract
 	finalRev.RevisionNumber = types.MaxRevisionNumber
 	finalRev.MissedRenterOutput = finalRev.ValidRenterOutput
@@ -717,9 +717,9 @@ func TestEarlyContractResolution(t *testing.T) {
 	finalRev.RenterSignature = renterPrivkey.SignHash(contractHash)
 	finalRev.HostSignature = hostPrivkey.SignHash(contractHash)
 	txn = types.Transaction{
-		FileContractRevisions: []types.FileContractRevision{{
-			Parent:   fc,
-			Revision: finalRev,
+		FileContractResolutions: []types.FileContractResolution{{
+			Parent:       fc,
+			Finalization: finalRev,
 		}},
 	}
 

--- a/merkle/multiproof.go
+++ b/merkle/multiproof.go
@@ -293,11 +293,13 @@ type compressedFileContractResolution types.FileContractResolution
 func (res compressedFileContractResolution) EncodeTo(e *types.Encoder) {
 	(compressedFileContractElement)(res.Parent).EncodeTo(e)
 	res.StorageProof.EncodeTo(e)
+	res.Finalization.EncodeTo(e)
 }
 
 func (res *compressedFileContractResolution) DecodeFrom(d *types.Decoder) {
 	(*compressedFileContractElement)(&res.Parent).DecodeFrom(d)
 	res.StorageProof.DecodeFrom(d)
+	res.Finalization.DecodeFrom(d)
 }
 
 type compressedTransaction types.Transaction

--- a/net/rhp/rpc.go
+++ b/net/rhp/rpc.go
@@ -63,7 +63,7 @@ type (
 	// and RenewContract RPCs. For the form contract RPC, a minimum of one
 	// transaction including a single file contract is required. For the renew
 	// contract RPC a minimum of two transactions are required, the first should
-	// clear the existing contract and the second should include the renewed
+	// finalize the existing contract and the second should include the renewed
 	// contract.
 	RPCContractRequest struct {
 		Transactions []types.Transaction
@@ -87,12 +87,12 @@ type (
 	}
 
 	// RPCRenewContractSignatures contains the signatures for a contract
-	// transaction, initial revision, and clearing revision. These signatures
-	// are sent by both the renter and host during contract renewal.
+	// transaction, initial revision, and finalization revision. These
+	// signatures are sent by both the renter and host during contract renewal.
 	RPCRenewContractSignatures struct {
 		SiacoinInputSignatures [][]types.InputSignature
 		RenewalSignature       types.Signature
-		ClearingSignature      types.Signature
+		FinalizationSignature  types.Signature
 	}
 
 	// RPCLockRequest contains the request parameters for the Lock RPC.
@@ -313,7 +313,7 @@ func (r *RPCRenewContractSignatures) EncodeTo(e *types.Encoder) {
 		}
 	}
 	r.RenewalSignature.EncodeTo(e)
-	r.ClearingSignature.EncodeTo(e)
+	r.FinalizationSignature.EncodeTo(e)
 }
 
 // DecodeFrom implements rpc.Object.
@@ -326,7 +326,7 @@ func (r *RPCRenewContractSignatures) DecodeFrom(d *types.Decoder) {
 		}
 	}
 	r.RenewalSignature.DecodeFrom(d)
-	r.ClearingSignature.DecodeFrom(d)
+	r.FinalizationSignature.DecodeFrom(d)
 }
 
 // MaxLen implements rpc.Object.

--- a/net/rhp/session_test.go
+++ b/net/rhp/session_test.go
@@ -167,8 +167,8 @@ func TestEncoding(t *testing.T) {
 			SiacoinInputSignatures: [][]types.InputSignature{
 				randomTxn.SiacoinInputs[0].Signatures,
 			},
-			RenewalSignature:  types.Signature(randomTxn.SiacoinInputs[0].Signatures[0]),
-			ClearingSignature: types.Signature(randomTxn.SiacoinInputs[0].Signatures[0]),
+			RenewalSignature:      types.Signature(randomTxn.SiacoinInputs[0].Signatures[0]),
+			FinalizationSignature: types.Signature(randomTxn.SiacoinInputs[0].Signatures[0]),
 		},
 		&RPCLockRequest{
 			ContractID: randomTxn.FileContractRevisions[0].Parent.ID,

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -410,6 +410,7 @@ func (sp StorageProof) EncodeTo(e *Encoder) {
 func (res FileContractResolution) EncodeTo(e *Encoder) {
 	res.Parent.EncodeTo(e)
 	res.StorageProof.EncodeTo(e)
+	res.Finalization.EncodeTo(e)
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -762,6 +763,7 @@ func (sp *StorageProof) DecodeFrom(d *Decoder) {
 func (res *FileContractResolution) DecodeFrom(d *Decoder) {
 	res.Parent.DecodeFrom(d)
 	res.StorageProof.DecodeFrom(d)
+	res.Finalization.DecodeFrom(d)
 }
 
 // DecodeFrom implements types.DecoderFrom.


### PR DESCRIPTION
Previously, a `FileContractRevision` could actually be a `FileContractResolution` if it satisfied certain properties. That felt a little too magic to me, so instead I moved the "early close" case into the `FileContractResolution` type. Now, a revision always revises, and a resolution always resolves.

...well, except that a resolution can also revise. But still, I think this is an improvement.