### PR TITLE
Network parameters

### DIFF
--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -214,7 +214,7 @@ func validateSiafunds(s State, store Store, txns []types.Transaction) error {
 			}
 			if sfi.UnlockConditions.UnlockHash() != parent.Address &&
 				// override old developer siafund address
-				!(s.childHeight() >= hardforkDevAddr &&
+				!(s.childHeight() >= s.params().hardforkHeightDevAddr &&
 					parent.Address.String() == "addr:7d0c44f7664e2d34e53efde0661a6f628ec9264785ae8e3cd7c973e8d190c3c97b5e3ecbc567" &&
 					sfi.UnlockConditions.UnlockHash().String() == "addr:f371c70bce9eb8979cd5099f599ec4e4fcb14e0afcf31f9791e03e6496a4c0b358c98279730b") {
 				return fmt.Errorf("transaction %v claims incorrect unlock conditions for siafund output %v", i, sfi.ParentID)
@@ -400,9 +400,9 @@ func validateStorageProofs(s State, store Store, txn types.Transaction) error {
 			totalLeaves++
 		}
 		var leafLen uint64
-		if s.childHeight() < hardforkTax {
+		if s.childHeight() < s.params().hardforkHeightTax {
 			leafLen = leafSize
-		} else if s.childHeight() < hardforkStorageProof {
+		} else if s.childHeight() < s.params().hardforkHeightStorageProof {
 			leafLen = leafSize
 			if leafIndex == totalLeaves-1 {
 				leafLen = fc.Filesize % leafSize
@@ -425,7 +425,7 @@ func validateStorageProofs(s State, store Store, txn types.Transaction) error {
 }
 
 func validateArbitraryData(s State, store Store, txn types.Transaction) error {
-	if s.childHeight() < hardforkFoundation {
+	if s.childHeight() < s.params().hardforkHeightFoundation {
 		return nil
 	}
 	for _, arb := range txn.ArbitraryData {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	go.sia.tech/mux v1.2.0
 	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122
-	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1
+	golang.org/x/sys v0.5.0
 	lukechampine.com/frand v1.4.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,9 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
I took a stab at addressing the issue that I alluded to in https://github.com/SiaFoundation/core/pull/95. The approach I ended up taking was a bit different than what I originally suggested. The problem with embedding the entire `NetworkParams` struct within `State` is that now you have to encode/decode all of those parameters every time you encode/decode a `State`. This is egregiously wasteful; the consensus DB would end up storing hundreds of thousands of copies of the same parameters. I suppose we could have the DB override the encoding of `State`, but you'd also have to override the encoding of any type that *contains* `State` (e.g. `Checkpoint`), and this would affect all future users of `State`, not just us.

It occurred to me that we could store just an ID, rather than the full params, and use the ID to select from a set of parameters defined locally in `consensus`. Then I thought: why bother with the IDs at all, when we can already distinguish between mainnet and testnet using `(State).GenesisTimestamp`? So that's what this PR does: use the genesis timestamp to select the set of network parameters.

I don't *love* this approach; it feels "sneaky," in the same way that global variables are sneaky. In particular, I don't like defining mainnet vs. testnet parameters within `consensus` itself. But the alternative -- passing them in -- means that they have to be embedded in every `State` object (wasteful/cumbersome) or supplied as a separate argument (i.e. everywhere we pass `consensus.State`, we now *also* have to pass a `NetworkParams`... gross). I also don't see much practical use for passing a `NetworkParams` *other* than mainnet or testnet.

That reminds me: another thing to note here is that we've gone from "standard, dev, testing, testnet" to just "mainnet, testnet." I don't think we have any real use for `dev` and `testing` anymore. `dev` was for antfarm stuff (which we can/should do on testnet now). `testing` was mostly a way of lowering the difficulty so that we could mine long chains during automated testing -- but if you set a very low initial difficulty, you can mine a *lot* of blocks before the difficulty ramps up. `testing` also triggered hardforks much earlier, but that's true of `testnet` as well, and the new consensus design makes it trivial to "fast-forward" to any desired hardfork height anyway.

Mainnet and testnet share a lot of constants (e.g. `BlockInterval`), so I didn't bother moving all of them to `networkParams`. You could argue that they belong there anyway, but idk, I'd rather have `networkParams` only specify what actually differs between chains.

cc @n8maninger 