### PR TITLE
 Restrict contract formation requests

### DIFF
--- a/host/host.go
+++ b/host/host.go
@@ -78,7 +78,7 @@ type (
 		Get(types.ElementID) (rhp.Contract, error)
 		// Add stores the provided contract, overwriting any previous contract
 		// with the same ID.
-		Add(rhp.Contract, []types.Transaction) error
+		Add(rhp.Contract, types.Transaction) error
 		// ReviseContract updates the current revision associated with a contract.
 		Revise(rhp.Contract) error
 
@@ -96,7 +96,7 @@ type (
 		Unlock(types.ElementID)
 		// Add stores the provided contract, overwriting any previous contract
 		// with the same ID.
-		Add(rhp.Contract, []types.Transaction) error
+		Add(rhp.Contract, types.Transaction) error
 		// ReviseContract updates the current revision associated with a contract.
 		Revise(rhp.Contract) error
 
@@ -114,7 +114,7 @@ type (
 	// A TransactionPool broadcasts transaction sets to miners for inclusion in
 	// an upcoming block.
 	TransactionPool interface {
-		AddTransactionSet(txns []types.Transaction) error
+		AddTransaction(txn types.Transaction) error
 		RecommendedFee() types.Currency
 	}
 

--- a/net/rhp/session_test.go
+++ b/net/rhp/session_test.go
@@ -149,17 +149,24 @@ func TestEncoding(t *testing.T) {
 	}
 	objs := []rpc.Object{
 		&rpc.Specifier{'f', 'o', 'o'},
-		&RPCContractRequest{
-			Transactions: []types.Transaction{randomTxn},
+		&RPCFormContractRequest{
+			Inputs:   randomTxn.SiacoinInputs,
+			Outputs:  randomTxn.SiacoinOutputs,
+			MinerFee: randomTxn.MinerFee,
+			Contract: randomTxn.FileContracts[0],
+		},
+		&RPCRenewContractRequest{
+			Inputs:     randomTxn.SiacoinInputs,
+			Outputs:    randomTxn.SiacoinOutputs,
+			MinerFee:   randomTxn.MinerFee,
+			Resolution: randomTxn.FileContractResolutions[0],
 		},
 		&RPCFormContractHostAdditions{
-			Parents:           []types.Transaction{randomTxn},
 			Inputs:            randomTxn.SiacoinInputs,
 			Outputs:           randomTxn.SiacoinOutputs,
 			ContractSignature: randomTxn.SiacoinInputs[0].Signatures[0],
 		},
 		&RPCRenewContractHostAdditions{
-			Parents:               []types.Transaction{randomTxn},
 			Inputs:                randomTxn.SiacoinInputs,
 			Outputs:               randomTxn.SiacoinOutputs,
 			RenewalSignature:      randomTxn.SiacoinInputs[0].Signatures[0],
@@ -170,7 +177,12 @@ func TestEncoding(t *testing.T) {
 				randomTxn.SiacoinInputs[0].Signatures,
 			},
 		},
-
+		&RPCRenewContractRenterSignatures{
+			SiacoinInputSignatures: [][]types.Signature{
+				randomTxn.SiacoinInputs[0].Signatures,
+			},
+			RenewalSignature: randomTxn.SiacoinInputs[0].Signatures[0],
+		},
 		&RPCLockRequest{
 			ContractID: randomTxn.FileContractRevisions[0].Parent.ID,
 			Signature:  randSignature(),


### PR DESCRIPTION
Changes the contract formation requests to only accept a subset of the transaction fields instead of a transaction set, as mentioned in #55.