### PR TITLE
Add ForceClose to Transport

### DIFF
--- a/rhp/v2/transport.go
+++ b/rhp/v2/transport.go
@@ -454,6 +454,18 @@ func (t *Transport) Close() (err error) {
 	return t.conn.Close()
 }
 
+// ForceClose calls Close on the transport's underlying connection.
+func (t *Transport) ForceClose() (err error) {
+	defer wrapErr(&err, "ForceClose")
+	if t.IsClosed() {
+		return nil
+	}
+	t.mu.Lock()
+	t.closed = true
+	t.mu.Unlock()
+	return t.conn.Close()
+}
+
 func hashKeys(k1, k2 [32]byte) types.Hash256 {
 	return blake2b.Sum256(append(append(make([]byte, 0, len(k1)+len(k2)), k1[:]...), k2[:]...))
 }


### PR DESCRIPTION
We need a `ForceClose` that doesn't try to gracefully close the transport by writing `LoopExit`. The reason for this is that the transport reuses bytes on write causing a data race is we try to close the transport from another thread.