### PR TITLE
Add test to ensure mux.Write blocks after large amounts of data are sent

### DIFF
--- a/net/mux/mux_test.go
+++ b/net/mux/mux_test.go
@@ -115,6 +115,7 @@ func TestSlowRead(t *testing.T) {
 				return err
 			}
 			defer s.Close()
+			time.Sleep(10 * time.Second)
 			for i := 0; i < sendCount; i++ {
 				buf := make([]byte, 13)
 				if _, err := io.ReadFull(s, buf); err != nil {
@@ -123,7 +124,6 @@ func TestSlowRead(t *testing.T) {
 				if string(buf) != "hello, world!" {
 					return errors.New("bad hello")
 				}
-				time.Sleep(time.Second / 1000)
 			}
 			return s.Close()
 		}()


### PR DESCRIPTION
This PR adds `TestSlowRead` to `mux_test.go` which ensures that the mux writer does not allow messages to simply pile up and will block after a certain point if they are not being accepted by the receiver.  This kind of scenario is obviously unlikely to show up in local testing instances but in practice connections can be unreliable so it is worth testing.