### PR TITLE
rhp: Add packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.sia.tech/core
 go 1.17
 
 require (
+	go.sia.tech/mux v1.1.0
 	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122
 	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
 	lukechampine.com/frand v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
+go.sia.tech/mux v1.1.0 h1:AH5aHAbYMhi309p4d3iufWgTYR+H7yUTmLaz8FXyH+A=
+go.sia.tech/mux v1.1.0/go.mod h1:Yyo6wZelOYTyvrHmJZ6aQfRoer3o4xyKQ4NmQLJrBSo=
 golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 h1:NvGWuYG8dkDHFSKksI1P9faiVJ9rayE6l0+ouWVIDs8=
 golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -1,0 +1,211 @@
+package rhp
+
+import (
+	"math/bits"
+
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+)
+
+// ContractFormationCost returns the cost of forming a contract.
+func ContractFormationCost(fc types.FileContract, contractFee types.Currency) types.Currency {
+	return fc.ValidRenterPayout().Add(contractFee).Add(contractTax(fc))
+}
+
+// ContractFormationCollateral returns the amount of collateral we add when forming a contract.
+func ContractFormationCollateral(expectedStorage, period uint64, host HostSettings) types.Currency {
+	hostCollateral := host.Collateral.Mul64(expectedStorage).Mul64(period)
+	if hostCollateral.Cmp(host.MaxCollateral) > 0 {
+		hostCollateral = host.MaxCollateral
+	}
+	return hostCollateral
+}
+
+// PrepareContractFormation constructs a contract formation transaction.
+func PrepareContractFormation(renterKey types.PrivateKey, hostKey types.PublicKey, renterPayout, hostCollateral types.Currency, endHeight uint64, host HostSettings, refundAddr types.Address) types.FileContract {
+	renterPubkey := renterKey.PublicKey()
+	uc := types.UnlockConditions{
+		PublicKeys: []types.UnlockKey{
+			{Algorithm: types.SpecifierEd25519, Key: renterPubkey[:]},
+			{Algorithm: types.SpecifierEd25519, Key: hostKey[:]},
+		},
+		SignaturesRequired: 2,
+	}
+
+	hostPayout := host.ContractPrice.Add(hostCollateral)
+	payout := taxAdjustedPayout(renterPayout.Add(hostPayout))
+
+	return types.FileContract{
+		Filesize:       0,
+		FileMerkleRoot: types.Hash256{},
+		WindowStart:    uint64(endHeight),
+		WindowEnd:      uint64(endHeight + host.WindowSize),
+		Payout:         payout,
+		UnlockHash:     types.Hash256(uc.UnlockHash()),
+		RevisionNumber: 0,
+		ValidProofOutputs: []types.SiacoinOutput{
+			// outputs need to account for tax
+			{Value: renterPayout, Address: refundAddr},
+			// collateral is returned to host
+			{Value: hostPayout, Address: host.Address},
+		},
+		MissedProofOutputs: []types.SiacoinOutput{
+			// same as above
+			{Value: renterPayout, Address: refundAddr},
+			// same as above
+			{Value: hostPayout, Address: host.Address},
+			// once we start doing revisions, we'll move some coins to the host and some to the void
+			{Value: types.ZeroCurrency, Address: types.Address{}},
+		},
+	}
+}
+
+// ContractRenewalCost returns the cost of renewing a contract.
+func ContractRenewalCost(fc types.FileContract, contractFee types.Currency) types.Currency {
+	return fc.ValidRenterPayout().Add(contractFee).Add(contractTax(fc))
+}
+
+// ContractRenewalCollateral returns the amount of collateral we add when
+// renewing a contract. It takes into account the host's max collateral setting
+// and ensures the total collateral does not exceed it.
+func ContractRenewalCollateral(fc types.FileContract, renterFunds types.Currency, host HostSettings, endHeight uint64) types.Currency {
+	extension := endHeight - fc.WindowEnd
+
+	// calculate cost per byte
+	costPerByte := host.UploadBandwidthPrice.Add(host.StoragePrice).Add(host.DownloadBandwidthPrice)
+	if costPerByte.IsZero() {
+		return types.ZeroCurrency
+	}
+
+	// calculate the base collateral - if it exceeds MaxCollateral we can't add more collateral
+	baseCollateral := host.Collateral.Mul64(fc.Filesize).Mul64(extension)
+	if baseCollateral.Cmp(host.MaxCollateral) >= 0 {
+		return types.ZeroCurrency
+	}
+
+	// calculate the new collateral
+	newCollateral := host.Collateral.Mul(renterFunds.Div(costPerByte))
+
+	// if the total collateral is more than the MaxCollateral, return the delta
+	totalCollateral := baseCollateral.Add(newCollateral)
+	if totalCollateral.Cmp(host.MaxCollateral) > 0 {
+		return totalCollateral.Sub(host.MaxCollateral)
+	}
+
+	return newCollateral
+}
+
+// PrepareContractRenewal constructs a contract renewal transaction.
+func PrepareContractRenewal(currentRevision types.FileContractRevision, renterAddress types.Address, renterKey types.PrivateKey, renterPayout, newCollateral types.Currency, hostKey types.PublicKey, host HostSettings, endHeight uint64) types.FileContract {
+	hostValidPayout, hostMissedPayout, voidMissedPayout := CalculateHostPayouts(currentRevision.FileContract, newCollateral, host, endHeight)
+
+	return types.FileContract{
+		Filesize:       currentRevision.Filesize,
+		FileMerkleRoot: currentRevision.FileMerkleRoot,
+		WindowStart:    uint64(endHeight),
+		WindowEnd:      uint64(endHeight + host.WindowSize),
+		Payout:         taxAdjustedPayout(renterPayout.Add(hostValidPayout)),
+		UnlockHash:     currentRevision.UnlockHash,
+		RevisionNumber: 0,
+		ValidProofOutputs: []types.SiacoinOutput{
+			{Value: renterPayout, Address: renterAddress},
+			{Value: hostValidPayout, Address: host.Address},
+		},
+		MissedProofOutputs: []types.SiacoinOutput{
+			{Value: renterPayout, Address: renterAddress},
+			{Value: hostMissedPayout, Address: host.Address},
+			{Value: voidMissedPayout, Address: types.Address{}},
+		},
+	}
+}
+
+// CalculateHostPayouts calculates the contract payouts for the host.
+func CalculateHostPayouts(fc types.FileContract, newCollateral types.Currency, settings HostSettings, endHeight uint64) (types.Currency, types.Currency, types.Currency) {
+	// The host gets their contract fee, plus the cost of the data already in the
+	// contract, plus their collateral. In the event of a missed payout, the cost
+	// and collateral of the data already in the contract is subtracted from the
+	// host, and sent to the void instead.
+	//
+	// However, it is possible for this subtraction to underflow: this can happen if
+	// baseCollateral is large and MaxCollateral is small. We cannot simply replace
+	// the underflow with a zero, because the host performs the same subtraction and
+	// returns an error on underflow. Nor can we increase the valid payout, because
+	// the host calculates its collateral contribution by subtracting the contract
+	// price and base price from this payout, and we're already at MaxCollateral.
+	// Thus the host has conflicting requirements, and renewing the contract is
+	// impossible until they change their settings.
+
+	// calculate base price and collateral
+	var basePrice, baseCollateral types.Currency
+
+	// if the contract height did not increase both prices are zero
+	if contractEnd := uint64(endHeight + settings.WindowSize); contractEnd > fc.WindowEnd {
+		timeExtension := uint64(contractEnd - fc.WindowEnd)
+		basePrice = settings.StoragePrice.Mul64(fc.Filesize).Mul64(timeExtension)
+		baseCollateral = settings.Collateral.Mul64(fc.Filesize).Mul64(timeExtension)
+	}
+
+	// calculate payouts
+	hostValidPayout := settings.ContractPrice.Add(basePrice).Add(baseCollateral).Add(newCollateral)
+	voidMissedPayout := basePrice.Add(baseCollateral)
+	if hostValidPayout.Cmp(voidMissedPayout) < 0 {
+		// TODO: detect this elsewhere
+		panic("host's settings are unsatisfiable")
+	}
+	hostMissedPayout := hostValidPayout.Sub(voidMissedPayout)
+	return hostValidPayout, hostMissedPayout, voidMissedPayout
+}
+
+// NOTE: due to a bug in the transaction validation code, calculating payouts
+// is way harder than it needs to be. Tax is calculated on the post-tax
+// contract payout (instead of the sum of the renter and host payouts). So the
+// equation for the payout is:
+//
+//	   payout = renterPayout + hostPayout + payout*tax
+//	∴  payout = (renterPayout + hostPayout) / (1 - tax)
+//
+// This would work if 'tax' were a simple fraction, but because the tax must
+// be evenly distributed among siafund holders, 'tax' is actually a function
+// that multiplies by a fraction and then rounds down to the nearest multiple
+// of the siafund count. Thus, when inverting the function, we have to make an
+// initial guess and then fix the rounding error.
+func taxAdjustedPayout(target types.Currency) types.Currency {
+	// compute initial guess as target * (1 / 1-tax); since this does not take
+	// the siafund rounding into account, the guess will be up to
+	// types.SiafundCount greater than the actual payout value.
+	guess := target.Mul64(1000).Div64(961)
+
+	// now, adjust the guess to remove the rounding error. We know that:
+	//
+	//   (target % types.SiafundCount) == (payout % types.SiafundCount)
+	//
+	// therefore, we can simply adjust the guess to have this remainder as
+	// well. The only wrinkle is that, since we know guess >= payout, if the
+	// guess remainder is smaller than the target remainder, we must subtract
+	// an extra types.SiafundCount.
+	//
+	// for example, if target = 87654321 and types.SiafundCount = 10000, then:
+	//
+	//   initial_guess  = 87654321 * (1 / (1 - tax))
+	//                  = 91211572
+	//   target % 10000 =     4321
+	//   adjusted_guess = 91204321
+
+	mod64 := func(c types.Currency, v uint64) types.Currency {
+		var r uint64
+		if c.Hi < v {
+			_, r = bits.Div64(c.Hi, c.Lo, v)
+		} else {
+			_, r = bits.Div64(0, c.Hi, v)
+			_, r = bits.Div64(r, c.Lo, v)
+		}
+		return types.NewCurrency64(r)
+	}
+	sfc := (consensus.State{}).SiafundCount()
+	tm := mod64(target, sfc)
+	gm := mod64(guess, sfc)
+	if gm.Cmp(tm) < 0 {
+		guess = guess.Sub(types.NewCurrency64(sfc))
+	}
+	return guess.Add(tm).Sub(gm)
+}

--- a/rhp/v2/encoding.go
+++ b/rhp/v2/encoding.go
@@ -1,0 +1,472 @@
+package rhp
+
+import (
+	"go.sia.tech/core/types"
+)
+
+// A ProtocolObject is an object that can be serialized for transport in the
+// renter-host protocol.
+type ProtocolObject interface {
+	types.EncoderTo
+	types.DecoderFrom
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCError) EncodeTo(e *types.Encoder) {
+	r.Type.EncodeTo(e)
+	e.WriteBytes(r.Data)
+	e.WriteString(r.Description)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCError) DecodeFrom(d *types.Decoder) {
+	r.Type.DecodeFrom(d)
+	r.Data = d.ReadBytes()
+	r.Description = d.ReadString()
+}
+
+// EncodeTo implements ProtocolObject.
+func (resp *rpcResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBool(resp.err != nil)
+	if resp.err != nil {
+		resp.err.EncodeTo(e)
+		return
+	}
+	resp.data.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (resp *rpcResponse) DecodeFrom(d *types.Decoder) {
+	if d.ReadBool() {
+		resp.err = new(RPCError)
+		resp.err.DecodeFrom(d)
+		return
+	}
+	resp.data.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *loopKeyExchangeRequest) EncodeTo(e *types.Encoder) {
+	loopEnter.EncodeTo(e)
+	e.Write(r.PublicKey[:])
+	e.WritePrefix(len(r.Ciphers))
+	for i := range r.Ciphers {
+		r.Ciphers[i].EncodeTo(e)
+	}
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *loopKeyExchangeRequest) DecodeFrom(d *types.Decoder) {
+	new(types.Specifier).DecodeFrom(d) // loopEnter
+	d.Read(r.PublicKey[:])
+	r.Ciphers = make([]types.Specifier, d.ReadPrefix())
+	for i := range r.Ciphers {
+		r.Ciphers[i].DecodeFrom(d)
+	}
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *loopKeyExchangeResponse) EncodeTo(e *types.Encoder) {
+	e.Write(r.PublicKey[:])
+	e.WriteBytes(r.Signature[:])
+	r.Cipher.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *loopKeyExchangeResponse) DecodeFrom(d *types.Decoder) {
+	d.Read(r.PublicKey[:])
+	copy(r.Signature[:], d.ReadBytes())
+	r.Cipher.DecodeFrom(d)
+}
+
+// RPCFormContract
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCFormContractRequest) EncodeTo(e *types.Encoder) {
+	e.WritePrefix(len(r.Transactions))
+	for i := range r.Transactions {
+		r.Transactions[i].EncodeTo(e)
+	}
+	r.RenterKey.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCFormContractRequest) DecodeFrom(d *types.Decoder) {
+	r.Transactions = make([]types.Transaction, d.ReadPrefix())
+	for i := range r.Transactions {
+		r.Transactions[i].DecodeFrom(d)
+	}
+	r.RenterKey.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCFormContractAdditions) EncodeTo(e *types.Encoder) {
+	e.WritePrefix(len(r.Parents))
+	for i := range r.Parents {
+		r.Parents[i].EncodeTo(e)
+	}
+	e.WritePrefix(len(r.Inputs))
+	for i := range r.Inputs {
+		r.Inputs[i].EncodeTo(e)
+	}
+	e.WritePrefix(len(r.Outputs))
+	for i := range r.Outputs {
+		r.Outputs[i].EncodeTo(e)
+	}
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCFormContractAdditions) DecodeFrom(d *types.Decoder) {
+	r.Parents = make([]types.Transaction, d.ReadPrefix())
+	for i := range r.Parents {
+		r.Parents[i].DecodeFrom(d)
+	}
+	r.Inputs = make([]types.SiacoinInput, d.ReadPrefix())
+	for i := range r.Inputs {
+		r.Inputs[i].DecodeFrom(d)
+	}
+	r.Outputs = make([]types.SiacoinOutput, d.ReadPrefix())
+	for i := range r.Outputs {
+		r.Outputs[i].DecodeFrom(d)
+	}
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCFormContractSignatures) EncodeTo(e *types.Encoder) {
+	e.WritePrefix(len(r.ContractSignatures))
+	for i := range r.ContractSignatures {
+		r.ContractSignatures[i].EncodeTo(e)
+	}
+	r.RevisionSignature.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCFormContractSignatures) DecodeFrom(d *types.Decoder) {
+	r.ContractSignatures = make([]types.TransactionSignature, d.ReadPrefix())
+	for i := range r.ContractSignatures {
+		r.ContractSignatures[i].DecodeFrom(d)
+	}
+	r.RevisionSignature.DecodeFrom(d)
+}
+
+// RPCRenewAndClear
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCRenewAndClearContractRequest) EncodeTo(e *types.Encoder) {
+	e.WritePrefix(len(r.Transactions))
+	for i := range r.Transactions {
+		r.Transactions[i].EncodeTo(e)
+	}
+	r.RenterKey.EncodeTo(e)
+	e.WritePrefix(len(r.FinalValidProofValues))
+	for i := range r.FinalValidProofValues {
+		r.FinalValidProofValues[i].EncodeTo(e)
+	}
+	e.WritePrefix(len(r.FinalMissedProofValues))
+	for i := range r.FinalMissedProofValues {
+		r.FinalMissedProofValues[i].EncodeTo(e)
+	}
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCRenewAndClearContractRequest) DecodeFrom(d *types.Decoder) {
+	r.Transactions = make([]types.Transaction, d.ReadPrefix())
+	for i := range r.Transactions {
+		r.Transactions[i].DecodeFrom(d)
+	}
+	r.RenterKey.DecodeFrom(d)
+	r.FinalValidProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.FinalValidProofValues {
+		r.FinalValidProofValues[i].DecodeFrom(d)
+	}
+	r.FinalMissedProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.FinalMissedProofValues {
+		r.FinalMissedProofValues[i].DecodeFrom(d)
+	}
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCRenewAndClearContractSignatures) EncodeTo(e *types.Encoder) {
+	e.WritePrefix(len(r.ContractSignatures))
+	for i := range r.ContractSignatures {
+		r.ContractSignatures[i].EncodeTo(e)
+	}
+	r.RevisionSignature.EncodeTo(e)
+	e.WriteBytes(r.FinalRevisionSignature[:])
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCRenewAndClearContractSignatures) DecodeFrom(d *types.Decoder) {
+	r.ContractSignatures = make([]types.TransactionSignature, d.ReadPrefix())
+	for i := range r.ContractSignatures {
+		r.ContractSignatures[i].DecodeFrom(d)
+	}
+	r.RevisionSignature.DecodeFrom(d)
+	copy(r.FinalRevisionSignature[:], d.ReadBytes())
+}
+
+// RPCLock
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCLockRequest) EncodeTo(e *types.Encoder) {
+	e.Write(r.ContractID[:])
+	e.WriteBytes(r.Signature[:])
+	e.WriteUint64(r.Timeout)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCLockRequest) DecodeFrom(d *types.Decoder) {
+	d.Read(r.ContractID[:])
+	copy(r.Signature[:], d.ReadBytes())
+	r.Timeout = d.ReadUint64()
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCLockResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBool(r.Acquired)
+	e.Write(r.NewChallenge[:])
+	r.Revision.EncodeTo(e)
+	e.WritePrefix(len(r.Signatures))
+	for i := range r.Signatures {
+		r.Signatures[i].EncodeTo(e)
+	}
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCLockResponse) DecodeFrom(d *types.Decoder) {
+	r.Acquired = d.ReadBool()
+	d.Read(r.NewChallenge[:])
+	r.Revision.DecodeFrom(d)
+	r.Signatures = make([]types.TransactionSignature, d.ReadPrefix())
+	for i := range r.Signatures {
+		r.Signatures[i].DecodeFrom(d)
+	}
+}
+
+// RPCRead
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCReadRequest) EncodeTo(e *types.Encoder) {
+	e.WritePrefix(len(r.Sections))
+	for i := range r.Sections {
+		e.Write(r.Sections[i].MerkleRoot[:])
+		e.WriteUint64(uint64(r.Sections[i].Offset))
+		e.WriteUint64(uint64(r.Sections[i].Length))
+	}
+	e.WriteBool(r.MerkleProof)
+	e.WriteUint64(r.RevisionNumber)
+	e.WritePrefix(len(r.ValidProofValues))
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].EncodeTo(e)
+	}
+	e.WritePrefix(len(r.MissedProofValues))
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].EncodeTo(e)
+	}
+	e.WriteBytes(r.Signature[:])
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCReadRequest) DecodeFrom(d *types.Decoder) {
+	r.Sections = make([]RPCReadRequestSection, d.ReadPrefix())
+	for i := range r.Sections {
+		d.Read(r.Sections[i].MerkleRoot[:])
+		r.Sections[i].Offset = d.ReadUint64()
+		r.Sections[i].Length = d.ReadUint64()
+	}
+	r.MerkleProof = d.ReadBool()
+	r.RevisionNumber = d.ReadUint64()
+	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].DecodeFrom(d)
+	}
+	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].DecodeFrom(d)
+	}
+	copy(r.Signature[:], d.ReadBytes())
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCReadResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBytes(r.Signature[:])
+	e.WriteBytes(r.Data)
+	e.WritePrefix(len(r.MerkleProof))
+	for i := range r.MerkleProof {
+		e.Write(r.MerkleProof[i][:])
+	}
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCReadResponse) DecodeFrom(d *types.Decoder) {
+	copy(r.Signature[:], d.ReadBytes())
+
+	// r.Data will typically be large (4 MiB), so reuse the existing capacity if
+	// possible.
+	//
+	// NOTE: for maximum efficiency, we should be doing this for every slice,
+	// but in most cases the extra performance isn't worth the aliasing issues.
+	dataLen := d.ReadPrefix()
+	if cap(r.Data) < dataLen {
+		r.Data = make([]byte, dataLen)
+	}
+	r.Data = r.Data[:dataLen]
+	d.Read(r.Data)
+
+	r.MerkleProof = make([]types.Hash256, d.ReadPrefix())
+	for i := range r.MerkleProof {
+		d.Read(r.MerkleProof[i][:])
+	}
+}
+
+// RPCSectorRoots
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCSectorRootsRequest) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(r.RootOffset)
+	e.WriteUint64(r.NumRoots)
+	e.WriteUint64(r.RevisionNumber)
+	e.WritePrefix(len(r.ValidProofValues))
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].EncodeTo(e)
+	}
+	e.WritePrefix(len(r.MissedProofValues))
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].EncodeTo(e)
+	}
+	e.WriteBytes(r.Signature[:])
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCSectorRootsRequest) DecodeFrom(d *types.Decoder) {
+	r.RootOffset = d.ReadUint64()
+	r.NumRoots = d.ReadUint64()
+	r.RevisionNumber = d.ReadUint64()
+	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].DecodeFrom(d)
+	}
+	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].DecodeFrom(d)
+	}
+	copy(r.Signature[:], d.ReadBytes())
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCSectorRootsResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBytes(r.Signature[:])
+	e.WritePrefix(len(r.SectorRoots))
+	for i := range r.SectorRoots {
+		e.Write(r.SectorRoots[i][:])
+	}
+	e.WritePrefix(len(r.MerkleProof))
+	for i := range r.MerkleProof {
+		e.Write(r.MerkleProof[i][:])
+	}
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCSectorRootsResponse) DecodeFrom(d *types.Decoder) {
+	copy(r.Signature[:], d.ReadBytes())
+	r.SectorRoots = make([]types.Hash256, d.ReadPrefix())
+	for i := range r.SectorRoots {
+		d.Read(r.SectorRoots[i][:])
+	}
+	r.MerkleProof = make([]types.Hash256, d.ReadPrefix())
+	for i := range r.MerkleProof {
+		d.Read(r.MerkleProof[i][:])
+	}
+}
+
+// RPCSettings
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCSettingsResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBytes(r.Settings)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCSettingsResponse) DecodeFrom(d *types.Decoder) {
+	r.Settings = d.ReadBytes()
+}
+
+// RPCWrite
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCWriteRequest) EncodeTo(e *types.Encoder) {
+	e.WritePrefix(len(r.Actions))
+	for i := range r.Actions {
+		e.Write(r.Actions[i].Type[:])
+		e.WriteUint64(r.Actions[i].A)
+		e.WriteUint64(r.Actions[i].B)
+		e.WriteBytes(r.Actions[i].Data)
+	}
+	e.WriteBool(r.MerkleProof)
+	e.WriteUint64(r.RevisionNumber)
+	e.WritePrefix(len(r.ValidProofValues))
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].EncodeTo(e)
+	}
+	e.WritePrefix(len(r.MissedProofValues))
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].EncodeTo(e)
+	}
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCWriteRequest) DecodeFrom(d *types.Decoder) {
+	r.Actions = make([]RPCWriteAction, d.ReadPrefix())
+	for i := range r.Actions {
+		d.Read(r.Actions[i].Type[:])
+		r.Actions[i].A = d.ReadUint64()
+		r.Actions[i].B = d.ReadUint64()
+		r.Actions[i].Data = d.ReadBytes()
+	}
+	r.MerkleProof = d.ReadBool()
+	r.RevisionNumber = d.ReadUint64()
+	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].DecodeFrom(d)
+	}
+	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].DecodeFrom(d)
+	}
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCWriteMerkleProof) EncodeTo(e *types.Encoder) {
+	e.WritePrefix(len(r.OldSubtreeHashes))
+	for i := range r.OldSubtreeHashes {
+		e.Write(r.OldSubtreeHashes[i][:])
+	}
+	e.WritePrefix(len(r.OldLeafHashes))
+	for i := range r.OldLeafHashes {
+		e.Write(r.OldLeafHashes[i][:])
+	}
+	e.Write(r.NewMerkleRoot[:])
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCWriteMerkleProof) DecodeFrom(d *types.Decoder) {
+	r.OldSubtreeHashes = make([]types.Hash256, d.ReadPrefix())
+	for i := range r.OldSubtreeHashes {
+		d.Read(r.OldSubtreeHashes[i][:])
+	}
+	r.OldLeafHashes = make([]types.Hash256, d.ReadPrefix())
+	for i := range r.OldLeafHashes {
+		d.Read(r.OldLeafHashes[i][:])
+	}
+	d.Read(r.NewMerkleRoot[:])
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCWriteResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBytes(r.Signature[:])
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCWriteResponse) DecodeFrom(d *types.Decoder) {
+	copy(r.Signature[:], d.ReadBytes())
+}

