### PR TITLE
rhp: Consolidate Instruction methods

### DIFF
--- a/host/executor.go
+++ b/host/executor.go
@@ -404,7 +404,7 @@ func (pe *ProgramExecutor) ExecuteInstruction(r io.Reader, w io.Writer, instruct
 			// update the registry value
 			return nil, pe.executeUpdateRegistry(value)
 		default:
-			return nil, fmt.Errorf("unknown instruction: %s", instruction.Specifier())
+			return nil, fmt.Errorf("unknown instruction: %T", instruction)
 		}
 	}()
 

--- a/net/rhp/builder.go
+++ b/net/rhp/builder.go
@@ -27,8 +27,8 @@ func (pb *ProgramBuilder) addUsage(usage ResourceUsage) {
 }
 
 func (pb *ProgramBuilder) appendInstruction(instr Instruction) {
-	pb.requiresContract = pb.requiresContract || instr.RequiresContract()
-	pb.requiresFinalization = pb.requiresFinalization || instr.RequiresFinalization()
+	pb.requiresContract = pb.requiresContract || InstructionRequiresContract(instr)
+	pb.requiresFinalization = pb.requiresFinalization || InstructionRequiresFinalization(instr)
 	pb.instructions = append(pb.instructions, instr)
 }
 

--- a/net/rhp/rpc.go
+++ b/net/rhp/rpc.go
@@ -800,42 +800,68 @@ func (r *RPCSettingsRegisteredResponse) DecodeFrom(d *types.Decoder) {
 	d.Read(r.ID[:])
 }
 
-func writeInstruction(e *types.Encoder, instr Instruction) {
-	specifier := instr.Specifier()
-	e.Write(specifier[:])
-	instr.EncodeTo(e)
+func writeInstruction(e *types.Encoder, i Instruction) {
+	var spec rpc.Specifier
+	switch i.(type) {
+	case *InstrAppendSector:
+		spec = SpecInstrAppendSector
+	case *InstrUpdateSector:
+		spec = SpecInstrUpdateSector
+	case *InstrContractRevision:
+		spec = SpecInstrContractRevision
+	case *InstrSectorRoots:
+		spec = SpecInstrSectorRoots
+	case *InstrDropSectors:
+		spec = SpecInstrDropSectors
+	case *InstrHasSector:
+		spec = SpecInstrHasSector
+	case *InstrReadOffset:
+		spec = SpecInstrReadOffset
+	case *InstrReadRegistry:
+		spec = SpecInstrReadRegistry
+	case *InstrReadSector:
+		spec = SpecInstrReadSector
+	case *InstrSwapSector:
+		spec = SpecInstrSwapSector
+	case *InstrUpdateRegistry:
+		spec = SpecInstrUpdateRegistry
+	default:
+		panic("unhandled instruction")
+	}
+	spec.EncodeTo(e)
+	i.EncodeTo(e)
 }
 
-func readInstruction(d *types.Decoder) (instr Instruction) {
+func readInstruction(d *types.Decoder) (i Instruction) {
 	var spec rpc.Specifier
 	d.Read(spec[:])
 
 	switch spec {
 	case SpecInstrAppendSector:
-		instr = new(InstrAppendSector)
+		i = new(InstrAppendSector)
 	case SpecInstrUpdateSector:
-		instr = new(InstrUpdateSector)
+		i = new(InstrUpdateSector)
 	case SpecInstrDropSectors:
-		instr = new(InstrDropSectors)
+		i = new(InstrDropSectors)
 	case SpecInstrHasSector:
-		instr = new(InstrHasSector)
+		i = new(InstrHasSector)
 	case SpecInstrReadOffset:
-		instr = new(InstrReadOffset)
+		i = new(InstrReadOffset)
 	case SpecInstrReadSector:
-		instr = new(InstrReadSector)
+		i = new(InstrReadSector)
 	case SpecInstrContractRevision:
-		instr = new(InstrContractRevision)
+		i = new(InstrContractRevision)
 	case SpecInstrSwapSector:
-		instr = new(InstrSwapSector)
+		i = new(InstrSwapSector)
 	case SpecInstrUpdateRegistry:
-		instr = new(InstrUpdateRegistry)
+		i = new(InstrUpdateRegistry)
 	case SpecInstrReadRegistry:
-		instr = new(InstrReadRegistry)
+		i = new(InstrReadRegistry)
 	default:
 		d.SetErr(fmt.Errorf("uknown instruction specifier, %v", spec))
 		return
 	}
-	instr.DecodeFrom(d)
+	i.DecodeFrom(d)
 	return
 }
 


### PR DESCRIPTION
The sheer number of methods here bothered me, so I consolidated them into a pair of top-level functions instead. I also moved the specifier methods into `writeInstruction`, for parity with `readInstruction`. (AFAIK, the `Specifier` method isn't needed anywhere else.) I think the latter is more justified than the former; there's certainly an argument to be made that methods like `RequiresFinalization` "belong" to their associated type. But the amount of code involved just didn't sit right with me.