### PR TITLE
Add Consensus/Chain Manager Test

### DIFF
--- a/chain/db_test.go
+++ b/chain/db_test.go
@@ -1,0 +1,293 @@
+package chain
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"go.sia.tech/core/consensus"
+	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
+)
+
+// StandardUnlockConditions returns the standard unlock conditions for a single
+// Ed25519 key.
+func StandardUnlockConditions(pub types.PublicKey) types.UnlockConditions {
+	return types.UnlockConditions{
+		PublicKeys: []types.UnlockKey{{
+			Algorithm: types.SpecifierEd25519,
+			Key:       pub[:],
+		}},
+		SignaturesRequired: 1,
+	}
+}
+
+// StandardAddress returns the standard address for an Ed25519 key.
+func StandardAddress(pub types.PublicKey) types.Address {
+	return StandardUnlockConditions(pub).UnlockHash()
+}
+
+// AppendTransactionSignature appends a TransactionSignature to txn and signs it
+// with key.
+func AppendTransactionSignature(cs consensus.State, key types.PrivateKey, parentID types.Hash256, txn *types.Transaction) {
+	sig := types.TransactionSignature{
+		ParentID:       parentID,
+		CoveredFields:  types.CoveredFields{WholeTransaction: true},
+		PublicKeyIndex: 0,
+	}
+	sigHash := key.SignHash(cs.WholeSigHash(*txn, sig.ParentID, sig.PublicKeyIndex, sig.Timelock, sig.CoveredFields.Signatures))
+	sig.Signature = sigHash[:]
+
+	txn.Signatures = append(txn.Signatures, sig)
+}
+
+// FindBlockNonce finds a block nonce meeting current target.
+func FindBlockNonce(cs consensus.State, b *types.Block) {
+	// ensure nonce meets factor requirement
+	for b.Nonce%cs.NonceFactor() != 0 {
+		b.Nonce++
+	}
+	for b.ID().CmpWork(cs.ChildTarget) < 0 {
+		b.Nonce += cs.NonceFactor()
+	}
+}
+
+func addBlock(cm *Manager, b *types.Block) error {
+	var minerAddress types.Address
+	frand.Read(minerAddress[:])
+
+	cs := cm.TipState()
+	b.MinerPayouts = []types.SiacoinOutput{{Address: minerAddress, Value: cs.BlockReward()}}
+	FindBlockNonce(cs, b)
+	return cm.AddBlocks([]types.Block{*b})
+}
+
+type diffSubscriber struct {
+	cau *consensus.BlockDiff
+	cru *consensus.BlockDiff
+}
+
+func (s *diffSubscriber) ProcessChainApplyUpdate(cau *ApplyUpdate, mayCommit bool) error {
+	if cau == nil {
+		s.cau = nil
+		s.cru = nil
+		return nil
+	}
+	s.cau = &cau.Diff
+	s.cru = nil
+	return nil
+}
+
+func (s *diffSubscriber) ProcessChainRevertUpdate(cru *RevertUpdate) error {
+	if cru == nil {
+		s.cau = nil
+		s.cru = nil
+		return nil
+	}
+	s.cau = nil
+	s.cru = &cru.Diff
+	return nil
+}
+
+func checkDBOutputsFunction(txn types.Transaction) func(DBTx) error {
+	return func(tx DBTx) error {
+		dtx := &dbTx{tx: tx}
+		for i := range txn.SiacoinOutputs {
+			out, ok := dtx.SiacoinOutput(txn.SiacoinOutputID(i))
+			if !ok {
+				return fmt.Errorf("expected output %v", txn.SiacoinOutputs[i])
+			}
+			if out != txn.SiacoinOutputs[i] {
+				return fmt.Errorf("outputs don't match: %v vs %v", txn.SiacoinOutputs[i], out)
+			}
+		}
+		for i := range txn.SiafundOutputs {
+			out, _, ok := dtx.SiafundOutput(txn.SiafundOutputID(i))
+			if !ok {
+				return fmt.Errorf("expected output %v", txn.SiafundOutputs[i])
+			}
+			if out != txn.SiafundOutputs[i] {
+				return fmt.Errorf("outputs don't match: %v vs %v", txn.SiafundOutputs[i], out)
+			}
+		}
+		return dtx.err
+	}
+}
+
+func TestChainManager(t *testing.T) {
+	db := NewMemDB()
+
+	privateKey := types.GeneratePrivateKey()
+
+	giftAddress := StandardAddress(privateKey.PublicKey())
+	giftAmountSC := types.Siacoins(100)
+	giftAmountSF := uint64(100)
+	giftTxn := types.Transaction{
+		SiacoinOutputs: []types.SiacoinOutput{
+			{Address: giftAddress, Value: giftAmountSC},
+		},
+		SiafundOutputs: []types.SiafundOutput{
+			{Address: giftAddress, Value: giftAmountSF},
+		},
+	}
+	genesisBlock := types.Block{
+		Transactions: []types.Transaction{giftTxn},
+	}
+
+	dbStore, checkpoint, err := NewDBStore(db, consensus.GenesisState(time.Time{}, types.BlockID{0xFF}, types.Address{}, types.Address{}), genesisBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cm := NewManager(dbStore, checkpoint.State)
+
+	if err := db.View(checkDBOutputsFunction(giftTxn)); err != nil {
+		t.Fatal(err)
+	}
+
+	var s diffSubscriber
+	if err := cm.AddSubscriber(&s, cm.Tip()); err != nil {
+		t.Fatal(err)
+	}
+
+	chainStates := []consensus.State{cm.TipState()}
+
+	// block with nothing except block reward
+	b1 := types.Block{
+		ParentID:  genesisBlock.ID(),
+		Timestamp: time.Now(),
+	}
+	if err := addBlock(cm, &b1); err != nil {
+		t.Fatal(err)
+	}
+	chainStates = append(chainStates, cm.TipState())
+
+	{
+		expect := &consensus.BlockDiff{
+			ImmatureSiacoinOutputs: []consensus.DelayedSiacoinOutputDiff{
+				{
+					ID:             b1.ID().MinerOutputID(0),
+					Output:         b1.MinerPayouts[0],
+					MaturityHeight: chainStates[len(chainStates)-1-1].MaturityHeight(),
+					Source:         consensus.OutputSourceMiner,
+				},
+			},
+		}
+		if !reflect.DeepEqual(s.cau, expect) {
+			t.Fatalf("diff doesn't match: %v vs %v", s.cau, expect)
+		}
+	}
+
+	// block that spends part of the gift transaction
+	txn := types.Transaction{
+		SiacoinInputs: []types.SiacoinInput{
+			{
+				ParentID:         giftTxn.SiacoinOutputID(0),
+				UnlockConditions: StandardUnlockConditions(privateKey.PublicKey()),
+			},
+		},
+		SiafundInputs: []types.SiafundInput{
+			{
+				ParentID:         giftTxn.SiafundOutputID(0),
+				ClaimAddress:     types.VoidAddress,
+				UnlockConditions: StandardUnlockConditions(privateKey.PublicKey()),
+			},
+		},
+		SiacoinOutputs: []types.SiacoinOutput{
+			{Value: giftAmountSC.Div64(2), Address: giftAddress},
+			{Value: giftAmountSC.Div64(2), Address: types.VoidAddress},
+		},
+		SiafundOutputs: []types.SiafundOutput{
+			{Value: giftAmountSF / 2, Address: giftAddress},
+			{Value: giftAmountSF / 2, Address: types.VoidAddress},
+		},
+	}
+	for i := range txn.SiacoinInputs {
+		AppendTransactionSignature(cm.TipState(), privateKey, types.Hash256(txn.SiacoinInputs[i].ParentID), &txn)
+	}
+	for i := range txn.SiafundInputs {
+		AppendTransactionSignature(cm.TipState(), privateKey, types.Hash256(txn.SiafundInputs[i].ParentID), &txn)
+	}
+
+	b2 := types.Block{
+		ParentID:     b1.ID(),
+		Timestamp:    time.Now(),
+		Transactions: []types.Transaction{txn},
+	}
+	if err := addBlock(cm, &b2); err != nil {
+		t.Fatal(err)
+	}
+	chainStates = append(chainStates, cm.TipState())
+
+	{
+		expect := &consensus.BlockDiff{
+			Transactions: []consensus.TransactionDiff{{
+				CreatedSiacoinOutputs: []consensus.SiacoinOutputDiff{
+					{
+						ID:     txn.SiacoinOutputID(0),
+						Output: txn.SiacoinOutputs[0],
+					},
+					{
+						ID:     txn.SiacoinOutputID(1),
+						Output: txn.SiacoinOutputs[1],
+					},
+				},
+				SpentSiacoinOutputs: []consensus.SiacoinOutputDiff{
+					{
+						ID:     giftTxn.SiacoinOutputID(0),
+						Output: giftTxn.SiacoinOutputs[0],
+					},
+				},
+				CreatedSiafundOutputs: []consensus.SiafundOutputDiff{
+					{
+						ID:     txn.SiafundOutputID(0),
+						Output: txn.SiafundOutputs[0],
+					},
+					{
+						ID:     txn.SiafundOutputID(1),
+						Output: txn.SiafundOutputs[1],
+					},
+				},
+				SpentSiafundOutputs: []consensus.SiafundOutputDiff{
+					{
+						ID:     giftTxn.SiafundOutputID(0),
+						Output: giftTxn.SiafundOutputs[0],
+					},
+				},
+				ImmatureSiacoinOutputs: []consensus.DelayedSiacoinOutputDiff{{
+					ID: giftTxn.SiafundOutputID(0).ClaimOutputID(),
+					Output: types.SiacoinOutput{
+						Value:   types.NewCurrency64(0),
+						Address: txn.SiafundInputs[0].ClaimAddress,
+					},
+					MaturityHeight: chainStates[len(chainStates)-1-1].MaturityHeight(),
+					Source:         consensus.OutputSourceSiafundClaim,
+				}},
+			}},
+			ImmatureSiacoinOutputs: []consensus.DelayedSiacoinOutputDiff{
+				{
+					ID:             b2.ID().MinerOutputID(0),
+					Output:         b2.MinerPayouts[0],
+					MaturityHeight: chainStates[len(chainStates)-1-1].MaturityHeight(),
+					Source:         consensus.OutputSourceMiner,
+				},
+			},
+		}
+		if !reflect.DeepEqual(s.cau, expect) {
+			t.Fatalf("diff doesn't match: %v vs %v", s.cau, expect)
+		}
+	}
+
+	if err := db.View(checkDBOutputsFunction(txn)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := dbStore.RevertDiff(cm.TipState(), *s.cau); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.View(checkDBOutputsFunction(txn)); err == nil {
+		t.Fatal("should be missing siacoin outputs from reverted block")
+	}
+}

--- a/v2/internal/chainutil/chainutil.go
+++ b/v2/internal/chainutil/chainutil.go
@@ -80,7 +80,7 @@ func (cs *ChainSim) Fork() *ChainSim {
 	return &cs2
 }
 
-//MineBlockWithTxns mine a block with the given transaction.
+// MineBlockWithTxns mine a block with the given transaction.
 func (cs *ChainSim) MineBlockWithTxns(txns ...types.Transaction) types.Block {
 	prev := cs.Genesis.Block.Header
 	if len(cs.Chain) > 0 {

--- a/v2/types/currency.go
+++ b/v2/types/currency.go
@@ -51,10 +51,9 @@ func (c Currency) Equals(v Currency) bool {
 
 // Cmp compares c and v and returns:
 //
-//   -1 if c <  v
-//    0 if c == v
-//   +1 if c >  v
-//
+//	-1 if c <  v
+//	 0 if c == v
+//	+1 if c >  v
 func (c Currency) Cmp(v Currency) int {
 	if c == v {
 		return 0
@@ -236,9 +235,9 @@ func (c Currency) String() string {
 
 // Format implements fmt.Formatter. It accepts the following formats:
 //
-//   d: raw integer (equivalent to ExactString())
-//   s: rounded integer with unit suffix (equivalent to String())
-//   v: same as s
+//	d: raw integer (equivalent to ExactString())
+//	s: rounded integer with unit suffix (equivalent to String())
+//	v: same as s
 func (c Currency) Format(f fmt.State, v rune) {
 	switch v {
 	case 'd':

--- a/wallet/address.go
+++ b/wallet/address.go
@@ -1,0 +1,20 @@
+package wallet
+
+import "go.sia.tech/core/types"
+
+// StandardUnlockConditions returns the standard unlock conditions for a single
+// Ed25519 key.
+func StandardUnlockConditions(pub types.PublicKey) types.UnlockConditions {
+	return types.UnlockConditions{
+		PublicKeys: []types.UnlockKey{{
+			Algorithm: types.SpecifierEd25519,
+			Key:       pub[:],
+		}},
+		SignaturesRequired: 1,
+	}
+}
+
+// StandardAddress returns the standard address for an Ed25519 key.
+func StandardAddress(pub types.PublicKey) types.Address {
+	return StandardUnlockConditions(pub).UnlockHash()
+}


### PR DESCRIPTION
Adds test that creates new chain.Manager and in memory DB, adds some blocks, ensures the block diffs are correct and checks that the SC and SF outputs from the transactions in the blocks are in the DB.