--- a/rhp/v2/merkle.go
+++ b/rhp/v2/merkle.go
@@ -1,0 +1,650 @@
+package rhp
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math"
+	"math/bits"
+	"sort"
+	"unsafe"
+
+	"go.sia.tech/core/internal/blake2b"
+	"go.sia.tech/core/types"
+)
+
+// Most of these algorithms are derived from "Streaming Merkle Proofs within
+// Binary Numeral Trees", available at https://eprint.iacr.org/2021/038
+
+const (
+	// LeafSize is the size of one leaf in bytes.
+	LeafSize = 64
+
+	// LeavesPerSector is the number of leaves in one sector.
+	LeavesPerSector = SectorSize / LeafSize
+)
+
+// Check that LeafSize == len(types.StorageProof{}.Leaf). We *could* define
+// LeafSize = len(types.StorageProof{}.Leaf), but then it would be an int
+// instead of a an untyped constant.
+var _ [LeafSize]byte = [len(types.StorageProof{}.Leaf)]byte{}
+
+// A proofAccumulator is a specialized accumulator for building and verifying
+// Merkle proofs.
+type proofAccumulator struct {
+	trees     [64]types.Hash256
+	numLeaves uint64
+}
+
+func (pa *proofAccumulator) hasNodeAtHeight(height int) bool {
+	return pa.numLeaves&(1<<height) != 0
+}
+
+func (pa *proofAccumulator) insertNode(h types.Hash256, height int) {
+	i := height
+	for ; pa.hasNodeAtHeight(i); i++ {
+		h = blake2b.SumPair(pa.trees[i], h)
+	}
+	pa.trees[i] = h
+	pa.numLeaves += 1 << height
+}
+
+func (pa *proofAccumulator) root() types.Hash256 {
+	i := bits.TrailingZeros64(pa.numLeaves)
+	if i == 64 {
+		return types.Hash256{}
+	}
+	root := pa.trees[i]
+	for i++; i < len(pa.trees); i++ {
+		if pa.hasNodeAtHeight(i) {
+			root = blake2b.SumPair(pa.trees[i], root)
+		}
+	}
+	return root
+}
+
+// sectorAccumulator is a specialized accumulator for computing the total root
+// of a sector.
+type sectorAccumulator struct {
+	// Unlike proofAccumulator, the subtree roots are ordered largest-to-
+	// smallest, and we store four roots per height. This ordering allows us to
+	// cast two adjacent elements into a single [8][32]byte, which reduces
+	// copying when hashing.
+	trees [15][4][32]byte
+	// Since we operate on 8 nodes at a time, we need a buffer to hold nodes
+	// until we have enough. And since the buffer is adjacent to the trees in
+	// memory, we can again avoid some copying.
+	nodeBuf [4][32]byte
+	// Like proofAccumulator, 'numLeaves' is both the number of subtree roots
+	// appended and a bit vector that indicates which elements are active. We
+	// also use it to determine how many nodes are in the buffer.
+	numLeaves uint32
+}
+
+// We rely on the nodeBuf field immediately following the last element of the
+// trees field. This should always be true -- there's no reason for a compiler
+// to insert padding between them -- but it doesn't hurt to check.
+var _ [unsafe.Offsetof(sectorAccumulator{}.nodeBuf)]struct{} = [unsafe.Sizeof(sectorAccumulator{}.trees)]struct{}{}
+
+func (sa *sectorAccumulator) reset() {
+	sa.numLeaves = 0
+}
+
+func (sa *sectorAccumulator) hasNodeAtHeight(i int) bool {
+	// not as simple as in proofAccumulator; order is reversed, and sa.numLeaves
+	// is "off" by a factor of 4
+	return (sa.numLeaves>>2)&(1<<(len(sa.trees)-i-1)) != 0
+}
+
+func (sa *sectorAccumulator) appendNode(h types.Hash256) {
+	sa.nodeBuf[sa.numLeaves%4] = h
+	sa.numLeaves++
+	if sa.numLeaves%4 == 0 {
+		sa.numLeaves -= 4 // hack: offset mergeNodeBuf adding 4
+		sa.mergeNodeBuf()
+	}
+}
+
+func (sa *sectorAccumulator) appendLeaves(leaves []byte) {
+	if len(leaves)%LeafSize != 0 {
+		panic("appendLeaves: illegal input size")
+	}
+	rem := len(leaves) % (LeafSize * 4)
+	for i := 0; i < len(leaves)-rem; i += LeafSize * 4 {
+		blake2b.SumLeaves(&sa.nodeBuf, (*[4][64]byte)(unsafe.Pointer(&leaves[i])))
+		sa.mergeNodeBuf()
+	}
+	for i := len(leaves) - rem; i < len(leaves); i += LeafSize {
+		sa.appendNode(blake2b.SumLeaf((*[64]byte)(unsafe.Pointer(&leaves[i]))))
+	}
+}
+
+func (sa *sectorAccumulator) mergeNodeBuf() {
+	// same as in proofAccumulator, except that we operate on 8 nodes at a time,
+	// exploiting the fact that the two groups of 4 are contiguous in memory
+	nodes := &sa.nodeBuf
+	i := len(sa.trees) - 1
+	for ; sa.hasNodeAtHeight(i); i-- {
+		blake2b.SumNodes(&sa.trees[i], (*[8][32]byte)(unsafe.Pointer(&sa.trees[i])))
+		nodes = &sa.trees[i]
+	}
+	sa.trees[i] = *nodes
+	sa.numLeaves += 4
+}
+
+func (sa *sectorAccumulator) root() types.Hash256 {
+	if sa.numLeaves == 0 {
+		return types.Hash256{}
+	}
+
+	// helper function for computing the root of four subtrees
+	root4 := func(nodes [4][32]byte) types.Hash256 {
+		// NOTE: it would be more efficient to mutate sa.trees directly, but
+		// that would make root non-idempotent
+		in := (*[8][32]byte)(unsafe.Pointer(&[2][4][32]byte{0: nodes}))
+		out := (*[4][32]byte)(unsafe.Pointer(in))
+		blake2b.SumNodes(out, in)
+		blake2b.SumNodes(out, in)
+		return out[0]
+	}
+
+	i := len(sa.trees) - 1 - bits.TrailingZeros32(sa.numLeaves>>2)
+	var root types.Hash256
+	switch sa.numLeaves % 4 {
+	case 0:
+		root = root4(sa.trees[i])
+		i--
+	case 1:
+		root = sa.nodeBuf[0]
+	case 2:
+		root = blake2b.SumPair(sa.nodeBuf[0], sa.nodeBuf[1])
+	case 3:
+		root = blake2b.SumPair(blake2b.SumPair(sa.nodeBuf[0], sa.nodeBuf[1]), sa.nodeBuf[2])
+	}
+	for ; i >= 0; i-- {
+		if sa.hasNodeAtHeight(i) {
+			root = blake2b.SumPair(root4(sa.trees[i]), root)
+		}
+	}
+	return root
+}
+
+// SectorRoot computes the Merkle root of a sector.
+func SectorRoot(sector *[SectorSize]byte) types.Hash256 {
+	var sa sectorAccumulator
+	sa.appendLeaves(sector[:])
+	return sa.root()
+}
+
+// ReaderRoot returns the Merkle root of the supplied stream, which must contain
+// an integer multiple of leaves.
+func ReaderRoot(r io.Reader) (types.Hash256, error) {
+	var s sectorAccumulator
+	leafBatch := make([]byte, LeafSize*16)
+	for {
+		n, err := io.ReadFull(r, leafBatch)
+		if err == io.EOF {
+			break
+		} else if err == io.ErrUnexpectedEOF {
+			if n%LeafSize != 0 {
+				return types.Hash256{}, errors.New("stream does not contain integer multiple of leaves")
+			}
+		} else if err != nil {
+			return types.Hash256{}, err
+		}
+		s.appendLeaves(leafBatch[:n])
+	}
+	return s.root(), nil
+}
+
+// ReadSector reads a single sector from r and calculates its root.
+func ReadSector(r io.Reader) (types.Hash256, *[SectorSize]byte, error) {
+	var sector [SectorSize]byte
+	buf := bytes.NewBuffer(sector[:0])
+	root, err := ReaderRoot(io.TeeReader(io.LimitReader(r, SectorSize), buf))
+	if buf.Len() != SectorSize {
+		return types.Hash256{}, nil, io.ErrUnexpectedEOF
+	}
+	return root, &sector, err
+}
+
+// MetaRoot calculates the root of a set of existing Merkle roots.
+func MetaRoot(roots []types.Hash256) types.Hash256 {
+	// sectorAccumulator is only designed to store one sector's worth of leaves,
+	// so we'll panic if we insert more than leavesPerSector leaves. To
+	// compensate, call MetaRoot recursively.
+	if len(roots) <= LeavesPerSector {
+		var sa sectorAccumulator
+		for _, r := range roots {
+			sa.appendNode(r)
+		}
+		return sa.root()
+	}
+	// split at largest power of two
+	split := 1 << (bits.Len(uint(len(roots)-1)) - 1)
+	return blake2b.SumPair(MetaRoot(roots[:split]), MetaRoot(roots[split:]))
+}
+
+// ProofSize returns the size of a Merkle proof for the leaf i within a tree
+// containing n leaves.
+func ProofSize(n, i uint64) uint64 {
+	return RangeProofSize(n, i, i+1)
+}
+
+// RangeProofSize returns the size of a Merkle proof for the leaf range [start,
+// end) within a tree containing n leaves.
+func RangeProofSize(n, start, end uint64) uint64 {
+	leftHashes := bits.OnesCount64(start)
+	pathMask := uint64(1)<<bits.Len64((end-1)^(n-1)) - 1
+	rightHashes := bits.OnesCount64(^(end - 1) & pathMask)
+	return uint64(leftHashes + rightHashes)
+}
+
+// nextSubtreeSize returns the size of the subtree adjacent to start that does
+// not overlap end.
+func nextSubtreeSize(start, end uint64) uint64 {
+	ideal := bits.TrailingZeros64(start)
+	max := bits.Len64(end-start) - 1
+	if ideal > max {
+		return 1 << max
+	}
+	return 1 << ideal
+}
+
+// BuildProof constructs a proof for the segment range [start, end). If a non-
+// nil precalc function is provided, it will be used to supply precalculated
+// subtree Merkle roots. For example, if the root of the left half of the
+// Merkle tree is precomputed, precalc should return it for i == 0 and j ==
+// SegmentsPerSector/2. If a precalculated root is not available, precalc
+// should return the zero hash.
+func BuildProof(sector *[SectorSize]byte, start, end uint64, precalc func(i, j uint64) types.Hash256) []types.Hash256 {
+	if end > LeavesPerSector || start > end || start == end {
+		panic("BuildProof: illegal proof range")
+	}
+	if precalc == nil {
+		precalc = func(i, j uint64) (h types.Hash256) { return }
+	}
+
+	// define a helper function for later
+	var s sectorAccumulator
+	subtreeRoot := func(i, j uint64) types.Hash256 {
+		s.reset()
+		s.appendLeaves(sector[i*LeafSize : j*LeafSize])
+		return s.root()
+	}
+
+	// we build the proof by recursively enumerating subtrees, left to right.
+	// If a subtree is inside the segment range, we can skip it (because the
+	// verifier has the segments); otherwise, we add its Merkle root to the
+	// proof.
+	//
+	// NOTE: this operation might be a little tricky to understand because
+	// it's a recursive function with side effects (appending to proof), but
+	// this is the simplest way I was able to implement it. Namely, it has the
+	// important advantage of being symmetrical to the Verify operation.
+	proof := make([]types.Hash256, 0, ProofSize(LeavesPerSector, start))
+	var rec func(uint64, uint64)
+	rec = func(i, j uint64) {
+		if i >= start && j <= end {
+			// this subtree contains only data segments; skip it
+		} else if j <= start || i >= end {
+			// this subtree does not contain any data segments; add its Merkle
+			// root to the proof. If we have a precalculated root, use that;
+			// otherwise, calculate it from scratch.
+			if h := precalc(i, j); h != (types.Hash256{}) {
+				proof = append(proof, h)
+			} else {
+				proof = append(proof, subtreeRoot(i, j))
+			}
+		} else {
+			// this subtree partially overlaps the data segments; split it
+			// into two subtrees and recurse on each
+			mid := (i + j) / 2
+			rec(i, mid)
+			rec(mid, j)
+		}
+	}
+	rec(0, LeavesPerSector)
+	return proof
+}
+
+// BuildSectorRangeProof constructs a proof for the sector range [start, end).
+func BuildSectorRangeProof(sectorRoots []types.Hash256, start, end uint64) []types.Hash256 {
+	numLeaves := uint64(len(sectorRoots))
+	if numLeaves == 0 {
+		return nil
+	} else if end > numLeaves || start > end || start == end {
+		panic("BuildSectorRangeProof: illegal proof range")
+	}
+
+	proof := make([]types.Hash256, 0, ProofSize(numLeaves, start))
+	buildRange := func(i, j uint64) {
+		for i < j && i < numLeaves {
+			subtreeSize := nextSubtreeSize(i, j)
+			if i+subtreeSize > numLeaves {
+				subtreeSize = numLeaves - i
+			}
+			proof = append(proof, MetaRoot(sectorRoots[i:][:subtreeSize]))
+			i += subtreeSize
+		}
+	}
+	buildRange(0, start)
+	buildRange(end, math.MaxInt32)
+	return proof
+}
+
+// A RangeProofVerifier allows range proofs to be verified in streaming fashion.
+type RangeProofVerifier struct {
+	start, end uint64
+	roots      []types.Hash256
+}
+
+// ReadFrom implements io.ReaderFrom.
+func (rpv *RangeProofVerifier) ReadFrom(r io.Reader) (int64, error) {
+	var total int64
+	i, j := rpv.start, rpv.end
+	for i < j {
+		subtreeSize := nextSubtreeSize(i, j)
+		n := int64(subtreeSize * LeafSize)
+		root, err := ReaderRoot(io.LimitReader(r, n))
+		if err != nil {
+			return total, err
+		}
+		total += n
+		rpv.roots = append(rpv.roots, root)
+		i += subtreeSize
+	}
+	return total, nil
+}
+
+// Verify verifies the supplied proof, using the data ingested from ReadFrom.
+func (rpv *RangeProofVerifier) Verify(proof []types.Hash256, root types.Hash256) bool {
+	if uint64(len(proof)) != RangeProofSize(LeavesPerSector, rpv.start, rpv.end) {
+		return false
+	}
+	var acc proofAccumulator
+	consume := func(roots *[]types.Hash256, i, j uint64) {
+		for i < j && len(*roots) > 0 {
+			subtreeSize := nextSubtreeSize(i, j)
+			height := bits.TrailingZeros(uint(subtreeSize)) // log2
+			acc.insertNode((*roots)[0], height)
+			*roots = (*roots)[1:]
+			i += subtreeSize
+		}
+	}
+	consume(&proof, 0, rpv.start)
+	consume(&rpv.roots, rpv.start, rpv.end)
+	consume(&proof, rpv.end, LeavesPerSector)
+	return acc.root() == root
+}
+
+// NewRangeProofVerifier returns a RangeProofVerifier for the sector range
+// [start, end).
+func NewRangeProofVerifier(start, end uint64) *RangeProofVerifier {
+	return &RangeProofVerifier{
+		start: start,
+		end:   end,
+	}
+}
+
+// VerifySectorRangeProof verifies a proof produced by BuildRangeProof.
+func VerifySectorRangeProof(proof []types.Hash256, rangeRoots []types.Hash256, start, end, numRoots uint64, root types.Hash256) bool {
+	if numRoots == 0 {
+		return len(proof) == 0
+	} else if uint64(len(rangeRoots)) != end-start {
+		panic("VerifySectorRangeProof: number of roots does not match range")
+	} else if end > numRoots || start > end || start == end {
+		panic("VerifySectorRangeProof: illegal proof range")
+	}
+	if uint64(len(proof)) != RangeProofSize(numRoots, start, end) {
+		return false
+	}
+
+	var acc proofAccumulator
+	insertRange := func(i, j uint64) {
+		for i < j && len(proof) > 0 {
+			subtreeSize := nextSubtreeSize(i, j)
+			height := bits.TrailingZeros64(subtreeSize) // log2
+			acc.insertNode(proof[0], height)
+			proof = proof[1:]
+			i += subtreeSize
+		}
+	}
+
+	insertRange(0, start)
+	for _, h := range rangeRoots {
+		acc.insertNode(h, 0)
+	}
+	insertRange(end, math.MaxUint64)
+	return acc.root() == root
+}
+
+// VerifyAppendProof verifies a proof produced by BuildAppendProof.
+func VerifyAppendProof(numLeaves uint64, treeHashes []types.Hash256, sectorRoot, oldRoot, newRoot types.Hash256) bool {
+	acc := proofAccumulator{numLeaves: numLeaves}
+	for i := range acc.trees {
+		if acc.hasNodeAtHeight(i) && len(treeHashes) > 0 {
+			acc.trees[i] = treeHashes[0]
+			treeHashes = treeHashes[1:]
+		}
+	}
+	if acc.root() != oldRoot {
+		return false
+	}
+	acc.insertNode(sectorRoot, 0)
+	return acc.root() == newRoot
+}
+
+// DiffProofSize returns the size of a Merkle diff proof for the specified
+// actions within a tree containing n leaves.
+func DiffProofSize(n uint64, actions []RPCWriteAction) uint64 {
+	return 128 // TODO
+}
+
+// BuildDiffProof constructs a diff proof for the specified actions.
+// ActionUpdate is not supported.
+func BuildDiffProof(actions []RPCWriteAction, sectorRoots []types.Hash256) (treeHashes, leafHashes []types.Hash256) {
+	indices := sectorsChanged(actions, uint64(len(sectorRoots)))
+	leafHashes = make([]types.Hash256, len(indices))
+	for i, j := range indices {
+		leafHashes[i] = sectorRoots[j]
+	}
+
+	treeHashes = make([]types.Hash256, 0, 128)
+	buildRange := func(i, j uint64) {
+		for i < j {
+			subtreeSize := nextSubtreeSize(i, j)
+			treeHashes = append(treeHashes, MetaRoot(sectorRoots[i:][:subtreeSize]))
+			i += subtreeSize
+		}
+	}
+
+	var start uint64
+	for _, end := range indices {
+		buildRange(start, end)
+		start = end + 1
+	}
+	buildRange(start, uint64(len(sectorRoots)))
+	return
+}
+
+// VerifyDiffProof verifies a proof produced by BuildDiffProof. ActionUpdate is
+// not supported. If appendRoots is non-nil, it is assumed to contain the
+// precomputed SectorRoots of all Append actions.
+func VerifyDiffProof(actions []RPCWriteAction, numLeaves uint64, treeHashes, leafHashes []types.Hash256, oldRoot, newRoot types.Hash256, appendRoots []types.Hash256) bool {
+	verifyMulti := func(proofIndices []uint64, treeHashes, leafHashes []types.Hash256, numLeaves uint64, root types.Hash256) bool {
+		var acc proofAccumulator
+		insertRange := func(i, j uint64) {
+			for i < j {
+				subtreeSize := nextSubtreeSize(i, j)
+				height := bits.TrailingZeros64(subtreeSize) // log2
+				acc.insertNode(treeHashes[0], height)
+				treeHashes = treeHashes[1:]
+				i += subtreeSize
+			}
+		}
+
+		var start uint64
+		for i, end := range proofIndices {
+			insertRange(start, end)
+			start = end + 1
+			acc.insertNode(leafHashes[i], 0)
+		}
+		insertRange(start, numLeaves)
+
+		return acc.root() == root
+	}
+
+	// first use the original proof to construct oldRoot
+	proofIndices := sectorsChanged(actions, numLeaves)
+	if len(proofIndices) != len(leafHashes) {
+		return false
+	}
+	if !verifyMulti(proofIndices, treeHashes, leafHashes, numLeaves, oldRoot) {
+		return false
+	}
+
+	// then modify the proof according to actions and construct the newRoot
+	newLeafHashes := modifyLeaves(leafHashes, actions, numLeaves, appendRoots)
+	newProofIndices := modifyProofRanges(proofIndices, actions, numLeaves)
+	numLeaves += uint64(len(newLeafHashes) - len(leafHashes))
+
+	return verifyMulti(newProofIndices, treeHashes, newLeafHashes, numLeaves, newRoot)
+}
+
+func sectorsChanged(actions []RPCWriteAction, numSectors uint64) []uint64 {
+	newNumSectors := numSectors
+	sectorsChanged := make(map[uint64]struct{})
+	for _, action := range actions {
+		switch action.Type {
+		case RPCWriteActionAppend:
+			sectorsChanged[newNumSectors] = struct{}{}
+			newNumSectors++
+
+		case RPCWriteActionTrim:
+			for i := uint64(0); i < action.A; i++ {
+				newNumSectors--
+				sectorsChanged[newNumSectors] = struct{}{}
+			}
+
+		case RPCWriteActionSwap:
+			sectorsChanged[action.A] = struct{}{}
+			sectorsChanged[action.B] = struct{}{}
+
+		default:
+			panic("unknown or unsupported action type: " + action.Type.String())
+		}
+	}
+
+	var sectorIndices []uint64
+	for index := range sectorsChanged {
+		if index < numSectors {
+			sectorIndices = append(sectorIndices, index)
+		}
+	}
+	sort.Slice(sectorIndices, func(i, j int) bool {
+		return sectorIndices[i] < sectorIndices[j]
+	})
+	return sectorIndices
+}
+
+// modifyProofRanges modifies the proof ranges produced by calculateProofRanges
+// to verify a post-modification Merkle diff proof for the specified actions.
+func modifyProofRanges(proofIndices []uint64, actions []RPCWriteAction, numSectors uint64) []uint64 {
+	for _, action := range actions {
+		switch action.Type {
+		case RPCWriteActionAppend:
+			proofIndices = append(proofIndices, numSectors)
+			numSectors++
+
+		case RPCWriteActionTrim:
+			proofIndices = proofIndices[:uint64(len(proofIndices))-action.A]
+			numSectors -= action.A
+
+		case RPCWriteActionSwap:
+		case RPCWriteActionUpdate:
+
+		default:
+			panic("unknown or unsupported action type: " + action.Type.String())
+		}
+	}
+	return proofIndices
+}
+
+// modifyLeaves modifies the leaf hashes of a Merkle diff proof to verify a
+// post-modification Merkle diff proof for the specified actions.
+func modifyLeaves(leafHashes []types.Hash256, actions []RPCWriteAction, numSectors uint64, appendRoots []types.Hash256) []types.Hash256 {
+	// determine which sector index corresponds to each leaf hash
+	var indices []uint64
+	for _, action := range actions {
+		switch action.Type {
+		case RPCWriteActionAppend:
+			indices = append(indices, numSectors)
+			numSectors++
+		case RPCWriteActionTrim:
+			for j := uint64(0); j < action.A; j++ {
+				numSectors--
+				indices = append(indices, numSectors)
+			}
+		case RPCWriteActionSwap:
+			indices = append(indices, action.A, action.B)
+
+		default:
+			panic("unknown or unsupported action type: " + action.Type.String())
+		}
+	}
+	sort.Slice(indices, func(i, j int) bool {
+		return indices[i] < indices[j]
+	})
+	indexMap := make(map[uint64]uint64, len(leafHashes))
+	for i, index := range indices {
+		if i > 0 && index == indices[i-1] {
+			continue // remove duplicates
+		}
+		indexMap[index] = uint64(len(indexMap))
+	}
+	leafHashes = append([]types.Hash256(nil), leafHashes...)
+	for _, action := range actions {
+		switch action.Type {
+		case RPCWriteActionAppend:
+			var root types.Hash256
+			if len(appendRoots) > 0 {
+				root, appendRoots = appendRoots[0], appendRoots[1:]
+			} else {
+				root = SectorRoot((*[SectorSize]byte)(action.Data))
+			}
+			leafHashes = append(leafHashes, root)
+
+		case RPCWriteActionTrim:
+			leafHashes = leafHashes[:uint64(len(leafHashes))-action.A]
+
+		case RPCWriteActionSwap:
+			i, j := indexMap[action.A], indexMap[action.B]
+			leafHashes[i], leafHashes[j] = leafHashes[j], leafHashes[i]
+
+		default:
+			panic("unknown or unsupported action type: " + action.Type.String())
+		}
+	}
+	return leafHashes
+}
+
+// ConvertProofOrdering converts "left-to-right" proofs into the "leaf-to-root"
+// ordering used in consensus storage proofs.
+func ConvertProofOrdering(proof []types.Hash256, index uint64) []types.Hash256 {
+	// strategy: split proof into lefts and rights, then iterate over bits in
+	// leaf-to-root order, selecting either a left or right hash as appropriate.
+	lefts := proof[:bits.OnesCount(uint(index))]
+	rights := proof[len(lefts):]
+	reordered := make([]types.Hash256, 0, len(proof))
+	for i := 0; len(reordered) < len(proof); i++ {
+		if index&(1<<i) != 0 {
+			reordered = append(reordered, lefts[len(lefts)-1])
+			lefts = lefts[:len(lefts)-1]
+		} else if len(rights) > 0 {
+			reordered = append(reordered, rights[0])
+			rights = rights[1:]
+		}
+	}
+	return reordered
+}

