### PR TITLE
Encapsulate SpendPolicy in concrete struct

### DIFF
--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -713,13 +713,13 @@ func TestValidateSpendPolicy(t *testing.T) {
 	}{
 		{
 			desc: "not enough signatures",
-			policy: types.PolicyThreshold{
-				N: 2,
-				Of: []types.SpendPolicy{
+			policy: types.PolicyThreshold(
+				2,
+				[]types.SpendPolicy{
 					types.PolicyPublicKey(pubkey(0)),
 					types.PolicyPublicKey(pubkey(1)),
 				},
-			},
+			),
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{privkey(0).SignHash(sigHash)}
 			},
@@ -739,14 +739,14 @@ func TestValidateSpendPolicy(t *testing.T) {
 		},
 		{
 			desc: "multiple public key signatures",
-			policy: types.PolicyThreshold{
-				N: 3,
-				Of: []types.SpendPolicy{
+			policy: types.PolicyThreshold(
+				3,
+				[]types.SpendPolicy{
 					types.PolicyPublicKey(pubkey(0)),
 					types.PolicyPublicKey(pubkey(1)),
 					types.PolicyPublicKey(pubkey(2)),
 				},
-			},
+			),
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{
 					privkey(0).SignHash(sigHash),
@@ -758,27 +758,27 @@ func TestValidateSpendPolicy(t *testing.T) {
 		},
 		{
 			desc: "invalid foundation failsafe",
-			policy: types.PolicyThreshold{
-				N: 1,
-				Of: []types.SpendPolicy{
-					types.PolicyThreshold{
-						N: 2,
-						Of: []types.SpendPolicy{
+			policy: types.PolicyThreshold(
+				1,
+				[]types.SpendPolicy{
+					types.PolicyThreshold(
+						2,
+						[]types.SpendPolicy{
 							types.PolicyPublicKey(pubkey(0)),
 							types.PolicyPublicKey(pubkey(1)),
 							types.PolicyPublicKey(pubkey(2)),
 						},
-					},
+					),
 					// failsafe policy is not satisfied because the current height is 100
-					types.PolicyThreshold{
-						N: 2,
-						Of: []types.SpendPolicy{
+					types.PolicyThreshold(
+						2,
+						[]types.SpendPolicy{
 							types.PolicyPublicKey(pubkey(3)),
 							types.PolicyAbove(150),
 						},
-					},
+					),
 				},
-			},
+			),
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{privkey(3).SignHash(sigHash)}
 			},
@@ -786,27 +786,27 @@ func TestValidateSpendPolicy(t *testing.T) {
 		},
 		{
 			desc: "valid foundation primary",
-			policy: types.PolicyThreshold{
-				N: 1,
-				Of: []types.SpendPolicy{
-					types.PolicyThreshold{
-						N: 2,
-						Of: []types.SpendPolicy{
+			policy: types.PolicyThreshold(
+				1,
+				[]types.SpendPolicy{
+					types.PolicyThreshold(
+						2,
+						[]types.SpendPolicy{
 							types.PolicyPublicKey(pubkey(0)),
 							types.PolicyPublicKey(pubkey(1)),
 							types.PolicyPublicKey(pubkey(2)),
 						},
-					},
+					),
 					// failsafe policy is not satisfied because the current height is 100
-					types.PolicyThreshold{
-						N: 2,
-						Of: []types.SpendPolicy{
+					types.PolicyThreshold(
+						2,
+						[]types.SpendPolicy{
 							types.PolicyPublicKey(pubkey(3)),
 							types.PolicyAbove(150),
 						},
-					},
+					),
 				},
-			},
+			),
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{
 					privkey(1).SignHash(sigHash),
@@ -817,27 +817,27 @@ func TestValidateSpendPolicy(t *testing.T) {
 		},
 		{
 			desc: "valid foundation failsafe",
-			policy: types.PolicyThreshold{
-				N: 1,
-				Of: []types.SpendPolicy{
-					types.PolicyThreshold{
-						N: 2,
-						Of: []types.SpendPolicy{
+			policy: types.PolicyThreshold(
+				1,
+				[]types.SpendPolicy{
+					types.PolicyThreshold(
+						2,
+						[]types.SpendPolicy{
 							types.PolicyPublicKey(pubkey(0)),
 							types.PolicyPublicKey(pubkey(1)),
 							types.PolicyPublicKey(pubkey(2)),
 						},
-					},
+					),
 					// failsafe policy is satisfied because the current height is 100
-					types.PolicyThreshold{
-						N: 2,
-						Of: []types.SpendPolicy{
+					types.PolicyThreshold(
+						2,
+						[]types.SpendPolicy{
 							types.PolicyPublicKey(pubkey(3)),
 							types.PolicyAbove(80),
 						},
-					},
+					),
 				},
-			},
+			),
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{privkey(3).SignHash(sigHash)}
 			},
@@ -845,14 +845,14 @@ func TestValidateSpendPolicy(t *testing.T) {
 		},
 		{
 			desc: "invalid legacy unlock hash",
-			policy: types.PolicyUnlockConditions{
+			policy: types.SpendPolicy{Type: types.PolicyTypeUnlockConditions{
 				PublicKeys: []types.PublicKey{
 					pubkey(0),
 					pubkey(1),
 					pubkey(2),
 				},
 				SignaturesRequired: 2,
-			},
+			}},
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{
 					privkey(0).SignHash(sigHash),
@@ -862,13 +862,13 @@ func TestValidateSpendPolicy(t *testing.T) {
 		},
 		{
 			desc: "invalid timelocked legacy unlock conditions",
-			policy: types.PolicyUnlockConditions{
+			policy: types.SpendPolicy{Type: types.PolicyTypeUnlockConditions{
 				PublicKeys: []types.PublicKey{
 					pubkey(0),
 				},
 				Timelock:           150,
 				SignaturesRequired: 1,
-			},
+			}},
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{
 					privkey(0).SignHash(sigHash),
@@ -878,14 +878,14 @@ func TestValidateSpendPolicy(t *testing.T) {
 		},
 		{
 			desc: "valid legacy unlock hash",
-			policy: types.PolicyUnlockConditions{
+			policy: types.SpendPolicy{Type: types.PolicyTypeUnlockConditions{
 				PublicKeys: []types.PublicKey{
 					pubkey(0),
 					pubkey(1),
 					pubkey(2),
 				},
 				SignaturesRequired: 2,
-			},
+			}},
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{
 					privkey(0).SignHash(sigHash),
@@ -896,13 +896,13 @@ func TestValidateSpendPolicy(t *testing.T) {
 		},
 		{
 			desc: "valid timelocked legacy unlock conditions",
-			policy: types.PolicyUnlockConditions{
+			policy: types.SpendPolicy{Type: types.PolicyTypeUnlockConditions{
 				PublicKeys: []types.PublicKey{
 					pubkey(0),
 				},
 				Timelock:           80,
 				SignaturesRequired: 1,
-			},
+			}},
 			sign: func(sigHash types.Hash256) []types.Signature {
 				return []types.Signature{privkey(0).SignHash(sigHash)}
 			},
@@ -915,7 +915,7 @@ func TestValidateSpendPolicy(t *testing.T) {
 			SiacoinInputs: []types.SiacoinInput{{
 				Parent: types.SiacoinElement{
 					SiacoinOutput: types.SiacoinOutput{
-						Address: types.PolicyAddress(tt.policy),
+						Address: tt.policy.Address(),
 					},
 				},
 				SpendPolicy: tt.policy,

--- a/merkle/multiproof.go
+++ b/merkle/multiproof.go
@@ -212,7 +212,7 @@ type compressedSiacoinInput types.SiacoinInput
 
 func (in compressedSiacoinInput) EncodeTo(e *types.Encoder) {
 	(compressedSiacoinElement)(in.Parent).EncodeTo(e)
-	e.WritePolicy(in.SpendPolicy)
+	in.SpendPolicy.EncodeTo(e)
 	e.WritePrefix(len(in.Signatures))
 	for _, sig := range in.Signatures {
 		sig.EncodeTo(e)
@@ -221,7 +221,7 @@ func (in compressedSiacoinInput) EncodeTo(e *types.Encoder) {
 
 func (in *compressedSiacoinInput) DecodeFrom(d *types.Decoder) {
 	(*compressedSiacoinElement)(&in.Parent).DecodeFrom(d)
-	in.SpendPolicy = d.ReadPolicy()
+	in.SpendPolicy.DecodeFrom(d)
 	in.Signatures = make([]types.Signature, d.ReadPrefix())
 	for i := range in.Signatures {
 		in.Signatures[i].DecodeFrom(d)
@@ -247,7 +247,7 @@ type compressedSiafundInput types.SiafundInput
 func (in compressedSiafundInput) EncodeTo(e *types.Encoder) {
 	(compressedSiafundElement)(in.Parent).EncodeTo(e)
 	in.ClaimAddress.EncodeTo(e)
-	e.WritePolicy(in.SpendPolicy)
+	in.SpendPolicy.EncodeTo(e)
 	e.WritePrefix(len(in.Signatures))
 	for _, sig := range in.Signatures {
 		sig.EncodeTo(e)
@@ -257,7 +257,7 @@ func (in compressedSiafundInput) EncodeTo(e *types.Encoder) {
 func (in *compressedSiafundInput) DecodeFrom(d *types.Decoder) {
 	(*compressedSiafundElement)(&in.Parent).DecodeFrom(d)
 	in.ClaimAddress.DecodeFrom(d)
-	in.SpendPolicy = d.ReadPolicy()
+	in.SpendPolicy.DecodeFrom(d)
 	in.Signatures = make([]types.Signature, d.ReadPrefix())
 	for i := range in.Signatures {
 		in.Signatures[i].DecodeFrom(d)

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -4,67 +4,42 @@ import (
 	"bytes"
 	"encoding"
 	"io"
-	"math"
 	"math/rand"
 	"reflect"
 	"testing"
 	"testing/quick"
-
-	"lukechampine.com/frand"
 )
 
-// testing/quick isn't able to generate random spend policies; we have to do
-// that ourselves
-func randPolicy(rand *rand.Rand) SpendPolicy {
+// Generate implements quick.Generator.
+func (p SpendPolicy) Generate(rand *rand.Rand, size int) reflect.Value {
 	switch rand.Intn(4) + 1 {
 	case opAbove:
-		return PolicyAbove(rand.Uint64())
+		return reflect.ValueOf(PolicyAbove(rand.Uint64()))
 	case opPublicKey:
 		var p PublicKey
 		rand.Read(p[:])
-		return PolicyPublicKey(p)
+		return reflect.ValueOf(PolicyPublicKey(p))
 	case opThreshold:
-		var p PolicyThreshold
-		p.Of = make([]SpendPolicy, rand.Intn(5))
-		if len(p.Of) > 0 {
-			p.N = uint8(rand.Intn(len(p.Of)))
-			for i := range p.Of {
-				p.Of[i] = randPolicy(rand)
+		n := uint8(0)
+		of := make([]SpendPolicy, rand.Intn(5))
+		if len(of) > 0 {
+			n = uint8(rand.Intn(len(of)))
+			for i := range of {
+				of[i] = p.Generate(rand, size).Interface().(SpendPolicy)
 			}
 		}
-		return p
+		return reflect.ValueOf(PolicyThreshold(n, of))
 	case opUnlockConditions:
-		var p PolicyUnlockConditions
+		var p PolicyTypeUnlockConditions
 		p.Timelock = rand.Uint64()
 		p.PublicKeys = make([]PublicKey, rand.Intn(5)+1)
 		p.SignaturesRequired = uint8(rand.Intn(len(p.PublicKeys)))
 		for i := range p.PublicKeys {
 			rand.Read(p.PublicKeys[i][:])
 		}
-		return p
+		return reflect.ValueOf(SpendPolicy{p})
 	}
 	panic("unreachable")
-}
-
-func quickValue(t reflect.Type, rand *rand.Rand) reflect.Value {
-	if t.String() == "types.SpendPolicy" {
-		return reflect.ValueOf(randPolicy(rand))
-	}
-	v := reflect.New(t).Elem()
-	switch t.Kind() {
-	default:
-		v, _ = quick.Value(t, rand)
-	case reflect.Slice:
-		v.Set(reflect.MakeSlice(t, 10, 10))
-		for i := 0; i < v.Len(); i++ {
-			v.Index(i).Set(quickValue(t.Elem(), rand))
-		}
-	case reflect.Struct:
-		for i := 0; i < v.NumField(); i++ {
-			v.Field(i).Set(quickValue(t.Field(i).Type, rand))
-		}
-	}
-	return v
 }
 
 func TestEncoderRoundtrip(t *testing.T) {
@@ -107,15 +82,6 @@ func TestEncoderRoundtrip(t *testing.T) {
 }
 
 func TestEncoderCompleteness(t *testing.T) {
-	// this test ensures that we keep the encoder in sync with the Transaction
-	// type by populating its fields with reflection
-	seed := int64(frand.Uint64n(math.MaxInt64))
-	cfg := &quick.Config{
-		Rand: rand.New(rand.NewSource(seed)),
-		Values: func(v []reflect.Value, r *rand.Rand) {
-			v[0] = quickValue(reflect.TypeOf(Transaction{}), r)
-		},
-	}
 	checkFn := func(txn Transaction) bool {
 		var buf bytes.Buffer
 		e := NewEncoder(&buf)
@@ -125,13 +91,17 @@ func TestEncoderCompleteness(t *testing.T) {
 		decTxn.DecodeFrom(NewBufDecoder(buf.Bytes()))
 		return reflect.DeepEqual(txn, decTxn)
 	}
-	if quick.Check(checkFn, cfg) != nil {
-		t.Fatalf("roundtrip test failed; did you forget to update transaction encoder? (seed = %v)", seed)
+	if quick.Check(checkFn, nil) != nil {
+		t.Fatal("roundtrip test failed; did you forget to update transaction encoder?")
 	}
 }
 
 func BenchmarkEncoding(b *testing.B) {
-	txn := quickValue(reflect.TypeOf(Transaction{}), rand.New(rand.NewSource(0))).Interface().(Transaction)
+	v, ok := quick.Value(reflect.TypeOf(Transaction{}), rand.New(rand.NewSource(0)))
+	if !ok {
+		b.Fatal("could not generate value")
+	}
+	txn := v.Interface().(Transaction)
 	e := NewEncoder(io.Discard)
 
 	b.ReportAllocs()

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -83,6 +83,19 @@ func TestEncoderRoundtrip(t *testing.T) {
 
 func TestEncoderCompleteness(t *testing.T) {
 	checkFn := func(txn Transaction) bool {
+		// NOTE: the compressed Transaction encoding will cause 0-length slices
+		// to decode as nil, so normalize any 0-length slices to nil now to
+		// ensure that DeepEqual will work.
+		txn.SiacoinInputs = append([]SiacoinInput(nil), txn.SiacoinInputs...)
+		txn.SiacoinOutputs = append([]SiacoinOutput(nil), txn.SiacoinOutputs...)
+		txn.SiafundInputs = append([]SiafundInput(nil), txn.SiafundInputs...)
+		txn.SiafundOutputs = append([]SiafundOutput(nil), txn.SiafundOutputs...)
+		txn.FileContracts = append([]FileContract(nil), txn.FileContracts...)
+		txn.FileContractRevisions = append([]FileContractRevision(nil), txn.FileContractRevisions...)
+		txn.FileContractResolutions = append([]FileContractResolution(nil), txn.FileContractResolutions...)
+		txn.Attestations = append([]Attestation(nil), txn.Attestations...)
+		txn.ArbitraryData = append([]byte(nil), txn.ArbitraryData...)
+
 		var buf bytes.Buffer
 		e := NewEncoder(&buf)
 		txn.EncodeTo(e)

--- a/types/policy_test.go
+++ b/types/policy_test.go
@@ -36,57 +36,57 @@ func TestPolicyAddressString(t *testing.T) {
 			"addr:a1b418e9905dd086e2d0c25ec3675568f849c18f401512d704eceafe1574ee19c48049c5f2b3",
 		},
 		{
-			PolicyThreshold{},
+			PolicyThreshold(0, nil),
 			"addr:a1b418e9905dd086e2d0c25ec3675568f849c18f401512d704eceafe1574ee19c48049c5f2b3",
 		},
 		{
-			PolicyThreshold{
-				N: 1,
-				Of: []SpendPolicy{
+			PolicyThreshold(
+				1,
+				[]SpendPolicy{
 					PolicyPublicKey(publicKeys[0]),
 				},
-			},
+			),
 			"addr:88a889bd46420209db5a41b164956e53ff3da9c4b3d1491d81f9c374f742dd3b0a7c72f58aff",
 		},
 		{
-			PolicyThreshold{
-				N: 1,
-				Of: []SpendPolicy{
+			PolicyThreshold(
+				1,
+				[]SpendPolicy{
 					PolicyPublicKey(publicKeys[0]),
-					PolicyThreshold{
-						N: 2,
-						Of: []SpendPolicy{
+					PolicyThreshold(
+						2,
+						[]SpendPolicy{
 							PolicyAbove(50),
 							PolicyPublicKey(publicKeys[1]),
 						},
-					},
+					),
 				},
-			},
+			),
 			"addr:2ce609abbd8bc26d0f22c8f6447d3144bc2ae2391f9b09685aca03237329c339ba3ec4a35133",
 		},
 		{
-			PolicyThreshold{
-				N: 2,
-				Of: []SpendPolicy{
+			PolicyThreshold(
+				2,
+				[]SpendPolicy{
 					PolicyPublicKey(publicKeys[0]),
 					PolicyPublicKey(publicKeys[1]),
 					PolicyPublicKey(publicKeys[2]),
 				},
-			},
+			),
 			"addr:0ca4d365f06ebf0de342ed617498521f0c0bcdc133c414428480e8826875c0a565ccaee80fb6",
 		},
 		{
-			policy: PolicyUnlockConditions{
+			policy: SpendPolicy{PolicyTypeUnlockConditions{
 				PublicKeys: []PublicKey{
 					publicKeys[0],
 				},
 				SignaturesRequired: 1,
-			},
+			}},
 			want: "addr:2f4a4a64712545bde8d38776377da2794d54685284a3768f78884643dad33a9a3822a0f4dc39",
 		},
 	}
 	for _, tt := range tests {
-		if got := PolicyAddress(tt.policy).String(); got != tt.want {
+		if got := tt.policy.Address().String(); got != tt.want {
 			t.Errorf("wrong address for %T(%v)", tt.policy, tt.policy)
 		}
 	}


### PR DESCRIPTION
The `SpendPolicy` type has historically been a real pain to work with. It's defined as an interface, which is a good fit for the underlying semantics (a set of possible policy types). But Go does not allow you to define methods on interfaces, which means `SpendPolicy` can't implement `EncoderTo`, `DecoderFrom`, `MarshalJSON`, or even `String()`. This is really annoying. It means we need a special `(Encoder).WritePolicy` method. It means we have to define a custom `MarshalJSON` method on every type that contains a `SpendPolicy`. etc.

You can *almost* get around this by adding those methods to the definition of `SpendPolicy`. But this falls apart when you want to *decode* a value, because there's no way to match a `nil` `SpendPolicy` to the concrete type that it *should* be decoded into.

This PR changes `SpendPolicy` from an `interface` to a `struct` *wrapping* an `interface`, giving us the ability to define methods on it. This comes at the cost of some API ugliness: instead of just `PolicyAbove`, we now have `PolicyTypeAbove` (the concrete type, implementing the now-wrapped interface) *and* `PolicyType` (a function that constructs a `PolicyTypeAbove` and wraps it in a `SpendPolicy` struct). This makes me sad, but it's still an improvement. If anyone wants to suggest a better approach, I'm all ears.

(There's one other option that I've considered: we could keep `SpendPolicy` in its encoded form at all times. That is, instead of a struct, you'd always be passing around strings like `thresh(1, above(123), pk(a0b32c2d...))`. This has some merit, but also some serious downsides. For one, the string representation requires >2x as much memory as the binary representation. You also have to parse the string in multiple places: during decoding (to check that the policy is legal) and again during consensus validation to actually enforce the policy. Thoughts?)