### PR TITLE
ci: add go 1.18

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go-version: [ '1.16', '1.17' ]
+        go-version: [ '1.17', '1.18' ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go-version: [ '1.16', '1.17' ]
+        go-version: [ '1.17', '1.18' ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Adds Go 1.18 to the CI test versions. The `go.mod` is still 1.16, do we want to drop it?