--- a/rhp/v2/merkle_test.go
+++ b/rhp/v2/merkle_test.go
@@ -1,0 +1,243 @@
+package rhp
+
+import (
+	"bytes"
+	"math/bits"
+	"testing"
+
+	"go.sia.tech/core/types"
+	"golang.org/x/crypto/blake2b"
+	"lukechampine.com/frand"
+)
+
+func leafHash(seg []byte) types.Hash256 {
+	return blake2b.Sum256(append([]byte{0}, seg...))
+}
+
+func nodeHash(left, right types.Hash256) types.Hash256 {
+	return blake2b.Sum256(append([]byte{1}, append(left[:], right[:]...)...))
+}
+
+func refSectorRoot(sector *[SectorSize]byte) types.Hash256 {
+	roots := make([]types.Hash256, LeavesPerSector)
+	for i := range roots {
+		roots[i] = leafHash(sector[i*LeafSize:][:LeafSize])
+	}
+	return recNodeRoot(roots)
+}
+
+func recNodeRoot(roots []types.Hash256) types.Hash256 {
+	switch len(roots) {
+	case 0:
+		return types.Hash256{}
+	case 1:
+		return roots[0]
+	default:
+		// split at largest power of two
+		split := 1 << (bits.Len(uint(len(roots)-1)) - 1)
+		return nodeHash(
+			recNodeRoot(roots[:split]),
+			recNodeRoot(roots[split:]),
+		)
+	}
+}
+
+func TestSectorRoot(t *testing.T) {
+	// test some known roots
+	var sector [SectorSize]byte
+	if SectorRoot(&sector).String() != "h:50ed59cecd5ed3ca9e65cec0797202091dbba45272dafa3faa4e27064eedd52c" {
+		t.Error("wrong Merkle root for empty sector")
+	}
+	sector[0] = 1
+	if SectorRoot(&sector).String() != "h:8c20a2c90a733a5139cc57e45755322e304451c3434b0c0a0aad87f2f89a44ab" {
+		t.Error("wrong Merkle root for sector[0] = 1")
+	}
+	sector[0] = 0
+	sector[SectorSize-1] = 1
+	if SectorRoot(&sector).String() != "h:d0ab6691d76750618452e920386e5f6f98fdd1219a70a06f06ef622ac6c6373c" {
+		t.Error("wrong Merkle root for sector[SectorSize-1] = 1")
+	}
+
+	// test some random roots against a reference implementation
+	for i := 0; i < 5; i++ {
+		frand.Read(sector[:])
+		if SectorRoot(&sector) != refSectorRoot(&sector) {
+			t.Error("SectorRoot does not match reference implementation")
+		}
+	}
+
+	// SectorRoot should not allocate
+	allocs := testing.AllocsPerRun(5, func() {
+		_ = SectorRoot(&sector)
+	})
+	if allocs > 0 {
+		t.Error("expected SectorRoot to allocate 0 times, got", allocs)
+	}
+}
+
+func BenchmarkSectorRoot(b *testing.B) {
+	b.ReportAllocs()
+	var sector [SectorSize]byte
+	b.SetBytes(SectorSize)
+	for i := 0; i < b.N; i++ {
+		_ = SectorRoot(&sector)
+	}
+}
+
+func TestMetaRoot(t *testing.T) {
+	// test some known roots
+	if MetaRoot(nil) != (types.Hash256{}) {
+		t.Error("wrong Merkle root for empty tree")
+	}
+	roots := make([]types.Hash256, 1)
+	roots[0] = frand.Entropy256()
+	if MetaRoot(roots) != roots[0] {
+		t.Error("wrong Merkle root for single root")
+	}
+	roots = make([]types.Hash256, 32)
+	if MetaRoot(roots).String() != "h:1c23727030051d1bba1c887273addac2054afbd6926daddef6740f4f8bf1fb7f" {
+		t.Error("wrong Merkle root for 32 empty roots")
+	}
+	roots[0][0] = 1
+	if MetaRoot(roots).String() != "h:c5da05749139505704ea18a5d92d46427f652ac79c5f5712e4aefb68e20dffb8" {
+		t.Error("wrong Merkle root for roots[0][0] = 1")
+	}
+
+	// test some random roots against a reference implementation
+	for i := 0; i < 5; i++ {
+		for j := range roots {
+			roots[j] = frand.Entropy256()
+		}
+		if MetaRoot(roots) != recNodeRoot(roots) {
+			t.Error("MetaRoot does not match reference implementation")
+		}
+	}
+	// test some random tree sizes
+	for i := 0; i < 10; i++ {
+		roots := make([]types.Hash256, frand.Intn(LeavesPerSector))
+		if MetaRoot(roots) != recNodeRoot(roots) {
+			t.Error("MetaRoot does not match reference implementation")
+		}
+	}
+
+	roots = roots[:5]
+	if MetaRoot(roots) != recNodeRoot(roots) {
+		t.Error("MetaRoot does not match reference implementation")
+	}
+
+	allocs := testing.AllocsPerRun(10, func() {
+		_ = MetaRoot(roots)
+	})
+	if allocs > 0 {
+		t.Error("expected MetaRoot to allocate 0 times, got", allocs)
+	}
+
+	// test a massive number of roots, larger than a single stack can store
+	const sectorsPerTerabyte = 262145
+	roots = make([]types.Hash256, sectorsPerTerabyte)
+	if MetaRoot(roots) != recNodeRoot(roots) {
+		t.Error("MetaRoot does not match reference implementation")
+	}
+}
+
+func BenchmarkMetaRoot1TB(b *testing.B) {
+	const sectorsPerTerabyte = 262144
+	roots := make([]types.Hash256, sectorsPerTerabyte)
+	b.SetBytes(sectorsPerTerabyte * 32)
+	for i := 0; i < b.N; i++ {
+		_ = MetaRoot(roots)
+	}
+}
+
+func TestProofAccumulator(t *testing.T) {
+	var pa proofAccumulator
+
+	// test some known roots
+	if pa.root() != (types.Hash256{}) {
+		t.Error("wrong root for empty accumulator")
+	}
+
+	roots := make([]types.Hash256, 32)
+	for _, root := range roots {
+		pa.insertNode(root, 0)
+	}
+	if pa.root().String() != "h:1c23727030051d1bba1c887273addac2054afbd6926daddef6740f4f8bf1fb7f" {
+		t.Error("wrong root for 32 empty roots")
+	}
+
+	pa = proofAccumulator{}
+	roots[0][0] = 1
+	for _, root := range roots {
+		pa.insertNode(root, 0)
+	}
+	if pa.root().String() != "h:c5da05749139505704ea18a5d92d46427f652ac79c5f5712e4aefb68e20dffb8" {
+		t.Error("wrong root for roots[0][0] = 1")
+	}
+
+	// test some random roots against a reference implementation
+	for i := 0; i < 5; i++ {
+		var pa proofAccumulator
+		for j := range roots {
+			roots[j] = frand.Entropy256()
+			pa.insertNode(roots[j], 0)
+		}
+		if pa.root() != recNodeRoot(roots) {
+			t.Error("root does not match reference implementation")
+		}
+	}
+
+	// test an odd number of roots
+	pa = proofAccumulator{}
+	roots = roots[:5]
+	for _, root := range roots {
+		pa.insertNode(root, 0)
+	}
+	refRoot := recNodeRoot([]types.Hash256{recNodeRoot(roots[:4]), roots[4]})
+	if pa.root() != refRoot {
+		t.Error("root does not match reference implementation")
+	}
+}
+
+func TestReadSector(t *testing.T) {
+	var expected [SectorSize]byte
+	frand.Read(expected[:256])
+	buf := bytes.NewBuffer(nil)
+	buf.Write(expected[:])
+
+	expectedRoot := refSectorRoot(&expected)
+	root, sector, err := ReadSector(buf)
+	if err != nil {
+		t.Fatal(err)
+	} else if expectedRoot != root {
+		t.Fatalf("incorrect root: expected %s, got %s", expected, root)
+	} else if !bytes.Equal(sector[:], expected[:]) {
+		t.Fatalf("incorrect data: expected %v, got %v", expected, sector)
+	}
+
+	buf.Reset()
+	buf.Write(expected[:len(expected)-100])
+	_, _, err = ReadSector(buf)
+	if err == nil {
+		t.Fatal("expected read error")
+	}
+}
+
+func BenchmarkReadSector(b *testing.B) {
+	buf := bytes.NewBuffer(nil)
+	buf.Grow(SectorSize)
+
+	sector := make([]byte, SectorSize)
+	frand.Read(sector[:256])
+
+	b.SetBytes(SectorSize)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		buf.Write(sector)
+		_, _, err := ReadSector(buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/rhp/v2/release.go
+++ b/rhp/v2/release.go
@@ -1,0 +1,19 @@
+//go:build !testing
+
+package rhp
+
+import (
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+)
+
+// SectorSize is the size of one sector in bytes.
+const SectorSize = 1 << 22 // 4 MiB
+
+func contractTax(fc types.FileContract) types.Currency {
+	// NOTE: siad uses different hardfork heights when -tags=testing is set,
+	// so we have to alter cs accordingly.
+	// TODO: remove this
+	cs := consensus.State{Index: types.ChainIndex{Height: fc.WindowStart}}
+	return cs.FileContractTax(fc)
+}

--- a/rhp/v2/rhp.go
+++ b/rhp/v2/rhp.go
@@ -1,0 +1,292 @@
+// Package rhp implements the Sia renter-host protocol, version 2.
+package rhp
+
+import (
+	"fmt"
+	"math/bits"
+	"net"
+	"time"
+
+	"go.sia.tech/core/types"
+)
+
+func wrapErr(err *error, fnName string) {
+	if *err != nil {
+		*err = fmt.Errorf("%s: %w", fnName, *err)
+	}
+}
+
+// A ContractRevision pairs a file contract with its signatures.
+type ContractRevision struct {
+	Revision   types.FileContractRevision
+	Signatures [2]types.TransactionSignature
+}
+
+// EndHeight returns the height at which the host is no longer obligated to
+// store contract data.
+func (c ContractRevision) EndHeight() uint64 {
+	return uint64(c.Revision.WindowStart)
+}
+
+// ID returns the ID of the original FileContract.
+func (c ContractRevision) ID() types.FileContractID {
+	return c.Revision.ParentID
+}
+
+// HostKey returns the public key of the host.
+func (c ContractRevision) HostKey() (pk types.PublicKey) {
+	copy(pk[:], c.Revision.UnlockConditions.PublicKeys[1].Key)
+	return
+}
+
+// RenterFunds returns the funds remaining in the contract's Renter payout.
+func (c ContractRevision) RenterFunds() types.Currency {
+	return c.Revision.ValidProofOutputs[0].Value
+}
+
+// NumSectors returns the number of sectors covered by the contract.
+func (c ContractRevision) NumSectors() uint64 {
+	return c.Revision.Filesize / SectorSize
+}
+
+// HostSettings are the settings and prices used when interacting with a host.
+type HostSettings struct {
+	AcceptingContracts         bool           `json:"acceptingcontracts"`
+	MaxDownloadBatchSize       uint64         `json:"maxdownloadbatchsize"`
+	MaxDuration                uint64         `json:"maxduration"`
+	MaxReviseBatchSize         uint64         `json:"maxrevisebatchsize"`
+	NetAddress                 string         `json:"netaddress"`
+	RemainingStorage           uint64         `json:"remainingstorage"`
+	SectorSize                 uint64         `json:"sectorsize"`
+	TotalStorage               uint64         `json:"totalstorage"`
+	Address                    types.Address  `json:"unlockhash"`
+	WindowSize                 uint64         `json:"windowsize"`
+	Collateral                 types.Currency `json:"collateral"`
+	MaxCollateral              types.Currency `json:"maxcollateral"`
+	BaseRPCPrice               types.Currency `json:"baserpcprice"`
+	ContractPrice              types.Currency `json:"contractprice"`
+	DownloadBandwidthPrice     types.Currency `json:"downloadbandwidthprice"`
+	SectorAccessPrice          types.Currency `json:"sectoraccessprice"`
+	StoragePrice               types.Currency `json:"storageprice"`
+	UploadBandwidthPrice       types.Currency `json:"uploadbandwidthprice"`
+	EphemeralAccountExpiry     time.Duration  `json:"ephemeralaccountexpiry"`
+	MaxEphemeralAccountBalance types.Currency `json:"maxephemeralaccountbalance"`
+	RevisionNumber             uint64         `json:"revisionnumber"`
+	Version                    string         `json:"version"`
+	SiaMuxPort                 string         `json:"siamuxport"`
+}
+
+// SiamuxAddr is a helper which returns an address that can be used to connect
+// to the host's siamux.
+func (s HostSettings) SiamuxAddr() string {
+	host, _, err := net.SplitHostPort(s.NetAddress)
+	if err != nil {
+		return ""
+	}
+	return net.JoinHostPort(host, s.SiaMuxPort)
+}
+
+// RPC IDs
+var (
+	RPCFormContractID       = types.NewSpecifier("LoopFormContract")
+	RPCLockID               = types.NewSpecifier("LoopLock")
+	RPCReadID               = types.NewSpecifier("LoopRead")
+	RPCRenewContractID      = types.NewSpecifier("LoopRenew")
+	RPCRenewClearContractID = types.NewSpecifier("LoopRenewClear")
+	RPCSectorRootsID        = types.NewSpecifier("LoopSectorRoots")
+	RPCSettingsID           = types.NewSpecifier("LoopSettings")
+	RPCUnlockID             = types.NewSpecifier("LoopUnlock")
+	RPCWriteID              = types.NewSpecifier("LoopWrite")
+)
+
+// Read/Write actions
+var (
+	RPCWriteActionAppend = types.NewSpecifier("Append")
+	RPCWriteActionTrim   = types.NewSpecifier("Trim")
+	RPCWriteActionSwap   = types.NewSpecifier("Swap")
+	RPCWriteActionUpdate = types.NewSpecifier("Update")
+
+	RPCReadStop = types.NewSpecifier("ReadStop")
+)
+
+// RPC request/response objects
+type (
+	// RPCFormContractRequest contains the request parameters for the
+	// FormContract and RenewContract RPCs.
+	RPCFormContractRequest struct {
+		Transactions []types.Transaction
+		RenterKey    types.UnlockKey
+	}
+
+	// RPCRenewAndClearContractRequest contains the request parameters for the
+	// RenewAndClearContract RPC.
+	RPCRenewAndClearContractRequest struct {
+		Transactions           []types.Transaction
+		RenterKey              types.UnlockKey
+		FinalValidProofValues  []types.Currency
+		FinalMissedProofValues []types.Currency
+	}
+
+	// RPCFormContractAdditions contains the parent transaction, inputs, and
+	// outputs added by the host when negotiating a file contract.
+	RPCFormContractAdditions struct {
+		Parents []types.Transaction
+		Inputs  []types.SiacoinInput
+		Outputs []types.SiacoinOutput
+	}
+
+	// RPCFormContractSignatures contains the signatures for a contract
+	// transaction and initial revision. These signatures are sent by both the
+	// renter and host during contract formation and renewal.
+	RPCFormContractSignatures struct {
+		ContractSignatures []types.TransactionSignature
+		RevisionSignature  types.TransactionSignature
+	}
+
+	// RPCRenewAndClearContractSignatures contains the signatures for a contract
+	// transaction, initial revision, and final revision of the contract being
+	// renewed. These signatures are sent by both the renter and host during the
+	// RenewAndClear RPC.
+	RPCRenewAndClearContractSignatures struct {
+		ContractSignatures     []types.TransactionSignature
+		RevisionSignature      types.TransactionSignature
+		FinalRevisionSignature types.Signature
+	}
+
+	// RPCLockRequest contains the request parameters for the Lock RPC.
+	RPCLockRequest struct {
+		ContractID types.FileContractID
+		Signature  types.Signature
+		Timeout    uint64
+	}
+
+	// RPCLockResponse contains the response data for the Lock RPC.
+	RPCLockResponse struct {
+		Acquired     bool
+		NewChallenge [16]byte
+		Revision     types.FileContractRevision
+		Signatures   []types.TransactionSignature
+	}
+
+	// RPCReadRequestSection is a section requested in RPCReadRequest.
+	RPCReadRequestSection struct {
+		MerkleRoot types.Hash256
+		Offset     uint64
+		Length     uint64
+	}
+
+	// RPCReadRequest contains the request parameters for the Read RPC.
+	RPCReadRequest struct {
+		Sections    []RPCReadRequestSection
+		MerkleProof bool
+
+		RevisionNumber    uint64
+		ValidProofValues  []types.Currency
+		MissedProofValues []types.Currency
+		Signature         types.Signature
+	}
+
+	// RPCReadResponse contains the response data for the Read RPC.
+	RPCReadResponse struct {
+		Signature   types.Signature
+		Data        []byte
+		MerkleProof []types.Hash256
+	}
+
+	// RPCSectorRootsRequest contains the request parameters for the SectorRoots RPC.
+	RPCSectorRootsRequest struct {
+		RootOffset uint64
+		NumRoots   uint64
+
+		RevisionNumber    uint64
+		ValidProofValues  []types.Currency
+		MissedProofValues []types.Currency
+		Signature         types.Signature
+	}
+
+	// RPCSectorRootsResponse contains the response data for the SectorRoots RPC.
+	RPCSectorRootsResponse struct {
+		Signature   types.Signature
+		SectorRoots []types.Hash256
+		MerkleProof []types.Hash256
+	}
+
+	// RPCSettingsResponse contains the response data for the SettingsResponse RPC.
+	RPCSettingsResponse struct {
+		Settings []byte // JSON-encoded hostdb.HostSettings
+	}
+
+	// RPCWriteRequest contains the request parameters for the Write RPC.
+	RPCWriteRequest struct {
+		Actions     []RPCWriteAction
+		MerkleProof bool
+
+		RevisionNumber    uint64
+		ValidProofValues  []types.Currency
+		MissedProofValues []types.Currency
+	}
+
+	// RPCWriteAction is a generic Write action. The meaning of each field
+	// depends on the Type of the action.
+	RPCWriteAction struct {
+		Type types.Specifier
+		A, B uint64
+		Data []byte
+	}
+
+	// RPCWriteMerkleProof contains the optional Merkle proof for response data
+	// for the Write RPC.
+	RPCWriteMerkleProof struct {
+		OldSubtreeHashes []types.Hash256
+		OldLeafHashes    []types.Hash256
+		NewMerkleRoot    types.Hash256
+	}
+
+	// RPCWriteResponse contains the response data for the Write RPC.
+	RPCWriteResponse struct {
+		Signature types.Signature
+	}
+)
+
+// RPCSectorRootsCost returns the price of a SectorRoots RPC.
+func RPCSectorRootsCost(settings HostSettings, n uint64) types.Currency {
+	return settings.BaseRPCPrice.
+		Add(settings.DownloadBandwidthPrice.Mul64(n * 32)).  // roots
+		Add(settings.DownloadBandwidthPrice.Mul64(128 * 32)) // proof
+}
+
+// RPCReadCost returns the price of a Read RPC.
+func RPCReadCost(settings HostSettings, sections []RPCReadRequestSection) types.Currency {
+	sectorAccessPrice := settings.SectorAccessPrice.Mul64(uint64(len(sections)))
+	var bandwidth uint64
+	for _, sec := range sections {
+		bandwidth += sec.Length
+		bandwidth += 2 * uint64(bits.Len64(LeavesPerSector)) * 32 // proof
+	}
+	if bandwidth < minMessageSize {
+		bandwidth = minMessageSize
+	}
+	bandwidthPrice := settings.DownloadBandwidthPrice.Mul64(bandwidth)
+	return settings.BaseRPCPrice.Add(sectorAccessPrice).Add(bandwidthPrice)
+}
+
+// RPCAppendCost returns the price and collateral of a Write RPC with a single
+// append operation.
+func RPCAppendCost(settings HostSettings, storageDuration uint64) (price, collateral types.Currency) {
+	price = settings.BaseRPCPrice.
+		Add(settings.StoragePrice.Mul64(SectorSize).Mul64(storageDuration)).
+		Add(settings.UploadBandwidthPrice.Mul64(SectorSize)).
+		Add(settings.DownloadBandwidthPrice.Mul64(128 * 32)) // proof
+	collateral = settings.Collateral.Mul64(SectorSize).Mul64(storageDuration)
+	// add some leeway to reduce chance of host rejecting
+	price = price.Mul64(125).Div64(100)
+	collateral = collateral.Mul64(95).Div64(100)
+	return
+}
+
+// RPCDeleteCost returns the price of a Write RPC that deletes n sectors.
+func RPCDeleteCost(settings HostSettings, n int) types.Currency {
+	price := settings.BaseRPCPrice.
+		Add(settings.DownloadBandwidthPrice.Mul64(128 * 32)) // proof
+	return price.Mul64(105).Div64(100)
+}

--- a/rhp/v2/testing.go
+++ b/rhp/v2/testing.go
@@ -1,0 +1,23 @@
+//go:build testing
+
+package rhp
+
+import (
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+)
+
+// SectorSize is the size of one sector in bytes.
+const SectorSize = 1 << 12 // 4 KiB
+
+func contractTax(fc types.FileContract) types.Currency {
+	// NOTE: siad uses different hardfork heights when -tags=testing is set,
+	// so we have to alter cs accordingly.
+	// TODO: remove this
+	cs := consensus.State{Index: types.ChainIndex{Height: fc.WindowStart}}
+	switch {
+	case cs.Index.Height >= 10:
+		cs.Index.Height = 21000
+	}
+	return cs.FileContractTax(fc)
+}

--- a/rhp/v2/transport.go
+++ b/rhp/v2/transport.go
@@ -1,0 +1,557 @@
+package rhp
+
+import (
+	"bytes"
+	"crypto/cipher"
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"go.sia.tech/core/types"
+	"golang.org/x/crypto/blake2b"
+	"golang.org/x/crypto/chacha20"
+	"golang.org/x/crypto/chacha20poly1305"
+	"golang.org/x/crypto/curve25519"
+	"golang.org/x/crypto/poly1305"
+	"lukechampine.com/frand"
+)
+
+// minMessageSize is the minimum size of an RPC message. If an encoded message
+// would be smaller than minMessageSize, the sender MAY pad it with random data.
+// This hinders traffic analysis by obscuring the true sizes of messages.
+const minMessageSize = 4096
+
+var (
+	// Handshake specifiers
+	loopEnter = types.NewSpecifier("LoopEnter")
+	loopExit  = types.NewSpecifier("LoopExit")
+
+	// RPC ciphers
+	cipherChaCha20Poly1305 = types.NewSpecifier("ChaCha20Poly1305")
+	cipherNoOverlap        = types.NewSpecifier("NoOverlap")
+
+	// ErrRenterClosed is returned by (*Transport).ReadID when the renter sends the
+	// Transport termination signal.
+	ErrRenterClosed = errors.New("renter has terminated Transport")
+)
+
+// wrapResponseErr formats RPC response errors nicely, wrapping them in either
+// readCtx or rejectCtx depending on whether we encountered an I/O error or the
+// host sent an explicit error message.
+func wrapResponseErr(err error, readCtx, rejectCtx string) error {
+	if errors.As(err, new(*RPCError)) {
+		return fmt.Errorf("%s: %w", rejectCtx, err)
+	}
+	if err != nil {
+		return fmt.Errorf("%s: %w", readCtx, err)
+	}
+	return nil
+}
+
+func generateX25519KeyPair() (xsk []byte, xpk [32]byte) {
+	xsk = frand.Bytes(32)
+	pk, _ := curve25519.X25519(xsk, curve25519.Basepoint)
+	copy(xpk[:], pk)
+	return
+}
+
+func deriveSharedSecret(xsk []byte, xpk [32]byte) ([]byte, error) {
+	return curve25519.X25519(xsk, xpk[:])
+}
+
+// An RPCError may be sent instead of a response object to any RPC.
+type RPCError struct {
+	Type        types.Specifier
+	Data        []byte // structure depends on Type
+	Description string // human-readable error string
+}
+
+// Error implements the error interface.
+func (e *RPCError) Error() string {
+	return e.Description
+}
+
+// Is reports whether this error matches target.
+func (e *RPCError) Is(target error) bool {
+	return strings.Contains(e.Description, target.Error())
+}
+
+// helper type for encoding and decoding RPC response messages, which can
+// represent either valid data or an error.
+type rpcResponse struct {
+	err  *RPCError
+	data ProtocolObject
+}
+
+// A Transport facilitates the exchange of RPCs via the renter-host protocol,
+// version 2.
+type Transport struct {
+	conn      net.Conn
+	aead      cipher.AEAD
+	key       []byte // for RawResponse
+	inbuf     bytes.Buffer
+	outbuf    bytes.Buffer
+	challenge [16]byte
+	isRenter  bool
+	hostKey   types.PublicKey
+
+	mu     sync.Mutex
+	r, w   uint64
+	err    error // set when Transport is prematurely closed
+	closed bool
+}
+
+func (t *Transport) setErr(err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if err != nil && t.err == nil {
+		if _, ok := err.(net.Error); !ok {
+			t.conn.Close()
+			t.err = err
+		}
+	}
+}
+
+// HostKey returns the host's public key.
+func (t *Transport) HostKey() types.PublicKey { return t.hostKey }
+
+// BytesRead returns the number of bytes read from the underlying connection.
+func (t *Transport) BytesRead() uint64 { return atomic.LoadUint64(&t.r) }
+
+// BytesWritten returns the number of bytes written to the underlying connection.
+func (t *Transport) BytesWritten() uint64 { return atomic.LoadUint64(&t.w) }
+
+// PrematureCloseErr returns the error that resulted in the Transport being closed
+// prematurely.
+func (t *Transport) PrematureCloseErr() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.err
+}
+
+// IsClosed returns whether the Transport is closed. Check PrematureCloseErr to
+// determine whether the Transport was closed gracefully.
+func (t *Transport) IsClosed() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.closed || t.err != nil
+}
+
+func hashChallenge(challenge [16]byte) [32]byte {
+	c := make([]byte, 32)
+	copy(c[:16], "challenge")
+	copy(c[16:], challenge[:])
+	return blake2b.Sum256(c)
+}
+
+// SetChallenge sets the current Transport challenge.
+func (t *Transport) SetChallenge(challenge [16]byte) {
+	t.challenge = challenge
+}
+
+// SignChallenge signs the current Transport challenge.
+func (t *Transport) SignChallenge(priv types.PrivateKey) types.Signature {
+	return priv.SignHash(hashChallenge(t.challenge))
+}
+
+// VerifyChallenge verifies a challenge signature and returns a new challenge.
+func (t *Transport) VerifyChallenge(sig types.Signature, pubkey types.PublicKey) ([16]byte, bool) {
+	ok := pubkey.VerifyHash(hashChallenge(t.challenge), sig)
+	if !ok {
+		return [16]byte{}, false
+	}
+	t.challenge = frand.Entropy128()
+	return t.challenge, true
+}
+
+func (t *Transport) writeMessage(obj ProtocolObject) error {
+	if err := t.PrematureCloseErr(); err != nil {
+		return err
+	}
+	nonce := make([]byte, 32)[:t.aead.NonceSize()] // avoid heap alloc
+	frand.Read(nonce)
+
+	t.outbuf.Reset()
+	t.outbuf.Grow(minMessageSize)
+	e := types.NewEncoder(&t.outbuf)
+	e.WritePrefix(0) // placeholder
+	e.Write(nonce)
+	obj.EncodeTo(e)
+	e.Flush()
+
+	// overwrite message length
+	msgSize := t.outbuf.Len() + t.aead.Overhead()
+	if msgSize < minMessageSize {
+		msgSize = minMessageSize
+	}
+	t.outbuf.Grow(t.aead.Overhead())
+	msg := t.outbuf.Bytes()[:msgSize]
+	binary.LittleEndian.PutUint64(msg[:8], uint64(msgSize-8))
+
+	// encrypt the object in-place
+	msgNonce := msg[8:][:len(nonce)]
+	payload := msg[8+len(nonce) : msgSize-t.aead.Overhead()]
+	t.aead.Seal(payload[:0], msgNonce, payload, nil)
+
+	n, err := t.conn.Write(msg)
+	atomic.AddUint64(&t.w, uint64(n))
+	t.setErr(err)
+	return err
+}
+
+func (t *Transport) readMessage(obj ProtocolObject, maxLen uint64) error {
+	if err := t.PrematureCloseErr(); err != nil {
+		return err
+	}
+	if maxLen < minMessageSize {
+		maxLen = minMessageSize
+	}
+	d := types.NewDecoder(io.LimitedReader{R: t.conn, N: int64(8 + maxLen)})
+	msgSize := d.ReadUint64()
+	if d.Err() != nil {
+		return d.Err()
+	} else if msgSize > maxLen {
+		return fmt.Errorf("message size (%v bytes) exceeds maxLen of %v bytes", msgSize, maxLen)
+	} else if msgSize < uint64(t.aead.NonceSize()+t.aead.Overhead()) {
+		return fmt.Errorf("message size (%v bytes) is too small (nonce + MAC is %v bytes)", msgSize, t.aead.NonceSize()+t.aead.Overhead())
+	}
+	t.inbuf.Reset()
+	t.inbuf.Grow(int(msgSize))
+	buf := t.inbuf.Bytes()[:msgSize]
+	d.Read(buf)
+	if d.Err() != nil {
+		return d.Err()
+	}
+	atomic.AddUint64(&t.r, uint64(8+msgSize))
+
+	nonce := buf[:t.aead.NonceSize()]
+	paddedPayload := buf[t.aead.NonceSize():]
+	plaintext, err := t.aead.Open(paddedPayload[:0], nonce, paddedPayload, nil)
+	if err != nil {
+		t.setErr(err) // not an I/O error, but still fatal
+		return err
+	}
+	d = types.NewBufDecoder(plaintext)
+	obj.DecodeFrom(d)
+	return d.Err()
+}
+
+// WriteRequest sends an encrypted RPC request, comprising an RPC ID and a
+// request object.
+func (t *Transport) WriteRequest(rpcID types.Specifier, req ProtocolObject) error {
+	if err := t.writeMessage(&rpcID); err != nil {
+		return fmt.Errorf("WriteRequestID: %w", err)
+	}
+	if req != nil {
+		if err := t.writeMessage(req); err != nil {
+			return fmt.Errorf("WriteRequest: %w", err)
+		}
+	}
+	return nil
+}
+
+// ReadID reads an RPC request ID. If the renter sends the Transport termination
+// signal, ReadID returns ErrRenterClosed.
+func (t *Transport) ReadID() (rpcID types.Specifier, err error) {
+	defer wrapErr(&err, "ReadID")
+	err = t.readMessage(&rpcID, minMessageSize)
+	if rpcID == loopExit {
+		err = ErrRenterClosed
+	}
+	return
+}
+
+// ReadRequest reads an RPC request using the new loop protocol.
+func (t *Transport) ReadRequest(req ProtocolObject, maxLen uint64) (err error) {
+	defer wrapErr(&err, "ReadRequest")
+	return t.readMessage(req, maxLen)
+}
+
+// WriteResponse writes an RPC response object.
+func (t *Transport) WriteResponse(resp ProtocolObject) (e error) {
+	defer wrapErr(&e, "WriteResponse")
+	return t.writeMessage(&rpcResponse{nil, resp})
+}
+
+// WriteResponseErr writes an error. If err is an *RPCError, it is sent
+// directly; otherwise, a generic RPCError is created from err's Error string.
+func (t *Transport) WriteResponseErr(err error) (e error) {
+	defer wrapErr(&e, "WriteResponseErr")
+	re, ok := err.(*RPCError)
+	if err != nil && !ok {
+		re = &RPCError{Description: err.Error()}
+	}
+	return t.writeMessage(&rpcResponse{re, nil})
+}
+
+// ReadResponse reads an RPC response. If the response is an error, it is
+// returned directly.
+func (t *Transport) ReadResponse(resp ProtocolObject, maxLen uint64) (err error) {
+	defer wrapErr(&err, "ReadResponse")
+	rr := rpcResponse{nil, resp}
+	if err := t.readMessage(&rr, maxLen); err != nil {
+		return err
+	} else if rr.err != nil {
+		return rr.err
+	}
+	return nil
+}
+
+// Call is a helper method that writes a request and then reads a response.
+func (t *Transport) Call(rpcID types.Specifier, req, resp ProtocolObject) error {
+	if err := t.WriteRequest(rpcID, req); err != nil {
+		return err
+	}
+	// use a maxlen large enough for all RPCs except Read, Write, and
+	// SectorRoots (which don't use Call anyway)
+	err := t.ReadResponse(resp, 4096)
+	return wrapResponseErr(err, fmt.Sprintf("couldn't read %v response", rpcID), fmt.Sprintf("host rejected %v request", rpcID))
+}
+
+// A ResponseReader contains an unencrypted, unauthenticated RPC response
+// message.
+type ResponseReader struct {
+	msgR   io.Reader
+	tagR   io.Reader
+	mac    *poly1305.MAC
+	clen   uint64
+	setErr func(error)
+}
+
+// Read implements io.Reader.
+func (rr *ResponseReader) Read(p []byte) (int, error) {
+	n, err := rr.msgR.Read(p)
+	if err != io.EOF {
+		// EOF is expected, since this is a limited reader
+		rr.setErr(err)
+	}
+	return n, err
+}
+
+// VerifyTag verifies the authentication tag appended to the message. VerifyTag
+// must be called after Read returns io.EOF, and the message must be discarded
+// if VerifyTag returns a non-nil error.
+func (rr *ResponseReader) VerifyTag() error {
+	// the caller may not have consumed the full message (e.g. if it was padded
+	// to minMessageSize), so make sure the whole thing is written to the MAC
+	if _, err := io.Copy(io.Discard, rr); err != nil {
+		return err
+	}
+
+	var tag [poly1305.TagSize]byte
+	if _, err := io.ReadFull(rr.tagR, tag[:]); err != nil {
+		rr.setErr(err)
+		return err
+	}
+	// MAC is padded to 16 bytes, and covers the length of AD (0 in this case)
+	// and ciphertext
+	tail := make([]byte, 0, 32)[:32-(rr.clen%16)]
+	binary.LittleEndian.PutUint64(tail[len(tail)-8:], rr.clen)
+	rr.mac.Write(tail)
+	var ourTag [poly1305.TagSize]byte
+	rr.mac.Sum(ourTag[:0])
+	if subtle.ConstantTimeCompare(tag[:], ourTag[:]) != 1 {
+		err := errors.New("chacha20poly1305: message authentication failed")
+		rr.setErr(err) // not an I/O error, but still fatal
+		return err
+	}
+	return nil
+}
+
+// RawResponse returns a stream containing the (unencrypted, unauthenticated)
+// content of the next message. The Reader must be fully consumed by the caller,
+// after which the caller should call VerifyTag to authenticate the message. If
+// the response was an RPCError, it is authenticated and returned immediately.
+func (t *Transport) RawResponse(maxLen uint64) (*ResponseReader, error) {
+	if maxLen < minMessageSize {
+		maxLen = minMessageSize
+	}
+	d := types.NewDecoder(io.LimitedReader{R: t.conn, N: int64(8 + chacha20.NonceSize)})
+	msgSize := d.ReadUint64()
+	if msgSize > maxLen {
+		return nil, fmt.Errorf("message size (%v bytes) exceeds maxLen of %v bytes", msgSize, maxLen)
+	} else if msgSize < uint64(chacha20.NonceSize+poly1305.TagSize) {
+		return nil, fmt.Errorf("message size (%v bytes) is too small (nonce + MAC is %v bytes)", msgSize, chacha20.NonceSize+poly1305.TagSize)
+	}
+	msgSize -= uint64(chacha20.NonceSize + poly1305.TagSize)
+
+	nonce := make([]byte, 32)[:chacha20.NonceSize] // avoid heap allocation
+	d.Read(nonce)
+
+	// construct reader
+	c, _ := chacha20.NewUnauthenticatedCipher(t.key, nonce)
+	var polyKey [32]byte
+	c.XORKeyStream(polyKey[:], polyKey[:])
+	mac := poly1305.New(&polyKey)
+	c.SetCounter(1)
+	rr := &ResponseReader{
+		msgR: cipher.StreamReader{
+			R: io.TeeReader(io.LimitReader(t.conn, int64(msgSize)), mac),
+			S: c,
+		},
+		tagR:   io.LimitReader(t.conn, poly1305.TagSize),
+		mac:    mac,
+		clen:   msgSize,
+		setErr: t.setErr,
+	}
+
+	// check if response is an RPCError
+	d = types.NewDecoder(io.LimitedReader{R: rr, N: int64(msgSize)})
+	if isErr := d.ReadBool(); isErr {
+		err := new(RPCError)
+		err.DecodeFrom(d)
+		if err := rr.VerifyTag(); err != nil {
+			return nil, err
+		}
+		return nil, err
+	}
+	// not an error; pass rest of stream to caller
+	return rr, nil
+}
+
+// Close gracefully terminates the RPC loop and closes the connection.
+func (t *Transport) Close() (err error) {
+	defer wrapErr(&err, "Close")
+	if t.IsClosed() {
+		return nil
+	}
+	t.mu.Lock()
+	t.closed = true
+	t.mu.Unlock()
+	if t.isRenter {
+		t.writeMessage(&loopExit)
+	}
+	return t.conn.Close()
+}
+
+func hashKeys(k1, k2 [32]byte) types.Hash256 {
+	return blake2b.Sum256(append(append(make([]byte, 0, len(k1)+len(k2)), k1[:]...), k2[:]...))
+}
+
+// NewHostTransport conducts the hosts's half of the renter-host protocol
+// handshake, returning a Transport that can be used to handle RPC requests.
+func NewHostTransport(conn net.Conn, priv types.PrivateKey) (_ *Transport, err error) {
+	defer wrapErr(&err, "NewHostTransport")
+	e := types.NewEncoder(conn)
+	d := types.NewDecoder(io.LimitedReader{R: conn, N: 1024})
+
+	var req loopKeyExchangeRequest
+	req.DecodeFrom(d)
+	if err := d.Err(); err != nil {
+		return nil, err
+	}
+
+	var supportsChaCha bool
+	for _, c := range req.Ciphers {
+		if c == cipherChaCha20Poly1305 {
+			supportsChaCha = true
+		}
+	}
+	if !supportsChaCha {
+		(&loopKeyExchangeResponse{Cipher: cipherNoOverlap}).EncodeTo(e)
+		return nil, errors.New("no supported ciphers")
+	}
+
+	xsk, xpk := generateX25519KeyPair()
+	h := hashKeys(req.PublicKey, xpk)
+	resp := loopKeyExchangeResponse{
+		Cipher:    cipherChaCha20Poly1305,
+		PublicKey: xpk,
+		Signature: priv.SignHash(h),
+	}
+	resp.EncodeTo(e)
+	if err := e.Flush(); err != nil {
+		return nil, err
+	}
+
+	cipherKey, err := deriveSharedSecret(xsk, req.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	aead, _ := chacha20poly1305.New(cipherKey) // no error possible
+	t := &Transport{
+		conn:      conn,
+		aead:      aead,
+		key:       cipherKey,
+		challenge: frand.Entropy128(),
+		isRenter:  false,
+		hostKey:   priv.PublicKey(),
+	}
+	// hack: cast challenge to Specifier to make it a ProtocolObject
+	if err := t.writeMessage((*types.Specifier)(&t.challenge)); err != nil {
+		return nil, err
+	}
+	return t, nil
+}
+
+// NewRenterTransport conducts the renter's half of the renter-host protocol
+// handshake, returning a Transport that can be used to make RPC requests.
+func NewRenterTransport(conn net.Conn, pub types.PublicKey) (_ *Transport, err error) {
+	defer wrapErr(&err, "NewRenterTransport")
+	e := types.NewEncoder(conn)
+	d := types.NewDecoder(io.LimitedReader{R: conn, N: 1024})
+
+	xsk, xpk := generateX25519KeyPair()
+	req := &loopKeyExchangeRequest{
+		PublicKey: xpk,
+		Ciphers:   []types.Specifier{cipherChaCha20Poly1305},
+	}
+	req.EncodeTo(e)
+	if err := e.Flush(); err != nil {
+		return nil, fmt.Errorf("couldn't write handshake: %w", err)
+	}
+	var resp loopKeyExchangeResponse
+	resp.DecodeFrom(d)
+	if err := d.Err(); err != nil {
+		return nil, fmt.Errorf("couldn't read host's handshake: %w", err)
+	}
+	// validate the signature before doing anything else
+	h := hashKeys(req.PublicKey, resp.PublicKey)
+	if !pub.VerifyHash(h, resp.Signature) {
+		return nil, errors.New("host's handshake signature was invalid")
+	}
+	if resp.Cipher == cipherNoOverlap {
+		return nil, errors.New("host does not support any of our proposed ciphers")
+	} else if resp.Cipher != cipherChaCha20Poly1305 {
+		return nil, errors.New("host selected unsupported cipher")
+	}
+
+	cipherKey, err := deriveSharedSecret(xsk, resp.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	aead, _ := chacha20poly1305.New(cipherKey) // no error possible
+	t := &Transport{
+		conn:     conn,
+		aead:     aead,
+		key:      cipherKey,
+		isRenter: true,
+		hostKey:  pub,
+	}
+	// hack: cast challenge to Specifier to make it a ProtocolObject
+	if err := t.readMessage((*types.Specifier)(&t.challenge), minMessageSize); err != nil {
+		fmt.Println("boooooo")
+		return nil, err
+	}
+	return t, nil
+}
+
+// Handshake objects
+type (
+	loopKeyExchangeRequest struct {
+		PublicKey [32]byte
+		Ciphers   []types.Specifier
+	}
+
+	loopKeyExchangeResponse struct {
+		PublicKey [32]byte
+		Signature types.Signature
+		Cipher    types.Specifier
+	}
+)

--- a/rhp/v3/encoding.go
+++ b/rhp/v3/encoding.go
@@ -1,0 +1,392 @@
+package rhp
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/core/types"
+)
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCError) EncodeTo(e *types.Encoder) {
+	r.Type.EncodeTo(e)
+	e.WriteBytes(r.Data)
+	e.WriteString(r.Description)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCError) DecodeFrom(d *types.Decoder) {
+	r.Type.DecodeFrom(d)
+	r.Data = d.ReadBytes()
+	r.Description = d.ReadString()
+}
+
+// EncodeTo implements ProtocolObject.
+func (s *SettingsID) EncodeTo(e *types.Encoder) { e.Write(s[:]) }
+
+// DecodeFrom implements ProtocolObject.
+func (s *SettingsID) DecodeFrom(d *types.Decoder) { d.Read(s[:]) }
+
+// String implements fmt.Stringer.
+func (s SettingsID) String() string {
+	return hex.EncodeToString(s[:])
+}
+
+// LoadString loads the unique id from the given string.
+func (s *SettingsID) LoadString(input string) error {
+	if len(input) != len(s)*2 {
+		return errors.New("incorrect length")
+	}
+	uidBytes, err := hex.DecodeString(input)
+	if err != nil {
+		return errors.New("could not unmarshal hash: " + err.Error())
+	}
+	copy(s[:], uidBytes)
+	return nil
+}
+
+// MarshalJSON marshals an id as a hex string.
+func (s SettingsID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// UnmarshalJSON decodes the json hex string of the id.
+func (s *SettingsID) UnmarshalJSON(b []byte) error {
+	if len(b) != len(SettingsID{})*2+2 {
+		return errors.New("incorrect length")
+	}
+	return s.LoadString(string(bytes.Trim(b, `"`)))
+}
+
+// EncodeTo implements ProtocolObject.
+func (resp *rpcResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBool(resp.err != nil)
+	if resp.err != nil {
+		resp.err.EncodeTo(e)
+		return
+	}
+	resp.data.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (resp *rpcResponse) DecodeFrom(d *types.Decoder) {
+	if d.ReadBool() {
+		resp.err = new(RPCError)
+		resp.err.DecodeFrom(d)
+		return
+	}
+	resp.data.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (a *Account) EncodeTo(e *types.Encoder) {
+	var uk types.UnlockKey
+	if *a != ZeroAccount {
+		uk.Algorithm = types.SpecifierEd25519
+		uk.Key = a[:]
+	}
+	uk.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (a *Account) DecodeFrom(d *types.Decoder) {
+	var spk types.UnlockKey
+	spk.DecodeFrom(d)
+	if spk.Algorithm == (types.Specifier{}) && len(spk.Key) == 0 {
+		*a = ZeroAccount
+		return
+	} else if spk.Algorithm != types.SpecifierEd25519 {
+		d.SetErr(fmt.Errorf("unsupported signature algorithm: %v", spk.Algorithm))
+		return
+	}
+	copy(a[:], spk.Key)
+}
+
+// MarshalJSON implements json.Marshaler.
+func (a Account) MarshalJSON() ([]byte, error) {
+	return types.PublicKey(a).MarshalJSON()
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (a *Account) UnmarshalJSON(b []byte) error {
+	return (*types.PublicKey)(a).UnmarshalJSON(b)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *PayByEphemeralAccountRequest) EncodeTo(e *types.Encoder) {
+	r.Account.EncodeTo(e)
+	e.WriteUint64(r.Expiry)
+	r.Amount.EncodeTo(e)
+	e.Write(r.Nonce[:])
+	r.Signature.EncodeTo(e)
+	e.WriteUint64(uint64(r.Priority))
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *PayByEphemeralAccountRequest) DecodeFrom(d *types.Decoder) {
+	r.Account.DecodeFrom(d)
+	r.Expiry = d.ReadUint64()
+	r.Amount.DecodeFrom(d)
+	d.Read(r.Nonce[:])
+	r.Signature.DecodeFrom(d)
+	r.Priority = int64(d.ReadUint64())
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *PayByContractRequest) EncodeTo(e *types.Encoder) {
+	r.ContractID.EncodeTo(e)
+	e.WriteUint64(r.RevisionNumber)
+	e.WritePrefix(len(r.ValidProofValues))
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].EncodeTo(e)
+	}
+	e.WritePrefix(len(r.MissedProofValues))
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].EncodeTo(e)
+	}
+	r.RefundAccount.EncodeTo(e)
+	e.WriteBytes(r.Signature[:])
+	r.HostSignature.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *PayByContractRequest) DecodeFrom(d *types.Decoder) {
+	r.ContractID.DecodeFrom(d)
+	r.RevisionNumber = d.ReadUint64()
+	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].DecodeFrom(d)
+	}
+	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].DecodeFrom(d)
+	}
+	r.RefundAccount.DecodeFrom(d)
+	copy(r.Signature[:], d.ReadBytes())
+	r.HostSignature.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *PaymentResponse) EncodeTo(e *types.Encoder) {
+	r.Signature.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *PaymentResponse) DecodeFrom(d *types.Decoder) {
+	r.Signature.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (RPCPriceTableResponse) EncodeTo(e *types.Encoder) {}
+
+// DecodeFrom implements ProtocolObject.
+func (RPCPriceTableResponse) DecodeFrom(d *types.Decoder) {}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCUpdatePriceTableResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBytes(r.PriceTableJSON)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCUpdatePriceTableResponse) DecodeFrom(d *types.Decoder) {
+	r.PriceTableJSON = d.ReadBytes()
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCFundAccountRequest) EncodeTo(e *types.Encoder) {
+	r.Account.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCFundAccountRequest) DecodeFrom(d *types.Decoder) {
+	r.Account.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *FundAccountReceipt) EncodeTo(e *types.Encoder) {
+	r.Host.EncodeTo(e)
+	r.Account.EncodeTo(e)
+	r.Amount.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *FundAccountReceipt) DecodeFrom(d *types.Decoder) {
+	r.Host.DecodeFrom(d)
+	r.Account.DecodeFrom(d)
+	r.Amount.DecodeFrom(d)
+	r.Timestamp = d.ReadTime()
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCFundAccountResponse) EncodeTo(e *types.Encoder) {
+	r.Balance.EncodeTo(e)
+	r.Receipt.EncodeTo(e)
+	r.Signature.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCFundAccountResponse) DecodeFrom(d *types.Decoder) {
+	r.Balance.DecodeFrom(d)
+	r.Receipt.DecodeFrom(d)
+	r.Signature.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCAccountBalanceRequest) EncodeTo(e *types.Encoder) {
+	r.Account.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCAccountBalanceRequest) DecodeFrom(d *types.Decoder) {
+	r.Account.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCAccountBalanceResponse) EncodeTo(e *types.Encoder) {
+	r.Balance.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCAccountBalanceResponse) DecodeFrom(d *types.Decoder) {
+	r.Balance.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCExecuteProgramRequest) EncodeTo(e *types.Encoder) {
+	r.FileContractID.EncodeTo(e)
+	e.WritePrefix(len(r.Program))
+	for _, instr := range r.Program {
+		instructionID(instr).EncodeTo(e)
+		instr.EncodeTo(e)
+	}
+	e.WriteBytes(r.ProgramData)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCExecuteProgramRequest) DecodeFrom(d *types.Decoder) {
+	r.FileContractID.DecodeFrom(d)
+	r.Program = make([]Instruction, d.ReadPrefix())
+	for i := range r.Program {
+		var id types.Specifier
+		id.DecodeFrom(d)
+		r.Program[i] = instructionForID(id, d.ReadUint64())
+		if r.Program[i] == nil {
+			d.SetErr(fmt.Errorf("unrecognized instruction id: %q", id))
+			return
+		}
+		if r.Program[i].DecodeFrom(d); d.Err() != nil {
+			return
+		}
+	}
+	r.ProgramData = d.ReadBytes()
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCExecuteProgramResponse) EncodeTo(e *types.Encoder) {
+	r.AdditionalCollateral.EncodeTo(e)
+	e.WriteUint64(r.OutputLength)
+	r.NewMerkleRoot.EncodeTo(e)
+	e.WriteUint64(r.NewSize)
+	e.WritePrefix(len(r.Proof))
+	for i := range r.Proof {
+		r.Proof[i].EncodeTo(e)
+	}
+	var errString string
+	if r.Error != nil {
+		errString = r.Error.Error()
+	}
+	e.WriteString(errString)
+	r.TotalCost.EncodeTo(e)
+	r.FailureRefund.EncodeTo(e)
+	e.Write(r.Output)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCExecuteProgramResponse) DecodeFrom(d *types.Decoder) {
+	r.AdditionalCollateral.DecodeFrom(d)
+	r.OutputLength = d.ReadUint64()
+	r.NewMerkleRoot.DecodeFrom(d)
+	r.NewSize = d.ReadUint64()
+	r.Proof = make([]types.Hash256, d.ReadPrefix())
+	for i := range r.Proof {
+		r.Proof[i].DecodeFrom(d)
+	}
+	if s := d.ReadString(); s != "" {
+		r.Error = errors.New(s)
+	}
+	r.TotalCost.DecodeFrom(d)
+	r.FailureRefund.DecodeFrom(d)
+	r.Output = make([]byte, r.OutputLength)
+	d.Read(r.Output)
+}
+
+func instructionID(instr Instruction) types.Specifier {
+	switch instr.(type) {
+	case *InstrAppendSector:
+		return idInstrAppendSector
+	case *InstrAppendSectorRoot:
+		return idInstrAppendSectorRoot
+	case *InstrDropSectors:
+		return idInstrDropSectors
+	case *InstrHasSector:
+		return idInstrHasSector
+	case *InstrStoreSector:
+		return idInstrStoreSector
+	case *InstrUpdateSector:
+		return idInstrUpdateSector
+	case *InstrReadOffset:
+		return idInstrReadOffset
+	case *InstrReadSector:
+		return idInstrReadSector
+	case *InstrRevision:
+		return idInstrContractRevision
+	case *InstrSwapSector:
+		return idInstrSwapSector
+	case *InstrUpdateRegistry, *InstrUpdateRegistryNoType:
+		return idInstrUpdateRegistry
+	case *InstrReadRegistry, *InstrReadRegistryNoVersion:
+		return idInstrReadRegistry
+	default:
+		panic(fmt.Sprintf("unhandled instruction type: %T", instr))
+	}
+}
+
+func instructionForID(id types.Specifier, argsLen uint64) Instruction {
+	switch id {
+	case idInstrAppendSector:
+		return new(InstrAppendSector)
+	case idInstrAppendSectorRoot:
+		return new(InstrAppendSectorRoot)
+	case idInstrDropSectors:
+		return new(InstrDropSectors)
+	case idInstrHasSector:
+		return new(InstrHasSector)
+	case idInstrStoreSector:
+		return new(InstrStoreSector)
+	case idInstrUpdateSector:
+		return new(InstrUpdateSector)
+	case idInstrReadOffset:
+		return new(InstrReadOffset)
+	case idInstrReadSector:
+		return new(InstrReadSector)
+	case idInstrContractRevision:
+		return new(InstrRevision)
+	case idInstrSwapSector:
+		return new(InstrSwapSector)
+	case idInstrUpdateRegistry:
+		if argsLen == 56 { // special handling for pre-1.5.7 update registry instructions
+			return new(InstrUpdateRegistryNoType)
+		}
+		return new(InstrUpdateRegistry)
+	case idInstrReadRegistry:
+		if argsLen == 24 { // special handling for pre-1.5.7 read registry instructions
+			return new(InstrReadRegistryNoVersion)
+		}
+		return new(InstrReadRegistry)
+	default:
+		return nil
+	}
+}

