### PR TITLE
Expose conn.SetDeadline on Transport

### DIFF
--- a/rhp/v2/transport.go
+++ b/rhp/v2/transport.go
@@ -166,6 +166,18 @@ func (t *Transport) SetDeadline(deadline time.Time) {
 	t.conn.SetDeadline(deadline)
 }
 
+// SetReadDeadline sets the deadline for future read calls on the underlying
+// connection.
+func (t *Transport) SetReadDeadline(deadline time.Time) {
+	t.conn.SetReadDeadline(deadline)
+}
+
+// SetWriteDeadline sets the deadline for future write calls on the underlying
+// connection.
+func (t *Transport) SetWriteDeadline(deadline time.Time) {
+	t.conn.SetWriteDeadline(deadline)
+}
+
 // SignChallenge signs the current Transport challenge.
 func (t *Transport) SignChallenge(priv types.PrivateKey) types.Signature {
 	return priv.SignHash(hashChallenge(t.challenge))

--- a/rhp/v2/transport.go
+++ b/rhp/v2/transport.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.sia.tech/core/types"
 	"golang.org/x/crypto/blake2b"
@@ -158,6 +159,11 @@ func hashChallenge(challenge [16]byte) [32]byte {
 // SetChallenge sets the current Transport challenge.
 func (t *Transport) SetChallenge(challenge [16]byte) {
 	t.challenge = challenge
+}
+
+// SetDeadline sets the read and write deadline on the underlying connection.
+func (t *Transport) SetDeadline(deadline time.Time) {
+	t.conn.SetDeadline(deadline)
 }
 
 // SignChallenge signs the current Transport challenge.


### PR DESCRIPTION
The `Session` object in `renterd` uses the `Transport` to read and write without imposing any deadlines or timeouts, even though a context is being passed down into most functions. So essentially the `Transport` is not respecting the timeouts imposed on it. I want to expose `SetDeadline` to be able to set a deadline on the underlying connection.

edit: exposed `SetReadDeadline` and `SetWriteDeadline` while we're at it