### PR TITLE
rhpv3 additions

### DIFF
--- a/rhp/v3/encoding.go
+++ b/rhp/v3/encoding.go
@@ -332,6 +332,40 @@ func (r *RPCExecuteProgramResponse) DecodeFrom(d *types.Decoder) {
 	d.Read(r.Output)
 }
 
+func (r *RPCFinalizeProgramRequest) EncodeTo(e *types.Encoder) {
+	e.WriteBytes(r.Signature[:])
+	e.WriteUint64(r.RevisionNumber)
+	e.WritePrefix(len(r.ValidProofValues))
+	for _, v := range r.ValidProofValues {
+		v.EncodeTo(e)
+	}
+	e.WritePrefix(len(r.MissedProofValues))
+	for _, v := range r.MissedProofValues {
+		v.EncodeTo(e)
+	}
+}
+
+func (r *RPCFinalizeProgramRequest) DecodeFrom(d *types.Decoder) {
+	copy(r.Signature[:], d.ReadBytes())
+	r.RevisionNumber = d.ReadUint64()
+	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.ValidProofValues {
+		r.ValidProofValues[i].DecodeFrom(d)
+	}
+	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
+	for i := range r.MissedProofValues {
+		r.MissedProofValues[i].DecodeFrom(d)
+	}
+}
+
+func (r *RPCFinalizeProgramResponse) EncodeTo(e *types.Encoder) {
+	e.WriteBytes(r.Signature[:])
+}
+
+func (r *RPCFinalizeProgramResponse) DecodeFrom(d *types.Decoder) {
+	copy(r.Signature[:], d.ReadBytes())
+}
+
 func instructionID(instr Instruction) types.Specifier {
 	switch instr.(type) {
 	case *InstrAppendSector:

--- a/rhp/v3/program.go
+++ b/rhp/v3/program.go
@@ -120,7 +120,6 @@ var (
 	idInstrReadOffset       = types.NewSpecifier("ReadOffset")
 	idInstrReadSector       = types.NewSpecifier("ReadSector")
 	idInstrContractRevision = types.NewSpecifier("Revision")
-	idInstrSectorRoots      = types.NewSpecifier("SectorRoots")
 	idInstrSwapSector       = types.NewSpecifier("SwapSector")
 	idInstrUpdateRegistry   = types.NewSpecifier("UpdateRegistry")
 	idInstrReadRegistry     = types.NewSpecifier("ReadRegistry")

--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -485,4 +485,19 @@ type (
 		FailureRefund        types.Currency
 		Output               []byte
 	}
+
+	// RPCFinalizeProgramRequest is the finalization request object for the
+	// ExecuteProgram RPC.
+	RPCFinalizeProgramRequest struct {
+		Signature         types.Signature
+		RevisionNumber    uint64
+		ValidProofValues  []types.Currency
+		MissedProofValues []types.Currency
+	}
+
+	// RPCFinalizeProgramResponse is the response object for finalizing the
+	// ExecuteProgram RPC
+	RPCFinalizeProgramResponse struct {
+		Signature types.Signature
+	}
 )

--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -240,6 +240,13 @@ func (a *ResourceCost) Add(b ResourceCost) ResourceCost {
 	}
 }
 
+// Total returns the total cost and collateral of a ResourceCost.
+func (a *ResourceCost) Total() (cost, collateral types.Currency) {
+	cost = a.Base.Add(a.Storage).Add(a.Egress).Add(a.Ingress)
+	collateral = a.Collateral
+	return
+}
+
 // writeBaseCost is the cost of executing a 'Write' instruction of a certain length
 // on the MDM.
 func (pt *HostPriceTable) writeBaseCost(writeLength uint64) types.Currency {


### PR DESCRIPTION
+ Adds a `ResourceCost.Total()` helper func
+ Removes the `SectorRoots` instruction, it doesn't exist in `siad`
+ Adds missing RPCExecute types