### PR TITLE
Remove distinct InputSignature type

### DIFF
--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -514,7 +514,7 @@ func TestFileContracts(t *testing.T) {
 	contractHash := sau.Context.ContractSigHash(*fc)
 	fc.RenterSignature = renterPrivkey.SignHash(contractHash)
 	fc.HostSignature = hostPrivkey.SignHash(contractHash)
-	sigHash := sau.Context.SigHash(txn)
+	sigHash := sau.Context.InputSigHash(txn)
 	txn.SiacoinInputs[0].Signatures = []types.InputSignature{types.InputSignature(renterPrivkey.SignHash(sigHash))}
 	txn.SiacoinInputs[1].Signatures = []types.InputSignature{types.InputSignature(hostPrivkey.SignHash(sigHash))}
 
@@ -687,7 +687,7 @@ func TestContractFinalization(t *testing.T) {
 		FileContracts: []types.FileContract{initialRev},
 		MinerFee:      renterOutput.Value.Add(hostOutput.Value).Sub(outputSum),
 	}
-	sigHash := sau.Context.SigHash(txn)
+	sigHash := sau.Context.InputSigHash(txn)
 	txn.SiacoinInputs[0].Signatures = []types.InputSignature{types.InputSignature(renterPrivkey.SignHash(sigHash))}
 	txn.SiacoinInputs[1].Signatures = []types.InputSignature{types.InputSignature(hostPrivkey.SignHash(sigHash))}
 
@@ -791,7 +791,7 @@ func TestRevertFileContractRevision(t *testing.T) {
 		FileContracts: []types.FileContract{initialRev},
 		MinerFee:      renterOutput.Value.Add(hostOutput.Value).Sub(outputSum),
 	}
-	sigHash := vc.SigHash(txn)
+	sigHash := vc.InputSigHash(txn)
 	txn.SiacoinInputs[0].Signatures = []types.InputSignature{types.InputSignature(renterPrivkey.SignHash(sigHash))}
 	txn.SiacoinInputs[1].Signatures = []types.InputSignature{types.InputSignature(hostPrivkey.SignHash(sigHash))}
 

--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -515,8 +515,8 @@ func TestFileContracts(t *testing.T) {
 	fc.RenterSignature = renterPrivkey.SignHash(contractHash)
 	fc.HostSignature = hostPrivkey.SignHash(contractHash)
 	sigHash := sau.Context.InputSigHash(txn)
-	txn.SiacoinInputs[0].Signatures = []types.InputSignature{types.InputSignature(renterPrivkey.SignHash(sigHash))}
-	txn.SiacoinInputs[1].Signatures = []types.InputSignature{types.InputSignature(hostPrivkey.SignHash(sigHash))}
+	txn.SiacoinInputs[0].Signatures = []types.Signature{renterPrivkey.SignHash(sigHash)}
+	txn.SiacoinInputs[1].Signatures = []types.Signature{hostPrivkey.SignHash(sigHash)}
 
 	b = mineBlock(sau.Context, b, txn)
 	if err := sau.Context.ValidateBlock(b); err != nil {
@@ -688,8 +688,8 @@ func TestContractFinalization(t *testing.T) {
 		MinerFee:      renterOutput.Value.Add(hostOutput.Value).Sub(outputSum),
 	}
 	sigHash := sau.Context.InputSigHash(txn)
-	txn.SiacoinInputs[0].Signatures = []types.InputSignature{types.InputSignature(renterPrivkey.SignHash(sigHash))}
-	txn.SiacoinInputs[1].Signatures = []types.InputSignature{types.InputSignature(hostPrivkey.SignHash(sigHash))}
+	txn.SiacoinInputs[0].Signatures = []types.Signature{renterPrivkey.SignHash(sigHash)}
+	txn.SiacoinInputs[1].Signatures = []types.Signature{hostPrivkey.SignHash(sigHash)}
 
 	b = mineBlock(sau.Context, b, txn)
 	if err := sau.Context.ValidateBlock(b); err != nil {
@@ -792,8 +792,8 @@ func TestRevertFileContractRevision(t *testing.T) {
 		MinerFee:      renterOutput.Value.Add(hostOutput.Value).Sub(outputSum),
 	}
 	sigHash := vc.InputSigHash(txn)
-	txn.SiacoinInputs[0].Signatures = []types.InputSignature{types.InputSignature(renterPrivkey.SignHash(sigHash))}
-	txn.SiacoinInputs[1].Signatures = []types.InputSignature{types.InputSignature(hostPrivkey.SignHash(sigHash))}
+	txn.SiacoinInputs[0].Signatures = []types.Signature{renterPrivkey.SignHash(sigHash)}
+	txn.SiacoinInputs[1].Signatures = []types.Signature{hostPrivkey.SignHash(sigHash)}
 
 	// mine a block confirming the contract
 	parent, b = b, mineBlock(vc, b, txn)

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -235,7 +235,7 @@ func (vc *ValidationContext) InputSigHash(txn types.Transaction) types.Hash256 {
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
-	h.E.WriteString("sia/sig/transaction")
+	h.E.WriteString("sia/sig/transactioninput")
 	h.E.WritePrefix(len(txn.SiacoinInputs))
 	for _, in := range txn.SiacoinInputs {
 		in.Parent.ID.EncodeTo(h.E)
@@ -602,7 +602,7 @@ func (vc *ValidationContext) validFoundationUpdate(txn types.Transaction) error 
 
 func (vc *ValidationContext) validSpendPolicies(txn types.Transaction) error {
 	sigHash := vc.InputSigHash(txn)
-	verifyPolicy := func(p types.SpendPolicy, sigs []types.InputSignature) error {
+	verifyPolicy := func(p types.SpendPolicy, sigs []types.Signature) error {
 		var verify func(types.SpendPolicy) error
 		verify = func(p types.SpendPolicy) error {
 			switch p := p.(type) {

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -230,8 +230,8 @@ func (vc *ValidationContext) Commitment(minerAddr types.Address, txns []types.Tr
 	return h.Sum()
 }
 
-// SigHash returns the hash that must be signed for each transaction input.
-func (vc *ValidationContext) SigHash(txn types.Transaction) types.Hash256 {
+// InputSigHash returns the hash that must be signed for each transaction input.
+func (vc *ValidationContext) InputSigHash(txn types.Transaction) types.Hash256 {
 	h := hasherPool.Get().(*types.Hasher)
 	defer hasherPool.Put(h)
 	h.Reset()
@@ -601,7 +601,7 @@ func (vc *ValidationContext) validFoundationUpdate(txn types.Transaction) error 
 }
 
 func (vc *ValidationContext) validSpendPolicies(txn types.Transaction) error {
-	sigHash := vc.SigHash(txn)
+	sigHash := vc.InputSigHash(txn)
 	verifyPolicy := func(p types.SpendPolicy, sigs []types.InputSignature) error {
 		var verify func(types.SpendPolicy) error
 		verify = func(p types.SpendPolicy) error {

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -34,7 +34,7 @@ func genesisWithSiacoinOutputs(scos ...types.SiacoinOutput) types.Block {
 }
 
 func signAllInputs(txn *types.Transaction, vc ValidationContext, priv types.PrivateKey) {
-	sigHash := vc.SigHash(*txn)
+	sigHash := vc.InputSigHash(*txn)
 	for i := range txn.SiacoinInputs {
 		txn.SiacoinInputs[i].Signatures = []types.InputSignature{types.InputSignature(priv.SignHash(sigHash))}
 	}
@@ -935,7 +935,7 @@ func TestValidateSpendPolicy(t *testing.T) {
 				SpendPolicy: tt.policy,
 			}},
 		}
-		sigHash := vc.SigHash(txn)
+		sigHash := vc.InputSigHash(txn)
 		txn.SiacoinInputs[0].Signatures = tt.sign(sigHash)
 		if err := vc.validSpendPolicies(txn); (err != nil) != tt.wantErr {
 			t.Fatalf("case %q failed: %v", tt.desc, err)
@@ -1167,7 +1167,7 @@ func TestNoDoubleContractUpdates(t *testing.T) {
 		},
 		FileContracts: []types.FileContract{fc},
 	}
-	sigHash := vc.SigHash(formationTxn)
+	sigHash := vc.InputSigHash(formationTxn)
 	formationTxn.SiacoinInputs[0].Signatures = []types.InputSignature{types.InputSignature(renterPriv.SignHash(sigHash))}
 	formationTxn.SiacoinInputs[1].Signatures = []types.InputSignature{types.InputSignature(hostPriv.SignHash(sigHash))}
 	b := mineBlock(vc, genesis, formationTxn)

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -36,10 +36,10 @@ func genesisWithSiacoinOutputs(scos ...types.SiacoinOutput) types.Block {
 func signAllInputs(txn *types.Transaction, vc ValidationContext, priv types.PrivateKey) {
 	sigHash := vc.InputSigHash(*txn)
 	for i := range txn.SiacoinInputs {
-		txn.SiacoinInputs[i].Signatures = []types.InputSignature{types.InputSignature(priv.SignHash(sigHash))}
+		txn.SiacoinInputs[i].Signatures = []types.Signature{types.Signature(priv.SignHash(sigHash))}
 	}
 	for i := range txn.SiafundInputs {
-		txn.SiafundInputs[i].Signatures = []types.InputSignature{types.InputSignature(priv.SignHash(sigHash))}
+		txn.SiafundInputs[i].Signatures = []types.Signature{types.Signature(priv.SignHash(sigHash))}
 	}
 }
 
@@ -720,7 +720,7 @@ func TestValidateSpendPolicy(t *testing.T) {
 	tests := []struct {
 		desc    string
 		policy  types.SpendPolicy
-		sign    func(sigHash types.Hash256) []types.InputSignature
+		sign    func(sigHash types.Hash256) []types.Signature
 		wantErr bool
 	}{
 		{
@@ -732,21 +732,21 @@ func TestValidateSpendPolicy(t *testing.T) {
 					types.PolicyPublicKey(pubkey(1)),
 				},
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{types.InputSignature(privkey(0).SignHash(sigHash))}
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{privkey(0).SignHash(sigHash)}
 			},
 			wantErr: true,
 		},
 		{
 			desc:    "height not above",
 			policy:  types.PolicyAbove(150),
-			sign:    func(types.Hash256) []types.InputSignature { return nil },
+			sign:    func(types.Hash256) []types.Signature { return nil },
 			wantErr: true,
 		},
 		{
 			desc:    "anyone can spend",
 			policy:  types.AnyoneCanSpend(),
-			sign:    func(types.Hash256) []types.InputSignature { return nil },
+			sign:    func(types.Hash256) []types.Signature { return nil },
 			wantErr: false,
 		},
 		{
@@ -759,11 +759,11 @@ func TestValidateSpendPolicy(t *testing.T) {
 					types.PolicyPublicKey(pubkey(2)),
 				},
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{
-					types.InputSignature(privkey(0).SignHash(sigHash)),
-					types.InputSignature(privkey(1).SignHash(sigHash)),
-					types.InputSignature(privkey(2).SignHash(sigHash)),
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{
+					privkey(0).SignHash(sigHash),
+					privkey(1).SignHash(sigHash),
+					privkey(2).SignHash(sigHash),
 				}
 			},
 			wantErr: false,
@@ -791,8 +791,8 @@ func TestValidateSpendPolicy(t *testing.T) {
 					},
 				},
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{types.InputSignature(privkey(3).SignHash(sigHash))}
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{privkey(3).SignHash(sigHash)}
 			},
 			wantErr: true,
 		},
@@ -819,10 +819,10 @@ func TestValidateSpendPolicy(t *testing.T) {
 					},
 				},
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{
-					types.InputSignature(privkey(1).SignHash(sigHash)),
-					types.InputSignature(privkey(2).SignHash(sigHash)),
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{
+					privkey(1).SignHash(sigHash),
+					privkey(2).SignHash(sigHash),
 				}
 			},
 			wantErr: false,
@@ -850,8 +850,8 @@ func TestValidateSpendPolicy(t *testing.T) {
 					},
 				},
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{types.InputSignature(privkey(3).SignHash(sigHash))}
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{privkey(3).SignHash(sigHash)}
 			},
 			wantErr: false,
 		},
@@ -865,9 +865,9 @@ func TestValidateSpendPolicy(t *testing.T) {
 				},
 				SignaturesRequired: 2,
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{
-					types.InputSignature(privkey(0).SignHash(sigHash)),
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{
+					privkey(0).SignHash(sigHash),
 				}
 			},
 			wantErr: true,
@@ -881,9 +881,9 @@ func TestValidateSpendPolicy(t *testing.T) {
 				Timelock:           150,
 				SignaturesRequired: 1,
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{
-					types.InputSignature(privkey(0).SignHash(sigHash)),
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{
+					privkey(0).SignHash(sigHash),
 				}
 			},
 			wantErr: true,
@@ -898,10 +898,10 @@ func TestValidateSpendPolicy(t *testing.T) {
 				},
 				SignaturesRequired: 2,
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{
-					types.InputSignature(privkey(0).SignHash(sigHash)),
-					types.InputSignature(privkey(1).SignHash(sigHash)),
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{
+					privkey(0).SignHash(sigHash),
+					privkey(1).SignHash(sigHash),
 				}
 			},
 			wantErr: false,
@@ -915,10 +915,8 @@ func TestValidateSpendPolicy(t *testing.T) {
 				Timelock:           80,
 				SignaturesRequired: 1,
 			},
-			sign: func(sigHash types.Hash256) []types.InputSignature {
-				return []types.InputSignature{
-					types.InputSignature(privkey(0).SignHash(sigHash)),
-				}
+			sign: func(sigHash types.Hash256) []types.Signature {
+				return []types.Signature{privkey(0).SignHash(sigHash)}
 			},
 			wantErr: false,
 		},
@@ -1168,8 +1166,8 @@ func TestNoDoubleContractUpdates(t *testing.T) {
 		FileContracts: []types.FileContract{fc},
 	}
 	sigHash := vc.InputSigHash(formationTxn)
-	formationTxn.SiacoinInputs[0].Signatures = []types.InputSignature{types.InputSignature(renterPriv.SignHash(sigHash))}
-	formationTxn.SiacoinInputs[1].Signatures = []types.InputSignature{types.InputSignature(hostPriv.SignHash(sigHash))}
+	formationTxn.SiacoinInputs[0].Signatures = []types.Signature{renterPriv.SignHash(sigHash)}
+	formationTxn.SiacoinInputs[1].Signatures = []types.Signature{hostPriv.SignHash(sigHash)}
 	b := mineBlock(vc, genesis, formationTxn)
 	if err := vc.ValidateBlock(b); err != nil {
 		t.Fatal(err)

--- a/internal/chainutil/chainutil.go
+++ b/internal/chainutil/chainutil.go
@@ -155,7 +155,7 @@ func (cs *ChainSim) MineBlockWithSiacoinOutputs(scos ...types.SiacoinOutput) typ
 	}
 
 	// sign and mine
-	sigHash := cs.Context.SigHash(txn)
+	sigHash := cs.Context.InputSigHash(txn)
 	for i := range txn.SiacoinInputs {
 		txn.SiacoinInputs[i].Signatures = []types.InputSignature{types.InputSignature(cs.privkey.SignHash(sigHash))}
 	}
@@ -178,7 +178,7 @@ func (cs *ChainSim) MineBlock() types.Block {
 			},
 			MinerFee: types.NewCurrency64(cs.Context.Index.Height),
 		}
-		sigHash := cs.Context.SigHash(txn)
+		sigHash := cs.Context.InputSigHash(txn)
 		for i := range txn.SiacoinInputs {
 			txn.SiacoinInputs[i].Signatures = []types.InputSignature{types.InputSignature(cs.privkey.SignHash(sigHash))}
 		}

--- a/internal/chainutil/chainutil.go
+++ b/internal/chainutil/chainutil.go
@@ -157,7 +157,7 @@ func (cs *ChainSim) MineBlockWithSiacoinOutputs(scos ...types.SiacoinOutput) typ
 	// sign and mine
 	sigHash := cs.Context.InputSigHash(txn)
 	for i := range txn.SiacoinInputs {
-		txn.SiacoinInputs[i].Signatures = []types.InputSignature{types.InputSignature(cs.privkey.SignHash(sigHash))}
+		txn.SiacoinInputs[i].Signatures = []types.Signature{cs.privkey.SignHash(sigHash)}
 	}
 	return cs.MineBlockWithTxns(txn)
 }
@@ -180,7 +180,7 @@ func (cs *ChainSim) MineBlock() types.Block {
 		}
 		sigHash := cs.Context.InputSigHash(txn)
 		for i := range txn.SiacoinInputs {
-			txn.SiacoinInputs[i].Signatures = []types.InputSignature{types.InputSignature(cs.privkey.SignHash(sigHash))}
+			txn.SiacoinInputs[i].Signatures = []types.Signature{cs.privkey.SignHash(sigHash)}
 		}
 
 		txns = append(txns, txn)

--- a/merkle/multiproof.go
+++ b/merkle/multiproof.go
@@ -222,7 +222,7 @@ func (in compressedSiacoinInput) EncodeTo(e *types.Encoder) {
 func (in *compressedSiacoinInput) DecodeFrom(d *types.Decoder) {
 	(*compressedSiacoinElement)(&in.Parent).DecodeFrom(d)
 	in.SpendPolicy = d.ReadPolicy()
-	in.Signatures = make([]types.InputSignature, d.ReadPrefix())
+	in.Signatures = make([]types.Signature, d.ReadPrefix())
 	for i := range in.Signatures {
 		in.Signatures[i].DecodeFrom(d)
 	}
@@ -258,7 +258,7 @@ func (in *compressedSiafundInput) DecodeFrom(d *types.Decoder) {
 	(*compressedSiafundElement)(&in.Parent).DecodeFrom(d)
 	in.ClaimAddress.DecodeFrom(d)
 	in.SpendPolicy = d.ReadPolicy()
-	in.Signatures = make([]types.InputSignature, d.ReadPrefix())
+	in.Signatures = make([]types.Signature, d.ReadPrefix())
 	for i := range in.Signatures {
 		in.Signatures[i].DecodeFrom(d)
 	}

--- a/net/rhp/rpc.go
+++ b/net/rhp/rpc.go
@@ -82,7 +82,7 @@ type (
 	// transaction and initial revision. These signatures are sent by both the
 	// renter and host during contract formation.
 	RPCContractSignatures struct {
-		SiacoinInputSignatures [][]types.InputSignature
+		SiacoinInputSignatures [][]types.Signature
 		RevisionSignature      types.Signature
 	}
 
@@ -90,7 +90,7 @@ type (
 	// transaction, initial revision, and finalization revision. These
 	// signatures are sent by both the renter and host during contract renewal.
 	RPCRenewContractSignatures struct {
-		SiacoinInputSignatures [][]types.InputSignature
+		SiacoinInputSignatures [][]types.Signature
 		RenewalSignature       types.Signature
 		FinalizationSignature  types.Signature
 	}
@@ -98,7 +98,7 @@ type (
 	// RPCLockRequest contains the request parameters for the Lock RPC.
 	RPCLockRequest struct {
 		ContractID types.ElementID
-		Signature  types.InputSignature
+		Signature  types.Signature
 		Timeout    uint64
 	}
 
@@ -288,9 +288,9 @@ func (r *RPCContractSignatures) EncodeTo(e *types.Encoder) {
 
 // DecodeFrom implements rpc.Object.
 func (r *RPCContractSignatures) DecodeFrom(d *types.Decoder) {
-	r.SiacoinInputSignatures = make([][]types.InputSignature, d.ReadPrefix())
+	r.SiacoinInputSignatures = make([][]types.Signature, d.ReadPrefix())
 	for i := range r.SiacoinInputSignatures {
-		r.SiacoinInputSignatures[i] = make([]types.InputSignature, d.ReadPrefix())
+		r.SiacoinInputSignatures[i] = make([]types.Signature, d.ReadPrefix())
 		for j := range r.SiacoinInputSignatures[i] {
 			r.SiacoinInputSignatures[i][j].DecodeFrom(d)
 		}
@@ -318,9 +318,9 @@ func (r *RPCRenewContractSignatures) EncodeTo(e *types.Encoder) {
 
 // DecodeFrom implements rpc.Object.
 func (r *RPCRenewContractSignatures) DecodeFrom(d *types.Decoder) {
-	r.SiacoinInputSignatures = make([][]types.InputSignature, d.ReadPrefix())
+	r.SiacoinInputSignatures = make([][]types.Signature, d.ReadPrefix())
 	for i := range r.SiacoinInputSignatures {
-		r.SiacoinInputSignatures[i] = make([]types.InputSignature, d.ReadPrefix())
+		r.SiacoinInputSignatures[i] = make([]types.Signature, d.ReadPrefix())
 		for j := range r.SiacoinInputSignatures[i] {
 			r.SiacoinInputSignatures[i][j].DecodeFrom(d)
 		}

--- a/net/rhp/session_test.go
+++ b/net/rhp/session_test.go
@@ -158,13 +158,13 @@ func TestEncoding(t *testing.T) {
 			Outputs: randomTxn.SiacoinOutputs,
 		},
 		&RPCContractSignatures{
-			SiacoinInputSignatures: [][]types.InputSignature{
+			SiacoinInputSignatures: [][]types.Signature{
 				randomTxn.SiacoinInputs[0].Signatures,
 			},
 			RevisionSignature: types.Signature(randomTxn.SiacoinInputs[0].Signatures[0]),
 		},
 		&RPCRenewContractSignatures{
-			SiacoinInputSignatures: [][]types.InputSignature{
+			SiacoinInputSignatures: [][]types.Signature{
 				randomTxn.SiacoinInputs[0].Signatures,
 			},
 			RenewalSignature:      types.Signature(randomTxn.SiacoinInputs[0].Signatures[0]),
@@ -172,7 +172,7 @@ func TestEncoding(t *testing.T) {
 		},
 		&RPCLockRequest{
 			ContractID: randomTxn.FileContractRevisions[0].Parent.ID,
-			Signature:  types.InputSignature(randSignature()),
+			Signature:  randSignature(),
 			Timeout:    frand.Uint64n(100),
 		},
 		&RPCLockResponse{

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -275,9 +275,6 @@ func (pk PublicKey) EncodeTo(e *Encoder) { e.Write(pk[:]) }
 func (s Signature) EncodeTo(e *Encoder) { e.Write(s[:]) }
 
 // EncodeTo implements types.EncoderTo.
-func (is InputSignature) EncodeTo(e *Encoder) { e.Write(is[:]) }
-
-// EncodeTo implements types.EncoderTo.
 func (w Work) EncodeTo(e *Encoder) { e.Write(w.NumHashes[:]) }
 
 // EncodeTo implements types.EncoderTo.
@@ -567,9 +564,6 @@ func (pk *PublicKey) DecodeFrom(d *Decoder) { d.Read(pk[:]) }
 func (s *Signature) DecodeFrom(d *Decoder) { d.Read(s[:]) }
 
 // DecodeFrom implements types.DecoderFrom.
-func (is *InputSignature) DecodeFrom(d *Decoder) { d.Read(is[:]) }
-
-// DecodeFrom implements types.DecoderFrom.
 func (w *Work) DecodeFrom(d *Decoder) { d.Read(w.NumHashes[:]) }
 
 // DecodeFrom implements types.DecoderFrom.
@@ -691,7 +685,7 @@ func (se *StateElement) DecodeFrom(d *Decoder) {
 func (in *SiacoinInput) DecodeFrom(d *Decoder) {
 	in.Parent.DecodeFrom(d)
 	in.SpendPolicy = d.ReadPolicy()
-	in.Signatures = make([]InputSignature, d.ReadPrefix())
+	in.Signatures = make([]Signature, d.ReadPrefix())
 	for i := range in.Signatures {
 		in.Signatures[i].DecodeFrom(d)
 	}
@@ -709,7 +703,7 @@ func (in *SiafundInput) DecodeFrom(d *Decoder) {
 	in.Parent.DecodeFrom(d)
 	in.ClaimAddress.DecodeFrom(d)
 	in.SpendPolicy = d.ReadPolicy()
-	in.Signatures = make([]InputSignature, d.ReadPrefix())
+	in.Signatures = make([]Signature, d.ReadPrefix())
 	for i := range in.Signatures {
 		in.Signatures[i].DecodeFrom(d)
 	}

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -69,7 +69,7 @@ func quickValue(t reflect.Type, rand *rand.Rand) reflect.Value {
 func TestEncoderRoundtrip(t *testing.T) {
 	tests := []EncoderTo{
 		Hash256{0: 0xAA, 31: 0xBB},
-		InputSignature{0: 0xAA, 63: 0xBB},
+		Signature{0: 0xAA, 63: 0xBB},
 		Work{NumHashes: [32]byte{0: 0xAA, 31: 0xBB}},
 		NewCurrency(5, 5),
 		ChainIndex{

--- a/types/types.go
+++ b/types/types.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -713,3 +714,21 @@ func (is *InputSignature) UnmarshalJSON(b []byte) error { return unmarshalJSONHe
 
 // String implements fmt.Stringer.
 func (w Work) String() string { return new(big.Int).SetBytes(w.NumHashes[:]).String() }
+
+// MarshalJSON implements json.Marshaler.
+func (w Work) MarshalJSON() ([]byte, error) {
+	return new(big.Int).SetBytes(w.NumHashes[:]).MarshalJSON()
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (w *Work) UnmarshalJSON(b []byte) error {
+	i := new(big.Int)
+	if err := json.Unmarshal(b, i); err != nil {
+		return err
+	} else if i.Sign() < 0 {
+		return errors.New("value cannot be negative")
+	} else if i.BitLen() > 128 {
+		return errors.New("value overflows Work representation")
+	}
+	return nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -102,9 +102,6 @@ func (pk PublicKey) VerifyHash(h Hash256, s Signature) bool {
 	return ed25519.Verify(pk[:], h[:], s[:])
 }
 
-// An InputSignature signs a transaction input.
-type InputSignature Signature
-
 // A SiacoinOutput is the recipient of some of the siacoins spent in a
 // transaction.
 type SiacoinOutput struct {
@@ -146,7 +143,7 @@ type FileContract struct {
 type SiacoinInput struct {
 	Parent      SiacoinElement
 	SpendPolicy SpendPolicy
-	Signatures  []InputSignature
+	Signatures  []Signature
 }
 
 // A SiafundInput spends an unspent SiafundElement in the state accumulator by
@@ -157,7 +154,7 @@ type SiafundInput struct {
 	Parent       SiafundElement
 	ClaimAddress Address
 	SpendPolicy  SpendPolicy
-	Signatures   []InputSignature
+	Signatures   []Signature
 }
 
 // A FileContractRevision updates the state of an existing file contract.
@@ -330,13 +327,13 @@ func (txn *Transaction) DeepCopy() Transaction {
 	c.SiacoinInputs = append([]SiacoinInput(nil), c.SiacoinInputs...)
 	for i := range c.SiacoinInputs {
 		c.SiacoinInputs[i].Parent.MerkleProof = append([]Hash256(nil), c.SiacoinInputs[i].Parent.MerkleProof...)
-		c.SiacoinInputs[i].Signatures = append([]InputSignature(nil), c.SiacoinInputs[i].Signatures...)
+		c.SiacoinInputs[i].Signatures = append([]Signature(nil), c.SiacoinInputs[i].Signatures...)
 	}
 	c.SiacoinOutputs = append([]SiacoinOutput(nil), c.SiacoinOutputs...)
 	c.SiafundInputs = append([]SiafundInput(nil), c.SiafundInputs...)
 	for i := range c.SiafundInputs {
 		c.SiafundInputs[i].Parent.MerkleProof = append([]Hash256(nil), c.SiafundInputs[i].Parent.MerkleProof...)
-		c.SiafundInputs[i].Signatures = append([]InputSignature(nil), c.SiafundInputs[i].Signatures...)
+		c.SiafundInputs[i].Signatures = append([]Signature(nil), c.SiafundInputs[i].Signatures...)
 	}
 	c.SiafundOutputs = append([]SiafundOutput(nil), c.SiafundOutputs...)
 	c.FileContracts = append([]FileContract(nil), c.FileContracts...)
@@ -704,13 +701,13 @@ func (tid TransactionID) MarshalJSON() ([]byte, error) { return marshalJSONHex("
 func (tid *TransactionID) UnmarshalJSON(b []byte) error { return unmarshalJSONHex(tid[:], "txid", b) }
 
 // String implements fmt.Stringer.
-func (is InputSignature) String() string { return stringerHex("sig", is[:]) }
+func (sig Signature) String() string { return stringerHex("sig", sig[:]) }
 
 // MarshalJSON implements json.Marshaler.
-func (is InputSignature) MarshalJSON() ([]byte, error) { return marshalJSONHex("sig", is[:]) }
+func (sig Signature) MarshalJSON() ([]byte, error) { return marshalJSONHex("sig", sig[:]) }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (is *InputSignature) UnmarshalJSON(b []byte) error { return unmarshalJSONHex(is[:], "sig", b) }
+func (sig *Signature) UnmarshalJSON(b []byte) error { return unmarshalJSONHex(sig[:], "sig", b) }
 
 // String implements fmt.Stringer.
 func (w Work) String() string { return new(big.Int).SetBytes(w.NumHashes[:]).String() }


### PR DESCRIPTION
I had originally thought that input signatures would need some additional metadata, like flags or an index, to indicate what part of the transaction they were signing. But I think we can get away without these: input signatures should just sign the entire transaction, always. There are a few fringe usecases for other types of signatures ([this](https://raghavsood.com/blog/2018/06/10/bitcoin-signature-types-sighash) is a good overview), but Sia doesn't benefit much from any of them. The only real "loss" is that you can't non-interactively sign an atomic swap transaction -- but you can still do it interactively by exchanging partially-signed transactions OOB (e.g. via Discord, which you'll probably be using to find swap partners anyway).

I also renamed `SigHash` to `InputSigHash`, for parity with `ContractSigHash` and `AttestationSigHash`.