### PR TITLE
Fix newCollateral math in ContractRenewalCollateral

### DIFF
--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -89,12 +89,17 @@ func ContractRenewalCollateral(fc types.FileContract, renterFunds types.Currency
 	// calculate the new collateral
 	newCollateral := host.Collateral.Mul(renterFunds.Div(costPerByte))
 
-	// if the total collateral is more than the MaxCollateral, return the delta
+	// if the total collateral is more than the MaxCollateral subtract the
+	// delta.
 	totalCollateral := baseCollateral.Add(newCollateral)
 	if totalCollateral.Cmp(host.MaxCollateral) > 0 {
-		return totalCollateral.Sub(host.MaxCollateral)
+		delta := totalCollateral.Sub(host.MaxCollateral)
+		if delta.Cmp(newCollateral) > 0 {
+			newCollateral = types.ZeroCurrency
+		} else {
+			newCollateral = newCollateral.Sub(delta)
+		}
 	}
-
 	return newCollateral
 }
 

--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -65,9 +65,9 @@ func ContractRenewalCost(fc types.FileContract, contractFee types.Currency) type
 	return fc.ValidRenterPayout().Add(contractFee).Add(contractTax(fc))
 }
 
-// ContractRenewalCollateral returns the amount of collateral we add when
-// renewing a contract. It takes into account the host's max collateral setting
-// and ensures the total collateral does not exceed it.
+// ContractRenewalCollateral returns the amount of collateral we add on top of
+// the baseCollateral when renewing a contract. It takes into account the host's
+// max collateral setting and ensures the total collateral does not exceed it.
 func ContractRenewalCollateral(fc types.FileContract, renterFunds types.Currency, host HostSettings, endHeight uint64) types.Currency {
 	if endHeight < fc.EndHeight() {
 		panic("endHeight should be at least the current end height of the contract")


### PR DESCRIPTION
This PR fixes the math in `ContractRenewalCollateral` and `ContractFormationCollateral`.

1. both now use the same math to compute collateral given the `renterFunds` which we are about to put into a contract.
2. `costPerByte` now accounts for the storage duration. This should drive the cost up significantly and reduce the amount of collateral we put into contracts.
3. The collateral capping math in `ContractRenewalCollateral` now subtracts the delta from `newCollateral` which fixes the case of hitting the `MaxCollateral` with a `baseCollateral` that is smaller than `newCollateral`. Previously the `newCollateral` returned in that case was far too small.
4. Computing the collateral now multiplies the collateral by the duration of the contract as well. Otherwise we only add enough collateral for a single block.