--- a/rhp/v3/program.go
+++ b/rhp/v3/program.go
@@ -1,0 +1,444 @@
+package rhp
+
+import (
+	"go.sia.tech/core/types"
+)
+
+type (
+	// An Instruction is an MDM instruction.
+	Instruction interface {
+		ProtocolObject
+		RequiresContract() bool
+		RequiresFinalization() bool
+	}
+
+	// InstrAppendSector stores a sector on the host and appends its Merkle root
+	// to a contract.
+	InstrAppendSector struct {
+		SectorDataOffset uint64
+		ProofRequired    bool
+	}
+
+	// InstrAppendSectorRoot appends a sector root to a contract
+	InstrAppendSectorRoot struct {
+		MerkleRootOffset uint64
+		ProofRequired    bool
+	}
+
+	// InstrDropSectors removes the last n sectors from a contract and deletes
+	// them from the host.
+	InstrDropSectors struct {
+		SectorCountOffset uint64
+		ProofRequired     bool
+	}
+
+	// InstrHasSector checks if a sector is present on the host.
+	InstrHasSector struct {
+		MerkleRootOffset uint64
+	}
+
+	// InstrReadOffset reads a range of bytes from an offset in the contract.
+	InstrReadOffset struct {
+		LengthOffset  uint64
+		OffsetOffset  uint64
+		ProofRequired bool
+	}
+
+	// InstrReadSector reads a range of bytes from a sector.
+	InstrReadSector struct {
+		LengthOffset     uint64
+		OffsetOffset     uint64
+		MerkleRootOffset uint64
+		ProofRequired    bool
+	}
+
+	// InstrSwapSector swaps two sectors in a contract
+	InstrSwapSector struct {
+		Sector1Offset uint64
+		Sector2Offset uint64
+		ProofRequired bool
+	}
+
+	// InstrUpdateSector overwrites data in an existing sector.
+	InstrUpdateSector struct {
+		Offset        uint64
+		Length        uint64
+		DataOffset    uint64
+		ProofRequired bool
+	}
+
+	// InstrStoreSector temporarily stores a sector on the host. The sector is
+	// not associated with any contract and collateral is not risked.
+	InstrStoreSector struct {
+		DataOffset uint64
+		Duration   uint64
+	}
+
+	// InstrRevision returns the latest revision of a contract
+	InstrRevision struct{}
+
+	// InstrReadRegistry reads a value from the registry
+	InstrReadRegistry struct {
+		PublicKeyOffset uint64
+		PublicKeyLength uint64
+		TweakOffset     uint64
+		Version         uint8
+	}
+
+	// InstrReadRegistryNoVersion reads a pre-1.5.7 read registry Instruction
+	// without the version byte
+	InstrReadRegistryNoVersion struct {
+		InstrReadRegistry
+	}
+
+	// InstrUpdateRegistry updates a registry value.
+	InstrUpdateRegistry struct {
+		TweakOffset     uint64
+		RevisionOffset  uint64
+		SignatureOffset uint64
+		PublicKeyOffset uint64
+		PublicKeyLength uint64
+		DataOffset      uint64
+		DataLength      uint64
+		EntryType       uint8
+	}
+
+	// InstrUpdateRegistryNoType reads a pre-1.5.7 update registry Instruction
+	// without the entry type byte
+	InstrUpdateRegistryNoType struct {
+		InstrUpdateRegistry
+	}
+)
+
+var (
+	idInstrAppendSector     = types.NewSpecifier("Append")
+	idInstrAppendSectorRoot = types.NewSpecifier("AppendSectorRoot")
+	idInstrDropSectors      = types.NewSpecifier("DropSectors")
+	idInstrHasSector        = types.NewSpecifier("HasSector")
+	idInstrStoreSector      = types.NewSpecifier("StoreSector")
+	idInstrUpdateSector     = types.NewSpecifier("UpdateSector")
+	idInstrReadOffset       = types.NewSpecifier("ReadOffset")
+	idInstrReadSector       = types.NewSpecifier("ReadSector")
+	idInstrContractRevision = types.NewSpecifier("Revision")
+	idInstrSectorRoots      = types.NewSpecifier("SectorRoots")
+	idInstrSwapSector       = types.NewSpecifier("SwapSector")
+	idInstrUpdateRegistry   = types.NewSpecifier("UpdateRegistry")
+	idInstrReadRegistry     = types.NewSpecifier("ReadRegistry")
+	idInstrReadRegistrySID  = types.NewSpecifier("ReadRegistrySID")
+)
+
+// RequiresContract implements Instruction.
+func (i *InstrAppendSector) RequiresContract() bool {
+	return true
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrAppendSector) RequiresFinalization() bool {
+	return true
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrAppendSector) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.SectorDataOffset)
+	e.WriteBool(i.ProofRequired)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrAppendSector) DecodeFrom(d *types.Decoder) {
+	i.SectorDataOffset = d.ReadUint64()
+	i.ProofRequired = d.ReadBool()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrAppendSectorRoot) RequiresContract() bool {
+	return true
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrAppendSectorRoot) RequiresFinalization() bool {
+	return true
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrAppendSectorRoot) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.MerkleRootOffset)
+	e.WriteBool(i.ProofRequired)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrAppendSectorRoot) DecodeFrom(d *types.Decoder) {
+	i.MerkleRootOffset = d.ReadUint64()
+	i.ProofRequired = d.ReadBool()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrDropSectors) RequiresContract() bool {
+	return true
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrDropSectors) RequiresFinalization() bool {
+	return true
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrDropSectors) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.SectorCountOffset)
+	e.WriteBool(i.ProofRequired)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrDropSectors) DecodeFrom(d *types.Decoder) {
+	i.SectorCountOffset = d.ReadUint64()
+	i.ProofRequired = d.ReadBool()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrHasSector) RequiresContract() bool {
+	return false
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrHasSector) RequiresFinalization() bool {
+	return false
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrHasSector) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.MerkleRootOffset)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrHasSector) DecodeFrom(d *types.Decoder) {
+	i.MerkleRootOffset = d.ReadUint64()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrReadOffset) RequiresContract() bool {
+	return true
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrReadOffset) RequiresFinalization() bool {
+	return false
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrReadOffset) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.LengthOffset)
+	e.WriteUint64(i.OffsetOffset)
+	e.WriteBool(i.ProofRequired)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrReadOffset) DecodeFrom(d *types.Decoder) {
+	i.LengthOffset = d.ReadUint64()
+	i.OffsetOffset = d.ReadUint64()
+	i.ProofRequired = d.ReadBool()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrReadSector) RequiresContract() bool {
+	return true
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrReadSector) RequiresFinalization() bool {
+	return false
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrReadSector) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.LengthOffset)
+	e.WriteUint64(i.OffsetOffset)
+	e.WriteUint64(i.MerkleRootOffset)
+	e.WriteBool(i.ProofRequired)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrReadSector) DecodeFrom(d *types.Decoder) {
+	i.LengthOffset = d.ReadUint64()
+	i.OffsetOffset = d.ReadUint64()
+	i.MerkleRootOffset = d.ReadUint64()
+	i.ProofRequired = d.ReadBool()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrSwapSector) RequiresContract() bool {
+	return true
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrSwapSector) RequiresFinalization() bool {
+	return true
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrSwapSector) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.Sector1Offset)
+	e.WriteUint64(i.Sector2Offset)
+	e.WriteBool(i.ProofRequired)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrSwapSector) DecodeFrom(d *types.Decoder) {
+	i.Sector1Offset = d.ReadUint64()
+	i.Sector2Offset = d.ReadUint64()
+	i.ProofRequired = d.ReadBool()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrUpdateSector) RequiresContract() bool {
+	return true
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrUpdateSector) RequiresFinalization() bool {
+	return true
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrUpdateSector) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.Offset)
+	e.WriteUint64(i.Length)
+	e.WriteUint64(i.DataOffset)
+	e.WriteBool(i.ProofRequired)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrUpdateSector) DecodeFrom(d *types.Decoder) {
+	i.Offset = d.ReadUint64()
+	i.Length = d.ReadUint64()
+	i.DataOffset = d.ReadUint64()
+	i.ProofRequired = d.ReadBool()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrStoreSector) RequiresContract() bool {
+	return false
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrStoreSector) RequiresFinalization() bool {
+	return false
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrStoreSector) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.DataOffset)
+	e.WriteUint64(i.Duration)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrStoreSector) DecodeFrom(d *types.Decoder) {
+	i.DataOffset = d.ReadUint64()
+	i.Duration = d.ReadUint64()
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrRevision) RequiresContract() bool {
+	return true
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrRevision) RequiresFinalization() bool {
+	return false
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrRevision) EncodeTo(e *types.Encoder) {
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrRevision) DecodeFrom(d *types.Decoder) {
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrReadRegistry) RequiresContract() bool {
+	return false
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrReadRegistry) RequiresFinalization() bool {
+	return false
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrReadRegistry) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.PublicKeyOffset)
+	e.WriteUint64(i.PublicKeyLength)
+	e.WriteUint64(i.TweakOffset)
+	e.WriteUint8(i.Version)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrReadRegistry) DecodeFrom(d *types.Decoder) {
+	i.PublicKeyOffset = d.ReadUint64()
+	i.PublicKeyLength = d.ReadUint64()
+	i.TweakOffset = d.ReadUint64()
+	i.Version = d.ReadUint8()
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrReadRegistryNoVersion) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.PublicKeyOffset)
+	e.WriteUint64(i.PublicKeyLength)
+	e.WriteUint64(i.TweakOffset)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrReadRegistryNoVersion) DecodeFrom(d *types.Decoder) {
+	i.PublicKeyOffset = d.ReadUint64()
+	i.PublicKeyLength = d.ReadUint64()
+	i.TweakOffset = d.ReadUint64()
+	i.Version = 1
+}
+
+// RequiresContract implements Instruction.
+func (i *InstrUpdateRegistry) RequiresContract() bool {
+	return false
+}
+
+// RequiresFinalization implements Instruction.
+func (i *InstrUpdateRegistry) RequiresFinalization() bool {
+	return false
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrUpdateRegistry) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.TweakOffset)
+	e.WriteUint64(i.RevisionOffset)
+	e.WriteUint64(i.SignatureOffset)
+	e.WriteUint64(i.PublicKeyOffset)
+	e.WriteUint64(i.PublicKeyLength)
+	e.WriteUint8(uint8(i.EntryType))
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrUpdateRegistry) DecodeFrom(d *types.Decoder) {
+	i.TweakOffset = d.ReadUint64()
+	i.RevisionOffset = d.ReadUint64()
+	i.SignatureOffset = d.ReadUint64()
+	i.PublicKeyOffset = d.ReadUint64()
+	i.PublicKeyLength = d.ReadUint64()
+	i.EntryType = d.ReadUint8()
+}
+
+// EncodeTo implements Instruction.
+func (i *InstrUpdateRegistryNoType) EncodeTo(e *types.Encoder) {
+	e.WriteUint64(i.TweakOffset)
+	e.WriteUint64(i.RevisionOffset)
+	e.WriteUint64(i.SignatureOffset)
+	e.WriteUint64(i.PublicKeyOffset)
+	e.WriteUint64(i.PublicKeyLength)
+}
+
+// DecodeFrom implements Instruction.
+func (i *InstrUpdateRegistryNoType) DecodeFrom(d *types.Decoder) {
+	i.TweakOffset = d.ReadUint64()
+	i.RevisionOffset = d.ReadUint64()
+	i.SignatureOffset = d.ReadUint64()
+	i.PublicKeyOffset = d.ReadUint64()
+	i.PublicKeyLength = d.ReadUint64()
+	i.EntryType = EntryTypeArbitrary
+}

