### PR TITLE
Allow empty storage proofs within the proof window

### DIFF
--- a/consensus/update.go
+++ b/consensus/update.go
@@ -216,6 +216,8 @@ func createdInBlock(vc ValidationContext, b types.Block) (sces []types.SiacoinEl
 				renter, host = fce.RenterOutput, fce.HostOutput
 			} else if fcr.HasFinalization() {
 				renter, host = fcr.Finalization.RenterOutput, fcr.Finalization.HostOutput
+			} else if fce.Filesize == 0 {
+				renter, host = fce.RenterOutput, fce.HostOutput
 			} else {
 				renter, host = fce.RenterOutput, fce.MissedHostOutput()
 			}

--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -541,6 +541,7 @@ func TestFileContracts(t *testing.T) {
 		merkle.StorageProofLeafHash(data[64:]),
 	)
 	finalRev.Revision.RevisionNumber++
+	finalRev.Revision.Filesize = uint64(len(data))
 	contractHash = sau.Context.ContractSigHash(finalRev.Revision)
 	finalRev.Revision.RenterSignature = renterPrivkey.SignHash(contractHash)
 	finalRev.Revision.HostSignature = hostPrivkey.SignHash(contractHash)
@@ -572,7 +573,7 @@ func TestFileContracts(t *testing.T) {
 		WindowStart: sau.Context.Index,
 		WindowProof: sau.HistoryProof(),
 	}
-	proofIndex := sau.Context.StorageProofLeafIndex(fc.Filesize, sp.WindowStart, fce.ID)
+	proofIndex := sau.Context.StorageProofLeafIndex(finalRev.Revision.Filesize, sp.WindowStart, fce.ID)
 	copy(sp.Leaf[:], data[64*proofIndex:])
 	if proofIndex == 0 {
 		sp.Proof = append(sp.Proof, merkle.StorageProofLeafHash(data[64:]))


### PR DESCRIPTION
Hosts cannot currently retrieve funds for empty contracts until after the proof window unless the renter finalizes the contract. This PR allows contract resolutions with empty storage proofs when the contract has a zero Merkle root. 