### PR TITLE
Transport Close WriteDeadline

### DIFF
--- a/rhp/v2/transport.go
+++ b/rhp/v2/transport.go
@@ -448,6 +448,7 @@ func (t *Transport) Close() (err error) {
 	t.closed = true
 	t.mu.Unlock()
 	if t.isRenter {
+		t.SetWriteDeadline(time.Now().Add(time.Second))
 		t.writeMessage(&loopExit)
 	}
 	return t.conn.Close()


### PR DESCRIPTION
This PR adds a write deadline of one second right before trying to gracefully close a transport by sending `LoopExit`. This to prevent the graceful shutdown from blocking the close.