--- a/rhp/v3/registry.go
+++ b/rhp/v3/registry.go
@@ -1,0 +1,149 @@
+package rhp
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"go.sia.tech/core/types"
+)
+
+const (
+	// EntryTypeArbitrary is a registry value where all data is arbitrary.
+	EntryTypeArbitrary = iota + 1
+
+	// EntryTypePubKey is a registry value where the first 20 bytes of data
+	// corresponds to the hash of a host's public key.
+	EntryTypePubKey
+)
+
+const (
+	// MaxValueDataSize is the maximum size of a Value's Data
+	// field.
+	MaxValueDataSize = 113
+)
+
+// A RegistryKey uniquely identifies a value in the host's registry.
+type RegistryKey struct {
+	PublicKey types.PublicKey
+	Tweak     types.Hash256
+}
+
+// A RegistryValue is a value associated with a key and a tweak in a host's
+// registry.
+type RegistryValue struct {
+	Data      []byte
+	Revision  uint64
+	Type      uint8
+	Signature types.Signature
+}
+
+// A RegistryEntry contains the data stored by a host for each registry value.
+type RegistryEntry struct {
+	RegistryKey
+	RegistryValue
+}
+
+// Hash returns the hash of the key.
+func (rk *RegistryKey) Hash() types.Hash256 {
+	h := types.NewHasher()
+	rk.PublicKey.UnlockKey().EncodeTo(h.E)
+	rk.Tweak.EncodeTo(h.E)
+	return h.Sum()
+}
+
+// Hash returns the hash used for signing the entry.
+func (re *RegistryEntry) Hash() types.Hash256 {
+	h := types.NewHasher()
+	re.Tweak.EncodeTo(h.E)
+	h.E.WriteBytes(re.Data)
+	h.E.WriteUint64(re.Revision)
+	if re.Type == EntryTypePubKey {
+		h.E.WriteUint8(re.Type)
+	}
+	return h.Sum()
+}
+
+// Work returns the work of an entry.
+func (re *RegistryEntry) Work() types.Hash256 {
+	data := re.Data
+	if re.Type == EntryTypePubKey {
+		data = re.Data[20:]
+	}
+	h := types.NewHasher()
+	re.Tweak.EncodeTo(h.E)
+	h.E.WriteBytes(data)
+	h.E.WriteUint64(re.Revision)
+	return h.Sum()
+}
+
+// CompareRegistryWork compares the work of two registry entries.
+func CompareRegistryWork(r1, r2 RegistryEntry) int {
+	r1w, r2w := r1.Work(), r2.Work()
+	return bytes.Compare(r1w[:], r2w[:])
+}
+
+// RegistryHostID returns the ID hash of the host for primary registry entries.
+func RegistryHostID(pk types.PublicKey) types.Hash256 {
+	h := types.NewHasher()
+	pk.UnlockKey().EncodeTo(h.E)
+	return h.Sum()
+}
+
+// ValidateRegistryEntry validates the fields of a registry entry.
+func ValidateRegistryEntry(re RegistryEntry) (err error) {
+	switch re.Type {
+	case EntryTypeArbitrary:
+		break // no extra validation required
+	case EntryTypePubKey:
+		// pub key entries have the first 20 bytes of the host's pub key hash
+		// prefixed to the data.
+		if len(re.Data) < 20 {
+			return errors.New("expected host public key hash")
+		}
+	default:
+		return fmt.Errorf("invalid registry value type: %d", re.Type)
+	}
+	if !re.PublicKey.VerifyHash(re.Hash(), re.Signature) {
+		return errors.New("invalid signature")
+	}
+	return nil
+}
+
+// ValidateRegistryUpdate validates a registry update against the current entry.
+// An updated registry entry must have a greater revision number, more work, or
+// be replacing a non-primary registry entry.
+func ValidateRegistryUpdate(old, update RegistryEntry, hostID types.Hash256) error {
+	// if the new revision is greater than the current revision, the update is
+	// valid.
+	if update.Revision > old.Revision {
+		return nil
+	} else if update.Revision < old.Revision {
+		return errors.New("update revision must be greater than current revision")
+	}
+
+	// if the revision number is the same, but the work is greater, the update
+	// is valid.
+	if w := CompareRegistryWork(update, old); w > 0 {
+		return nil
+	} else if w < 0 {
+		return errors.New("update must have greater work or greater revision number than current entry")
+	}
+
+	// if the update entry is an arbitrary value entry, the update is invalid.
+	if update.Type == EntryTypeArbitrary {
+		return errors.New("update must be a primary entry or have a greater revision number")
+	}
+
+	// if the updated entry is not a primary entry, it is invalid.
+	if !bytes.Equal(update.Data[:20], hostID[:20]) {
+		return errors.New("update must be a primary entry or have a greater revision number")
+	}
+
+	// if the update and current entry are both primary, the update is invalid
+	if old.Type == EntryTypePubKey && bytes.Equal(old.Data[:20], hostID[:20]) {
+		return errors.New("update revision must be greater than current revision")
+	}
+
+	return nil
+}

