### PR TITLE
v2: use a more robust parser in ParseSpendPolicy

### DIFF
--- a/types/policy_test.go
+++ b/types/policy_test.go
@@ -192,6 +192,7 @@ func TestPolicyJSON(t *testing.T) {
 		`uc(1, [])`,
 		`uc(1, [],)`,
 		`uc(1, [],a)`,
+		`uc(1, [aa], 1)`,
 	}
 	for _, test := range testStrings {
 		var p SpendPolicy

--- a/types/policy_test.go
+++ b/types/policy_test.go
@@ -101,81 +101,114 @@ func TestPolicyJSON(t *testing.T) {
 		mustParsePublicKey("ed25519:11aa63482223329fb8b8313da78cc58820f2933cc621e0ef275c305092ea3704"),
 	}
 
-	tests := []SpendPolicy{
-		PolicyAbove(50),
-		PolicyPublicKey(publicKeys[0]),
-		AnyoneCanSpend(),
-		PolicyThreshold(0, nil),
-		PolicyThreshold(
-			1,
-			[]SpendPolicy{
-				PolicyPublicKey(publicKeys[0]),
-			},
-		),
-		PolicyThreshold(
-			1,
-			[]SpendPolicy{
-				PolicyPublicKey(publicKeys[0]),
-				PolicyThreshold(
-					2,
-					[]SpendPolicy{
-						PolicyAbove(50),
-						PolicyPublicKey(publicKeys[1]),
-					},
-				),
-			},
-		),
-		PolicyThreshold(
-			2,
-			[]SpendPolicy{
-				PolicyPublicKey(publicKeys[0]),
-				PolicyThreshold(
-					2,
-					[]SpendPolicy{
-						PolicyAbove(50),
-						PolicyPublicKey(publicKeys[1]),
-						PolicyThreshold(
-							2,
-							[]SpendPolicy{
-								PolicyAbove(50),
-								PolicyPublicKey(publicKeys[1]),
-							},
-						),
-					},
-				),
-				PolicyPublicKey(publicKeys[1]),
-				PolicyPublicKey(publicKeys[2]),
-			},
-		),
-		{PolicyTypeUnlockConditions{
-			PublicKeys: []PublicKey{
-				publicKeys[0],
-			},
-			SignaturesRequired: 1,
-		}},
-		{PolicyTypeUnlockConditions{}},
+	tests := []struct {
+		policy SpendPolicy
+		want   string
+	}{
+		{
+			PolicyAbove(50),
+			"above(50)",
+		},
+		{
+			PolicyPublicKey(publicKeys[0]),
+			"pk(42d33219eb9e7d52d4a4edff215e36535d9d82c9439497a05ab7712193d43282)",
+		},
+		{
+			AnyoneCanSpend(),
+			"thresh(0,[])",
+		},
+		{
+			PolicyThreshold(0, nil),
+			"thresh(0,[])",
+		},
+		{
+			PolicyThreshold(
+				1,
+				[]SpendPolicy{
+					PolicyPublicKey(publicKeys[0]),
+				},
+			),
+			"thresh(1,[pk(42d33219eb9e7d52d4a4edff215e36535d9d82c9439497a05ab7712193d43282)])",
+		},
+		{
+			PolicyThreshold(
+				1,
+				[]SpendPolicy{
+					PolicyPublicKey(publicKeys[0]),
+					PolicyThreshold(
+						2,
+						[]SpendPolicy{
+							PolicyAbove(50),
+							PolicyPublicKey(publicKeys[1]),
+						},
+					),
+				},
+			),
+			"thresh(1,[pk(42d33219eb9e7d52d4a4edff215e36535d9d82c9439497a05ab7712193d43282),thresh(2,[above(50),pk(b908477c624679a2dc934a662e43c22844595902f1c8dc29b7f8caf2e0369cc9)])])",
+		},
+		{
+			PolicyThreshold(
+				2,
+				[]SpendPolicy{
+					PolicyPublicKey(publicKeys[0]),
+					PolicyThreshold(
+						2,
+						[]SpendPolicy{
+							PolicyAbove(50),
+							PolicyPublicKey(publicKeys[1]),
+							PolicyThreshold(
+								2,
+								[]SpendPolicy{
+									PolicyAbove(50),
+									PolicyPublicKey(publicKeys[1]),
+								},
+							),
+						},
+					),
+					PolicyPublicKey(publicKeys[1]),
+					PolicyPublicKey(publicKeys[2]),
+				},
+			), "thresh(2,[pk(42d33219eb9e7d52d4a4edff215e36535d9d82c9439497a05ab7712193d43282),thresh(2,[above(50),pk(b908477c624679a2dc934a662e43c22844595902f1c8dc29b7f8caf2e0369cc9),thresh(2,[above(50),pk(b908477c624679a2dc934a662e43c22844595902f1c8dc29b7f8caf2e0369cc9)])]),pk(b908477c624679a2dc934a662e43c22844595902f1c8dc29b7f8caf2e0369cc9),pk(11aa63482223329fb8b8313da78cc58820f2933cc621e0ef275c305092ea3704)])"},
+		{
+			SpendPolicy{PolicyTypeUnlockConditions{
+				PublicKeys: []PublicKey{
+					publicKeys[0],
+				},
+				SignaturesRequired: 1,
+			}},
+			"uc(0,[42d33219eb9e7d52d4a4edff215e36535d9d82c9439497a05ab7712193d43282],1)",
+		},
+		{
+			SpendPolicy{PolicyTypeUnlockConditions{}},
+			"uc(0,[],0)",
+		},
 	}
 
 	for _, test := range tests {
-		data, err := json.Marshal(test)
+		data, err := json.Marshal(test.policy)
 		if err != nil {
 			t.Fatal(err)
 		}
+		if string(data) != (`"` + test.want + `"`) {
+			t.Fatalf("expected %s got %s", test.want, string(data))
+		}
+
 		var p SpendPolicy
 		if err := json.Unmarshal(data, &p); err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(p, test) {
-			t.Fatalf("expected %v got %v", test, p)
+		if !reflect.DeepEqual(p, test.policy) {
+			t.Fatalf("expected %v got %v", test.policy, p)
 		}
 	}
 
-	testStrings := []string{
+	invalidPolicies := []string{
 		"",
 		")(",
 		"aaa(5)",
 		"above()",
 		"above(zzz)",
+		"above(0)trailingbytes",
 		"pk()",
 		"pk(zzz)",
 		"thresh(zzz)",
@@ -194,7 +227,7 @@ func TestPolicyJSON(t *testing.T) {
 		`uc(1, [],a)`,
 		`uc(1, [aa], 1)`,
 	}
-	for _, test := range testStrings {
+	for _, test := range invalidPolicies {
 		var p SpendPolicy
 		if err := json.Unmarshal([]byte(`"`+test+`"`), &p); err == nil {
 			t.Fatalf("unmarshal should have errored on input %s", test)


### PR DESCRIPTION
Replaces the rather complicated string indexing of the old ParseSpendPolicy with a more standard recursive parser.