### PR TITLE
consensus: Fix how blocks contribute to TotalWork

### DIFF
--- a/consensus/update.go
+++ b/consensus/update.go
@@ -74,10 +74,9 @@ func applyHeader(vc *ValidationContext, h types.BlockHeader) {
 		vc.Index = h.Index()
 		return
 	}
-	blockWork := types.WorkRequiredForHash(h.ID())
-	vc.TotalWork = vc.TotalWork.Add(blockWork)
+	vc.TotalWork = vc.TotalWork.Add(vc.Difficulty)
 	parentTimestamp := vc.PrevTimestamps[vc.numTimestamps()-1]
-	vc.OakTime, vc.OakWork = updateOakTotals(vc.OakTime, h.Timestamp.Sub(parentTimestamp), vc.OakWork, blockWork)
+	vc.OakTime, vc.OakWork = updateOakTotals(vc.OakTime, h.Timestamp.Sub(parentTimestamp), vc.OakWork, vc.Difficulty)
 	vc.Difficulty = adjustDifficulty(vc.Difficulty, h.Height, h.Timestamp.Sub(vc.GenesisTimestamp), vc.OakTime, vc.OakWork)
 	if vc.numTimestamps() < len(vc.PrevTimestamps) {
 		vc.PrevTimestamps[vc.numTimestamps()] = h.Timestamp


### PR DESCRIPTION
In retrospect, this is obvious: a really low hash does not imply that more work was performed, only that the miner got lucky. We don't care *which* specific hash the miner found, only that it's below the required target.

This might cause some issues for tests, since you won't be able to make one chain heavier than another just by grinding a slightly better nonce; you'll have to mine additional blocks, or mess with the timestamps. Shouldn't be too bad.