--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -1,0 +1,327 @@
+// Package rhp implements the Sia renter-host protocol, version 3.
+package rhp
+
+import (
+	"time"
+
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
+)
+
+// An Account is a public key used to identify an ephemeral account on a host.
+type Account types.PublicKey
+
+// ZeroAccount is a sentinel value that indicates the lack of an account.
+var ZeroAccount Account
+
+// A PaymentMethod is a way of paying for an arbitrary host operation.
+type PaymentMethod interface {
+	ProtocolObject
+	isPaymentMethod()
+}
+
+func (PayByEphemeralAccountRequest) isPaymentMethod() {}
+func (PayByContractRequest) isPaymentMethod()         {}
+
+// SigHash returns the hash that is signed to authorize the account payment.
+func (p PayByEphemeralAccountRequest) SigHash() types.Hash256 {
+	h := types.NewHasher()
+	p.Account.EncodeTo(h.E)
+	h.E.WriteUint64(p.Expiry)
+	p.Amount.EncodeTo(h.E)
+	h.E.Write(p.Nonce[:])
+	return h.Sum()
+}
+
+// SigHash returns the hash that is signed to authorize the contract payment.
+func (p PayByContractRequest) SigHash(rev types.FileContractRevision) types.Hash256 {
+	txn := types.Transaction{
+		FileContractRevisions: []types.FileContractRevision{rev},
+	}
+	cs := consensus.State{Index: types.ChainIndex{Height: rev.WindowEnd}}
+	return cs.PartialSigHash(txn, types.CoveredFields{FileContractRevisions: []uint64{0}})
+}
+
+// PayByEphemeralAccount creates a PayByEphemeralAccountRequest.
+func PayByEphemeralAccount(account Account, amount types.Currency, expiry uint64, sk types.PrivateKey) PayByEphemeralAccountRequest {
+	p := PayByEphemeralAccountRequest{
+		Account:  account,
+		Expiry:   expiry,
+		Amount:   amount,
+		Priority: 0, // TODO ???
+	}
+	frand.Read(p.Nonce[:])
+	p.Signature = sk.SignHash(p.SigHash())
+	return p
+}
+
+// PayByContract creates a PayByContractRequest by revising the supplied
+// contract.
+func PayByContract(rev *types.FileContractRevision, amount types.Currency, refundAcct Account, sk types.PrivateKey) (PayByContractRequest, bool) {
+	if rev.ValidRenterPayout().Cmp(amount) < 0 || rev.MissedRenterPayout().Cmp(amount) < 0 {
+		return PayByContractRequest{}, false
+	}
+	rev.ValidProofOutputs[0].Value = rev.ValidProofOutputs[0].Value.Sub(amount)
+	rev.ValidProofOutputs[1].Value = rev.ValidProofOutputs[1].Value.Add(amount)
+	rev.MissedProofOutputs[0].Value = rev.MissedProofOutputs[0].Value.Sub(amount)
+	rev.MissedProofOutputs[1].Value = rev.MissedProofOutputs[1].Value.Add(amount)
+	rev.RevisionNumber++
+
+	newValid := make([]types.Currency, len(rev.ValidProofOutputs))
+	for i, o := range rev.ValidProofOutputs {
+		newValid[i] = o.Value
+	}
+	newMissed := make([]types.Currency, len(rev.MissedProofOutputs))
+	for i, o := range rev.MissedProofOutputs {
+		newMissed[i] = o.Value
+	}
+	p := PayByContractRequest{
+		ContractID:        rev.ParentID,
+		RevisionNumber:    rev.RevisionNumber,
+		ValidProofValues:  newValid,
+		MissedProofValues: newMissed,
+		RefundAccount:     refundAcct,
+	}
+	p.Signature = sk.SignHash(p.SigHash(*rev))
+	return p, true
+}
+
+// A SettingsID is a unique identifier for registered host settings used by renters
+// when interacting with the host.
+type SettingsID [16]byte
+
+// An HostPriceTable contains the host's current prices for each RPC.
+type HostPriceTable struct {
+	// UID is a unique specifier that identifies this price table
+	UID SettingsID `json:"uid"`
+
+	// Validity is a duration that specifies how long the host guarantees these
+	// prices for and are thus considered valid.
+	Validity time.Duration `json:"validity"`
+
+	// HostBlockHeight is the block height of the host. This allows the renter
+	// to create valid withdrawal messages in case it is not synced yet.
+	HostBlockHeight uint64 `json:"hostblockheight"`
+
+	// UpdatePriceTableCost refers to the cost of fetching a new price table
+	// from the host.
+	UpdatePriceTableCost types.Currency `json:"updatepricetablecost"`
+
+	// AccountBalanceCost refers to the cost of fetching the balance of an
+	// ephemeral account.
+	AccountBalanceCost types.Currency `json:"accountbalancecost"`
+
+	// FundAccountCost refers to the cost of funding an ephemeral account on the
+	// host.
+	FundAccountCost types.Currency `json:"fundaccountcost"`
+
+	// LatestRevisionCost refers to the cost of asking the host for the latest
+	// revision of a contract.
+	LatestRevisionCost types.Currency `json:"latestrevisioncost"`
+
+	// SubscriptionMemoryCost is the cost of storing a byte of data for
+	// SubscriptionPeriod time.
+	SubscriptionMemoryCost types.Currency `json:"subscriptionmemorycost"`
+
+	// SubscriptionNotificationCost is the cost of a single notification on top
+	// of what is charged for bandwidth.
+	SubscriptionNotificationCost types.Currency `json:"subscriptionnotificationcost"`
+
+	// MDM related costs
+	//
+	// InitBaseCost is the amount of cost that is incurred when an MDM program
+	// starts to run. This doesn't include the memory used by the program data.
+	// The total cost to initialize a program is calculated as
+	// InitCost = InitBaseCost + MemoryTimeCost * Time
+	InitBaseCost types.Currency `json:"initbasecost"`
+
+	// MemoryTimeCost is the amount of cost per byte per time that is incurred
+	// by the memory consumption of the program.
+	MemoryTimeCost types.Currency `json:"memorytimecost"`
+
+	// Cost values specific to the bandwidth consumption.
+	DownloadBandwidthCost types.Currency `json:"downloadbandwidthcost"`
+	UploadBandwidthCost   types.Currency `json:"uploadbandwidthcost"`
+
+	// Cost values specific to the DropSectors instruction.
+	DropSectorsBaseCost types.Currency `json:"dropsectorsbasecost"`
+	DropSectorsUnitCost types.Currency `json:"dropsectorsunitcost"`
+
+	// Cost values specific to the HasSector command.
+	HasSectorBaseCost types.Currency `json:"hassectorbasecost"`
+
+	// Cost values specific to the Read instruction.
+	ReadBaseCost   types.Currency `json:"readbasecost"`
+	ReadLengthCost types.Currency `json:"readlengthcost"`
+
+	// Cost values specific to the RenewContract instruction.
+	RenewContractCost types.Currency `json:"renewcontractcost"`
+
+	// Cost values specific to the Revision command.
+	RevisionBaseCost types.Currency `json:"revisionbasecost"`
+
+	// SwapSectorCost is the cost of swapping 2 full sectors by root.
+	SwapSectorCost types.Currency `json:"swapsectorcost"`
+
+	// Cost values specific to the Write instruction.
+	WriteBaseCost   types.Currency `json:"writebasecost"`   // per write
+	WriteLengthCost types.Currency `json:"writelengthcost"` // per byte written
+	WriteStoreCost  types.Currency `json:"writestorecost"`  // per byte / block of additional storage
+
+	// TxnFee estimations.
+	TxnFeeMinRecommended types.Currency `json:"txnfeeminrecommended"`
+	TxnFeeMaxRecommended types.Currency `json:"txnfeemaxrecommended"`
+
+	// ContractPrice is the additional fee a host charges when forming/renewing
+	// a contract to cover the miner fees when submitting the contract and
+	// revision to the blockchain.
+	ContractPrice types.Currency `json:"contractprice"`
+
+	// CollateralCost is the amount of money per byte the host is promising to
+	// lock away as collateral when adding new data to a contract. It's paid out
+	// to the host regardless of the outcome of the storage proof.
+	CollateralCost types.Currency `json:"collateralcost"`
+
+	// MaxCollateral is the maximum amount of collateral the host is willing to
+	// put into a single file contract.
+	MaxCollateral types.Currency `json:"maxcollateral"`
+
+	// MaxDuration is the max duration for which the host is willing to form a
+	// contract.
+	MaxDuration uint64 `json:"maxduration"`
+
+	// WindowSize is the minimum time in blocks the host requests the
+	// renewWindow of a new contract to be.
+	WindowSize uint64 `json:"windowsize"`
+
+	// Registry related fields.
+	RegistryEntriesLeft  uint64 `json:"registryentriesleft"`
+	RegistryEntriesTotal uint64 `json:"registryentriestotal"`
+}
+
+const registryEntrySize = 256
+
+// UpdateRegistryCost is the cost of executing a 'UpdateRegistry'
+// instruction on the MDM.
+func (pt *HostPriceTable) UpdateRegistryCost() (writeCost, storeCost types.Currency) {
+	// Cost is the same as uploading and storing a registry entry for 5 years.
+	const blocksPerYear = 365 * 24 * time.Hour / (10 * time.Minute)
+	writeCost = pt.writeCost(registryEntrySize)
+	storeCost = pt.WriteStoreCost.Mul64(registryEntrySize).Mul64(uint64(5 * blocksPerYear))
+	return writeCost.Add(storeCost), storeCost
+}
+
+// writeCost is the cost of executing a 'Write' instruction of a certain length
+// on the MDM.
+func (pt *HostPriceTable) writeCost(writeLength uint64) types.Currency {
+	const atomicWriteSize = 1 << 12
+	if mod := writeLength % atomicWriteSize; mod != 0 {
+		writeLength += (atomicWriteSize - mod)
+	}
+	writeCost := pt.WriteLengthCost.Mul64(writeLength).Add(pt.WriteBaseCost)
+	return writeCost
+}
+
+type (
+	// PayByEphemeralAccountRequest represents a payment made using an ephemeral account.
+	PayByEphemeralAccountRequest struct {
+		Account   Account
+		Expiry    uint64
+		Amount    types.Currency
+		Nonce     [8]byte
+		Signature types.Signature
+		Priority  int64
+	}
+
+	// PayByContractRequest represents a payment made using a contract revision.
+	PayByContractRequest struct {
+		ContractID        types.FileContractID
+		RevisionNumber    uint64
+		ValidProofValues  []types.Currency
+		MissedProofValues []types.Currency
+		RefundAccount     Account
+		Signature         types.Signature
+		HostSignature     types.Signature
+	}
+)
+
+// RPC IDs
+var (
+	RPCAccountBalanceID       = types.NewSpecifier("AccountBalance")
+	RPCExecuteProgramID       = types.NewSpecifier("ExecuteProgram")
+	RPCUpdatePriceTableID     = types.NewSpecifier("UpdatePriceTable")
+	RPCFundAccountID          = types.NewSpecifier("FundAccount")
+	RPCLatestRevisionID       = types.NewSpecifier("LatestRevision")
+	RPCRegistrySubscriptionID = types.NewSpecifier("Subscription")
+	RPCFormContractID         = types.NewSpecifier("FormContract")
+	RPCRenewContractID        = types.NewSpecifier("RenewContract")
+
+	PaymentTypeContract         = types.NewSpecifier("PayByContract")
+	PaymentTypeEphemeralAccount = types.NewSpecifier("PayByEphemAcc")
+)
+
+type (
+	// PaymentResponse is the response to a payment request.
+	PaymentResponse struct {
+		Signature types.Signature
+	}
+
+	// RPCUpdatePriceTableResponse is the response object for the UpdatePriceTableResponse RPC.
+	RPCUpdatePriceTableResponse struct {
+		PriceTableJSON []byte
+	}
+
+	// RPCPriceTableResponse is the response object for the PriceTableResponse RPC.
+	RPCPriceTableResponse struct{}
+
+	// RPCFundAccountRequest is the request object for the FundAccountRequest RPC.
+	RPCFundAccountRequest struct {
+		Account Account
+	}
+
+	// A FundAccountReceipt is a receipt for a payment made to an account.
+	FundAccountReceipt struct {
+		Host      types.UnlockKey
+		Account   Account
+		Amount    types.Currency
+		Timestamp time.Time
+	}
+
+	// RPCFundAccountResponse is the response object for the FundAccountResponse RPC.
+	RPCFundAccountResponse struct {
+		Balance   types.Currency
+		Receipt   FundAccountReceipt
+		Signature types.Signature
+	}
+
+	// RPCAccountBalanceRequest is the request object for the AccountBalanceRequest RPC.
+	RPCAccountBalanceRequest struct {
+		Account Account
+	}
+
+	// RPCAccountBalanceResponse is the response object for the AccountBalanceResponse RPC.
+	RPCAccountBalanceResponse struct {
+		Balance types.Currency
+	}
+
+	// RPCExecuteProgramRequest is the request object for the ExecuteProgramRequest RPC.
+	RPCExecuteProgramRequest struct {
+		FileContractID types.FileContractID
+		Program        []Instruction
+		ProgramData    []byte
+	}
+
+	// RPCExecuteProgramResponse is the response object for the ExecuteProgramResponse RPC.
+	RPCExecuteProgramResponse struct {
+		AdditionalCollateral types.Currency
+		OutputLength         uint64
+		NewMerkleRoot        types.Hash256
+		NewSize              uint64
+		Proof                []types.Hash256
+		Error                error
+		TotalCost            types.Currency
+		FailureRefund        types.Currency
+		Output               []byte
+	}
+)

