### PR TITLE
Separate contract signature validation

### DIFF
--- a/host/executor.go
+++ b/host/executor.go
@@ -438,27 +438,34 @@ func (pe *ProgramExecutor) ExecuteInstruction(r io.Reader, w io.Writer, instruct
 // FinalizeContract updates the contract to reflect the final state of the
 // program.
 func (pe *ProgramExecutor) FinalizeContract(req rhp.RPCFinalizeProgramRequest) (rhp.Contract, error) {
-	c := pe.contract
-	c.Revision.RevisionNumber = req.NewRevisionNumber
-	req.NewOutputs.Apply(&c.Revision)
+	revision := pe.contract.Revision
+	revision.RevisionNumber = req.NewRevisionNumber
+	req.NewOutputs.Apply(&revision)
 	// update the contract's merkle root and file size.
-	c.Revision.FileMerkleRoot = pe.newMerkleRoot
-	c.Revision.Filesize = pe.newFileSize
-
-	c.Revision.RenterSignature = req.Signature
-	c.Revision.HostSignature = pe.privkey.SignHash(pe.vc.ContractSigHash(c.Revision))
+	revision.FileMerkleRoot = pe.newMerkleRoot
+	revision.Filesize = pe.newFileSize
 
 	// validate that the renter's revision is valid and only transfers the
 	// additional collateral and storage costs to the void. All other
 	// costs have already been paid by the RPC budget.
-	if err := rhp.ValidateProgramRevision(pe.vc, pe.contract, c, pe.additionalStorage, pe.additionalCollateral); err != nil {
-		return rhp.Contract{}, fmt.Errorf("failed to verify contract revision: %w", err)
-	} else if err := pe.contracts.Revise(c); err != nil {
+	if err := rhp.ValidateProgramRevision(pe.contract.Revision, revision, pe.additionalStorage, pe.additionalCollateral); err != nil {
+		return rhp.Contract{}, fmt.Errorf("failed to validate program revision: %w", err)
+	}
+
+	sigHash := pe.vc.ContractSigHash(revision)
+	if !pe.contract.Revision.RenterPublicKey.VerifyHash(sigHash, req.Signature) {
+		return rhp.Contract{}, errors.New("invalid renter signature")
+	}
+	revision.RenterSignature = req.Signature
+	revision.HostSignature = pe.privkey.SignHash(sigHash)
+	pe.contract.Revision = revision
+
+	if err := pe.contracts.Revise(pe.contract); err != nil {
 		return rhp.Contract{}, fmt.Errorf("failed to revise contract: %w", err)
-	} else if err := pe.contracts.SetRoots(c.ID, pe.newRoots); err != nil {
+	} else if err := pe.contracts.SetRoots(pe.contract.ID, pe.newRoots); err != nil {
 		return rhp.Contract{}, fmt.Errorf("failed to set new roots: %w", err)
 	}
-	return c, nil
+	return pe.contract, nil
 }
 
 // Revert removes the sectors that were added by the program. If


### PR DESCRIPTION
Removes signature validation from the validation functions, signatures would need to be validated externally. The primary motivation was changing `ValidateContractFinalization` to validate all fields except the signature fields to short-circuit the renew RPC before the host has the renter signatures, like `ValidateRenewal` and `ValidateContractFormation`. However, I'm unsure if the change makes sense for the other validation methods, like `ValidatePaymentRevision`, which would have the signatures immediately.