### PR TITLE
RHP Encoding Fixes

### DIFF
--- a/rhp/v3/encoding.go
+++ b/rhp/v3/encoding.go
@@ -217,6 +217,7 @@ func (r *FundAccountReceipt) EncodeTo(e *types.Encoder) {
 	r.Host.EncodeTo(e)
 	r.Account.EncodeTo(e)
 	r.Amount.EncodeTo(e)
+	e.WriteTime(r.Timestamp)
 }
 
 // DecodeFrom implements ProtocolObject.

--- a/rhp/v3/encoding.go
+++ b/rhp/v3/encoding.go
@@ -158,7 +158,6 @@ func (r *PayByContractRequest) EncodeTo(e *types.Encoder) {
 	}
 	r.RefundAccount.EncodeTo(e)
 	e.WriteBytes(r.Signature[:])
-	r.HostSignature.EncodeTo(e)
 }
 
 // DecodeFrom implements ProtocolObject.
@@ -175,7 +174,6 @@ func (r *PayByContractRequest) DecodeFrom(d *types.Decoder) {
 	}
 	r.RefundAccount.DecodeFrom(d)
 	copy(r.Signature[:], d.ReadBytes())
-	r.HostSignature.DecodeFrom(d)
 }
 
 // EncodeTo implements ProtocolObject.

--- a/rhp/v3/encoding.go
+++ b/rhp/v3/encoding.go
@@ -291,7 +291,6 @@ func (r *RPCExecuteProgramRequest) DecodeFrom(d *types.Decoder) {
 			d.SetErr(fmt.Errorf("unrecognized instruction id: %q", id))
 			return
 		}
-		_ = d.ReadPrefix() // unused length prefix
 		if r.Program[i].DecodeFrom(d); d.Err() != nil {
 			return
 		}

--- a/rhp/v3/program.go
+++ b/rhp/v3/program.go
@@ -224,15 +224,15 @@ func (i *InstrReadOffset) RequiresFinalization() bool {
 
 // EncodeTo implements Instruction.
 func (i *InstrReadOffset) EncodeTo(e *types.Encoder) {
-	e.WriteUint64(i.LengthOffset)
 	e.WriteUint64(i.OffsetOffset)
+	e.WriteUint64(i.LengthOffset)
 	e.WriteBool(i.ProofRequired)
 }
 
 // DecodeFrom implements Instruction.
 func (i *InstrReadOffset) DecodeFrom(d *types.Decoder) {
-	i.LengthOffset = d.ReadUint64()
 	i.OffsetOffset = d.ReadUint64()
+	i.LengthOffset = d.ReadUint64()
 	i.ProofRequired = d.ReadBool()
 }
 
@@ -248,17 +248,17 @@ func (i *InstrReadSector) RequiresFinalization() bool {
 
 // EncodeTo implements Instruction.
 func (i *InstrReadSector) EncodeTo(e *types.Encoder) {
-	e.WriteUint64(i.LengthOffset)
-	e.WriteUint64(i.OffsetOffset)
 	e.WriteUint64(i.MerkleRootOffset)
+	e.WriteUint64(i.OffsetOffset)
+	e.WriteUint64(i.LengthOffset)
 	e.WriteBool(i.ProofRequired)
 }
 
 // DecodeFrom implements Instruction.
 func (i *InstrReadSector) DecodeFrom(d *types.Decoder) {
-	i.LengthOffset = d.ReadUint64()
-	i.OffsetOffset = d.ReadUint64()
 	i.MerkleRootOffset = d.ReadUint64()
+	i.OffsetOffset = d.ReadUint64()
+	i.LengthOffset = d.ReadUint64()
 	i.ProofRequired = d.ReadBool()
 }
 
@@ -410,6 +410,8 @@ func (i *InstrUpdateRegistry) EncodeTo(e *types.Encoder) {
 	e.WriteUint64(i.SignatureOffset)
 	e.WriteUint64(i.PublicKeyOffset)
 	e.WriteUint64(i.PublicKeyLength)
+	e.WriteUint64(i.DataOffset)
+	e.WriteUint64(i.DataLength)
 	e.WriteUint8(uint8(i.EntryType))
 }
 
@@ -420,6 +422,8 @@ func (i *InstrUpdateRegistry) DecodeFrom(d *types.Decoder) {
 	i.SignatureOffset = d.ReadUint64()
 	i.PublicKeyOffset = d.ReadUint64()
 	i.PublicKeyLength = d.ReadUint64()
+	i.DataOffset = d.ReadUint64()
+	i.DataLength = d.ReadUint64()
 	i.EntryType = d.ReadUint8()
 }
 
@@ -430,6 +434,8 @@ func (i *InstrUpdateRegistryNoType) EncodeTo(e *types.Encoder) {
 	e.WriteUint64(i.SignatureOffset)
 	e.WriteUint64(i.PublicKeyOffset)
 	e.WriteUint64(i.PublicKeyLength)
+	e.WriteUint64(i.DataOffset)
+	e.WriteUint64(i.DataLength)
 }
 
 // DecodeFrom implements Instruction.
@@ -439,5 +445,7 @@ func (i *InstrUpdateRegistryNoType) DecodeFrom(d *types.Decoder) {
 	i.SignatureOffset = d.ReadUint64()
 	i.PublicKeyOffset = d.ReadUint64()
 	i.PublicKeyLength = d.ReadUint64()
+	i.DataOffset = d.ReadUint64()
+	i.DataLength = d.ReadUint64()
 	i.EntryType = EntryTypeArbitrary
 }

--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -403,7 +403,6 @@ type (
 		MissedProofValues []types.Currency
 		RefundAccount     Account
 		Signature         types.Signature
-		HostSignature     types.Signature
 	}
 )
 

--- a/rhp/v3/transport.go
+++ b/rhp/v3/transport.go
@@ -95,7 +95,16 @@ func (s *Stream) writeObject(resp *rpcResponse) error {
 	resp.EncodeTo(e)
 	e.Flush()
 	b := buf.Bytes()
-	binary.LittleEndian.PutUint64(b[:8], uint64(len(b)-8))
+	length := len(b) - 8
+	// HACK: in siad, the ExecuteProgram RPC sends the ProgramData separately
+	// from the rest of the request object. This was a performance optimization
+	// relating to how siad handles encoding and length prefixes. Suffice it to
+	// say, that optimization is not necessary in core, but we still have to
+	// preserve compatibility with how siad does things.
+	if r, ok := resp.data.(*RPCExecuteProgramRequest); ok {
+		length -= len(r.ProgramData)
+	}
+	binary.LittleEndian.PutUint64(b[:8], uint64(length))
 	_, err := s.s.Write(b)
 	return err
 }


### PR DESCRIPTION
This PR fixes some of the encoding issues in the new `rhp` code. I've only tested it with `ReadSector`. I decided to open a PR because I think Nate and I are working through the same issues so I figured we could consolidate our efforts into one PR/branch and get it merged. 

The main issues I think are:
- [ ] instructions should be length prefixed
- [ ] `writeObject` requires a hack-fix in the lenght prefix because MDM programs now include the data
- [ ] order of field encoding is off at times
- [ ] some fields are missing in the encoding