--- a/rhp/v3/transport.go
+++ b/rhp/v3/transport.go
@@ -1,0 +1,273 @@
+package rhp
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"go.sia.tech/core/types"
+	"go.sia.tech/mux"
+	"lukechampine.com/frand"
+)
+
+// An RPCError may be sent instead of a response object to any RPC.
+type RPCError struct {
+	Type        types.Specifier
+	Data        []byte // structure depends on Type
+	Description string // human-readable error string
+}
+
+// Error implements the error interface.
+func (e *RPCError) Error() string {
+	return e.Description
+}
+
+// Is reports whether this error matches target.
+func (e *RPCError) Is(target error) bool {
+	return strings.Contains(e.Description, target.Error())
+}
+
+func wrapErr(err *error, fnName string) {
+	if *err != nil {
+		*err = fmt.Errorf("%s: %w", fnName, *err)
+	}
+}
+
+// helper type for encoding and decoding RPC response messages, which can
+// represent either valid data or an error.
+type rpcResponse struct {
+	err  *RPCError
+	data ProtocolObject
+}
+
+// A ProtocolObject can be transferred using the RHPv3 protocol.
+type ProtocolObject interface {
+	types.EncoderTo
+	types.DecoderFrom
+}
+
+const minMessageSize = 1024
+
+// A Stream is a duplex connection over which RPCs can be sent and received.
+type Stream struct {
+	s *mux.Stream
+}
+
+func (s *Stream) readObject(resp ProtocolObject, maxLen uint64) error {
+	d := types.NewDecoder(io.LimitedReader{R: s.s, N: int64(maxLen)})
+	if l := d.ReadPrefix(); uint64(l) > maxLen {
+		return fmt.Errorf("message too long: %v > %v", l, maxLen)
+	}
+	rr := rpcResponse{nil, resp}
+	rr.DecodeFrom(d)
+	if d.Err() != nil {
+		return d.Err()
+	} else if rr.err != nil {
+		return rr.err
+	}
+	return nil
+}
+
+func (s *Stream) writeObject(resp *rpcResponse) error {
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+	e.WritePrefix(0) // placeholder
+	resp.EncodeTo(e)
+	e.Flush()
+	b := buf.Bytes()
+	binary.LittleEndian.PutUint64(b[:8], uint64(len(b)-8))
+	_, err := s.s.Write(b)
+	return err
+}
+
+// WriteResponse writes an RPC response object.
+func (s *Stream) WriteResponse(resp ProtocolObject) (err error) {
+	defer wrapErr(&err, "WriteResponse")
+	return s.writeObject(&rpcResponse{nil, resp})
+}
+
+// WriteResponseErr writes an error. If err is an *RPCError, it is sent
+// directly; otherwise, a generic RPCError is created from err's Error string.
+func (s *Stream) WriteResponseErr(resp error) (err error) {
+	defer wrapErr(&err, "WriteResponseErr")
+	re, ok := resp.(*RPCError)
+	if resp != nil && !ok {
+		re = &RPCError{Description: resp.Error()}
+	}
+	return s.writeObject(&rpcResponse{re, nil})
+}
+
+// WriteRequest sends an encrypted RPC request, comprising an RPC ID and a
+// request object.
+func (s *Stream) WriteRequest(rpcID types.Specifier, req ProtocolObject) error {
+	// write subscription and read response
+	e := types.NewEncoder(s.s)
+	e.WritePrefix(8 + len("host"))
+	e.WriteString("host")
+	if err := e.Flush(); err != nil {
+		return err
+	}
+	d := types.NewDecoder(io.LimitedReader{R: s.s, N: minMessageSize})
+	d.ReadPrefix()
+	if errStr := d.ReadString(); errStr != "" {
+		return errors.New(errStr)
+	} else if d.Err() != nil {
+		return d.Err()
+	}
+
+	// write ID and request object
+	if err := s.writeObject(&rpcResponse{nil, &rpcID}); err != nil {
+		return fmt.Errorf("WriteRequestID: %w", err)
+	}
+	if req != nil {
+		if err := s.writeObject(&rpcResponse{nil, req}); err != nil {
+			return fmt.Errorf("WriteRequest: %w", err)
+		}
+	}
+	return nil
+}
+
+// ReadID reads an RPC request ID.
+func (s *Stream) ReadID() (rpcID types.Specifier, err error) {
+	defer wrapErr(&err, "ReadID")
+
+	// read subscription and write response
+	d := types.NewDecoder(io.LimitedReader{R: s.s, N: minMessageSize})
+	d.ReadPrefix()
+	sub := d.ReadString()
+	if d.Err() != nil {
+		return types.Specifier{}, d.Err()
+	}
+	errStr := ""
+	if sub != "host" {
+		errStr = "bad subscription"
+	}
+	e := types.NewEncoder(s.s)
+	e.WritePrefix(8)
+	e.WriteString(errStr)
+	if err := e.Flush(); err != nil {
+		return types.Specifier{}, err
+	} else if errStr != "" {
+		return types.Specifier{}, errors.New(errStr)
+	}
+
+	err = s.readObject(&rpcID, minMessageSize)
+	return
+}
+
+// ReadRequest reads an RPC request using the new loop protocol.
+func (s *Stream) ReadRequest(req ProtocolObject, maxLen uint64) (err error) {
+	defer wrapErr(&err, "ReadRequest")
+	return s.readObject(req, maxLen)
+}
+
+// ReadResponse reads an RPC response. If the response is an error, it is
+// returned directly.
+func (s *Stream) ReadResponse(resp ProtocolObject, maxLen uint64) (err error) {
+	defer wrapErr(&err, "ReadResponse")
+	return s.readObject(resp, maxLen)
+}
+
+// Call is a helper method that writes a request and then reads a response.
+func (s *Stream) Call(rpcID types.Specifier, req, resp ProtocolObject) error {
+	if err := s.WriteRequest(rpcID, req); err != nil {
+		return err
+	}
+	// use a maxlen large enough for all RPCs except Read, Write, and
+	// SectorRoots (which don't use Call anyway)
+	err := s.ReadResponse(resp, 4096)
+	if errors.As(err, new(*RPCError)) {
+		return fmt.Errorf("host rejected %v request: %w", rpcID, err)
+	} else if err != nil {
+		return fmt.Errorf("couldn't read %v response: %w", rpcID, err)
+	}
+	return nil
+}
+
+// SetDeadline sets the read and write deadlines associated with the Stream.
+func (s *Stream) SetDeadline(t time.Time) error {
+	return s.s.SetDeadline(t)
+}
+
+// Close closes the Stream.
+func (s *Stream) Close() error {
+	return s.s.Close()
+}
+
+// A Transport facilitates the exchange of RPCs via the renter-host protocol,
+// version 3.
+type Transport struct {
+	mux *mux.Mux
+}
+
+// DialStream opens a new stream with the host.
+func (t *Transport) DialStream() *Stream {
+	s := t.mux.DialStream()
+	return &Stream{s: s}
+}
+
+// AcceptStream accepts a new stream from the renter.
+func (t *Transport) AcceptStream() (*Stream, error) {
+	s, err := t.mux.AcceptStream()
+	return &Stream{s: s}, err
+}
+
+// Close closes the protocol connection.
+func (t *Transport) Close() error {
+	return t.mux.Close()
+}
+
+// NewRenterTransport establishes a new RHPv3 session over the supplied connection.
+func NewRenterTransport(conn net.Conn, hostKey types.PublicKey) (*Transport, error) {
+	m, err := mux.Dial(conn, hostKey[:])
+	if err != nil {
+		return nil, err
+	}
+
+	// perform seed handshake
+	s := m.DialStream()
+	defer s.Close()
+	buf := make([]byte, 8+8)
+	binary.LittleEndian.PutUint64(buf[:8], 8)
+	frand.Read(buf[8:])
+	if _, err := s.Write(buf); err != nil {
+		return nil, err
+	} else if _, err := io.ReadFull(s, buf); err != nil {
+		return nil, err
+	}
+
+	return &Transport{
+		mux: m,
+	}, nil
+}
+
+// NewHostTransport establishes a new RHPv3 session over the supplied connection.
+func NewHostTransport(conn net.Conn, hostKey types.PrivateKey) (*Transport, error) {
+	m, err := mux.Accept(conn, ed25519.PrivateKey(hostKey))
+	if err != nil {
+		return nil, err
+	}
+
+	// perform seed handshake
+	s := m.DialStream()
+	defer s.Close()
+	buf := make([]byte, 8+8)
+	if _, err := io.ReadFull(s, buf); err != nil {
+		return nil, err
+	}
+	binary.LittleEndian.PutUint64(buf[:8], 8)
+	frand.Read(buf[8:])
+	if _, err := s.Write(buf); err != nil {
+		return nil, err
+	}
+
+	return &Transport{
+		mux: m,
+	}, nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -44,6 +44,14 @@ func (pk PublicKey) VerifyHash(h Hash256, s Signature) bool {
 	return ed25519.Verify(pk[:], h[:], s[:])
 }
 
+// UnlockKey returns pk as an UnlockKey.
+func (pk PublicKey) UnlockKey() UnlockKey {
+	return UnlockKey{
+		Algorithm: SpecifierEd25519,
+		Key:       pk[:],
+	}
+}
+
 // A PrivateKey is an Ed25519 private key.
 type PrivateKey []byte
 
@@ -195,8 +203,8 @@ type SiafundOutputID Hash256
 
 // ClaimOutputID returns the ID of the SiacoinOutput that is created when
 // the siafund output is spent.
-func (id SiafundOutputID) ClaimOutputID() SiacoinOutputID {
-	return SiacoinOutputID(HashBytes(id[:]))
+func (sfoid SiafundOutputID) ClaimOutputID() SiacoinOutputID {
+	return SiacoinOutputID(HashBytes(sfoid[:]))
 }
 
 // A SiafundInput spends an unspent SiafundOutput in the UTXO set by revealing
@@ -470,6 +478,9 @@ func (b *Block) Header() BlockHeader {
 
 // ID returns a hash that uniquely identifies a block. It is equivalent to
 // b.Header().ID().
+//
+// Note that this is a relatively expensive operation, as it computes the Merkle
+// root of the block's transactions.
 func (b *Block) ID() BlockID { return b.Header().ID() }
 
 // Work represents a quantity of work.

--- a/wallet/seed.go
+++ b/wallet/seed.go
@@ -1,13 +1,13 @@
 package wallet
 
 import (
-	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"strings"
 
+	"go.sia.tech/core/types"
 	"golang.org/x/crypto/blake2b"
 	"lukechampine.com/frand"
 )
@@ -44,12 +44,12 @@ func SeedFromPhrase(seed *[32]byte, phrase string) error {
 }
 
 // KeyFromSeed returns the Ed25519 key derived from the supplied seed and index.
-func KeyFromSeed(seed *[32]byte, index uint64) ed25519.PrivateKey {
+func KeyFromSeed(seed *[32]byte, index uint64) types.PrivateKey {
 	buf := make([]byte, 32+8)
 	copy(buf[:32], seed[:])
 	binary.LittleEndian.PutUint64(buf[32:], index)
 	h := blake2b.Sum256(buf)
-	key := ed25519.NewKeyFromSeed(h[:])
+	key := types.NewPrivateKeyFromSeed(h[:])
 	memclr(h[:])
 	return key
 }


### PR DESCRIPTION
This moves large swathes of shared RHP code from `renterd` and `hostd` into `core`.

Since this is `core`, the code is fairly low-level and avoids "making decisions." For example, `core` does not provide functions that actually *call* the RHP RPCs, nor any form of "handler" or "server" that decodes incoming RPCs and routes them to an appropriate function. That code still lives in `renterd` and `hostd`, respectively.