### PR TITLE
consensus: Use build tag for testnet

### DIFF
--- a/consensus/network_mainnet.go
+++ b/consensus/network_mainnet.go
@@ -1,0 +1,24 @@
+//go:build !testnet
+
+package consensus
+
+import (
+	"time"
+
+	"go.sia.tech/core/types"
+)
+
+const (
+	hardforkHeightDevAddr      = 10000
+	hardforkHeightTax          = 21000
+	hardforkHeightStorageProof = 100000
+	hardforkHeightOak          = 135000
+	hardforkHeightOakFix       = 139000
+	hardforkHeightASIC         = 179000
+	hardforkHeightFoundation   = 298000
+
+	hardforkASICTotalTime = 120000 * time.Second
+	minimumCoinbase       = 30000
+)
+
+var hardforkASICTotalTarget = types.BlockID{8: 32}

--- a/consensus/network_testnet.go
+++ b/consensus/network_testnet.go
@@ -1,0 +1,24 @@
+//go:build testnet
+
+package consensus
+
+import (
+	"time"
+
+	"go.sia.tech/core/types"
+)
+
+const (
+	hardforkHeightDevAddr      = 1
+	hardforkHeightTax          = 2
+	hardforkHeightStorageProof = 5
+	hardforkHeightOak          = 10
+	hardforkHeightOakFix       = 12
+	hardforkHeightASIC         = 20
+	hardforkHeightFoundation   = 30
+
+	hardforkASICTotalTime = 10000 * time.Second
+	minimumCoinbase       = 300000
+)
+
+var hardforkASICTotalTarget = types.BlockID{4: 1}

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -38,11 +38,11 @@ func mulTargetFrac(x types.BlockID, n, d int64) (m types.BlockID) {
 }
 
 func updateOakTime(s State, blockTimestamp time.Time) time.Duration {
-	if s.childHeight() == s.params().hardforkHeightASIC-1 {
-		return s.params().hardforkASICTotalTime
+	if s.childHeight() == hardforkHeightASIC-1 {
+		return hardforkASICTotalTime
 	}
 	prevTotalTime := s.OakTime
-	if s.childHeight() == s.params().hardforkHeightOak-1 {
+	if s.childHeight() == hardforkHeightOak-1 {
 		prevTotalTime = s.BlockInterval() * time.Duration(s.childHeight())
 	}
 	decayedTime := (((prevTotalTime / time.Second) * 995) / 1000) * time.Second
@@ -50,8 +50,8 @@ func updateOakTime(s State, blockTimestamp time.Time) time.Duration {
 }
 
 func updateOakTarget(s State) types.BlockID {
-	if s.childHeight() == s.params().hardforkHeightASIC-1 {
-		return s.params().hardforkASICTotalTarget
+	if s.childHeight() == hardforkHeightASIC-1 {
+		return hardforkASICTotalTarget
 	}
 	return addTarget(mulTargetFrac(s.OakTarget, 1000, 995), s.ChildTarget)
 }
@@ -60,7 +60,7 @@ func adjustTarget(s State, blockTimestamp time.Time, store Store) types.BlockID 
 	blockInterval := int64(s.BlockInterval() / time.Second)
 
 	// pre-Oak algorithm
-	if s.childHeight() <= s.params().hardforkHeightOak {
+	if s.childHeight() <= hardforkHeightOak {
 		windowSize := uint64(1000)
 		if s.childHeight()%(windowSize/2) != 0 {
 			return s.ChildTarget // no change
@@ -85,7 +85,7 @@ func adjustTarget(s State, blockTimestamp time.Time, store Store) types.BlockID 
 	oakTotalTime := int64(s.OakTime / time.Second)
 
 	var delta int64
-	if s.Index.Height < s.params().hardforkHeightOakFix {
+	if s.Index.Height < hardforkHeightOakFix {
 		delta = (blockInterval * int64(s.Index.Height)) - oakTotalTime
 	} else {
 		parentTimestamp := s.PrevTimestamps[0]
@@ -137,7 +137,7 @@ func adjustTarget(s State, blockTimestamp time.Time, store Store) types.BlockID 
 	//
 	// NOTE: the multiplications are flipped re: siad because we are comparing
 	// work, not targets
-	if s.childHeight() == s.params().hardforkHeightASIC {
+	if s.childHeight() == hardforkHeightASIC {
 		return newTarget
 	}
 	min := mulTargetFrac(s.ChildTarget, 1004, 1000)
@@ -168,7 +168,7 @@ func ApplyState(s State, store Store, b types.Block) State {
 	newFoundationFailsafeAddress := s.FoundationFailsafeAddress
 	var updatedFoundation bool // Foundation addresses can only be updated once per block
 	for _, txn := range b.Transactions {
-		if s.Index.Height >= s.params().hardforkHeightFoundation {
+		if s.Index.Height >= hardforkHeightFoundation {
 			for _, arb := range txn.ArbitraryData {
 				if bytes.HasPrefix(arb, types.SpecifierFoundation[:]) && !updatedFoundation {
 					var update types.FoundationAddressUpdate

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -214,7 +214,7 @@ func validateSiafunds(s State, store Store, txns []types.Transaction) error {
 			}
 			if sfi.UnlockConditions.UnlockHash() != parent.Address &&
 				// override old developer siafund address
-				!(s.childHeight() >= s.params().hardforkHeightDevAddr &&
+				!(s.childHeight() >= hardforkHeightDevAddr &&
 					parent.Address.String() == "addr:7d0c44f7664e2d34e53efde0661a6f628ec9264785ae8e3cd7c973e8d190c3c97b5e3ecbc567" &&
 					sfi.UnlockConditions.UnlockHash().String() == "addr:f371c70bce9eb8979cd5099f599ec4e4fcb14e0afcf31f9791e03e6496a4c0b358c98279730b") {
 				return fmt.Errorf("transaction %v claims incorrect unlock conditions for siafund output %v", i, sfi.ParentID)
@@ -400,9 +400,9 @@ func validateStorageProofs(s State, store Store, txn types.Transaction) error {
 			totalLeaves++
 		}
 		var leafLen uint64
-		if s.childHeight() < s.params().hardforkHeightTax {
+		if s.childHeight() < hardforkHeightTax {
 			leafLen = leafSize
-		} else if s.childHeight() < s.params().hardforkHeightStorageProof {
+		} else if s.childHeight() < hardforkHeightStorageProof {
 			leafLen = leafSize
 			if leafIndex == totalLeaves-1 {
 				leafLen = fc.Filesize % leafSize
@@ -425,7 +425,7 @@ func validateStorageProofs(s State, store Store, txn types.Transaction) error {
 }
 
 func validateArbitraryData(s State, store Store, txn types.Transaction) error {
-	if s.childHeight() < s.params().hardforkHeightFoundation {
+	if s.childHeight() < hardforkHeightFoundation {
 		return nil
 	}
 	for _, arb := range txn.ArbitraryData {


### PR DESCRIPTION
Flip-flopping on #96 :|

I don't like build tags in general, but I'll allow it for this. It's better than branching through `s.params()` everywhere.

For posterity, I also investigated a "fork flag" approach, which worked like this:
```go
type ForkFlags uint64

const (
	ForkTestnet ForkFlags = iota
	ForkDevAddr
	ForkTax
	// ...
)

type State struct {
	ForkFlags ForkFlags
	// ...
}

// used like so:
func (s State) NonceFactor() uint64 {
	if s.ForkFlags&(1<<ForkASIC) != 0 {
		return 1009
	}
	return 1
}

// set like so:

type Network interface {
	ForkFlags(s State, b types.Block) ForkFlags
}

func ApplyState(s State, store Store, b types.Block, network Network) State {
	// ...
	return State{
		ForkFlags: network.ForkFlags(s, b),
	}
```

Basically, you pass a `Network` to ApplyState, and it sets the fork flags on the resulting `State`. So on mainnet (and testnet), we would pass a `Network` that sets flags based on `s.Index.Height`. In our automated tests, though, we could set the flags directly, instead of fast-forwarding to a particular height like we do now. Neat! Another cute feature is that you can encode the flags as a string, with emoji representing each flag.

Unfortunately, practice turned out to be uglier than theory. This approach *could* work, but it would require many more flags than you would expect. For example, the Foundation subsidy is paid out every 4380 blocks, starting at the hardfork height. But in this design, `State` doesn't know what the hardfork height is. So instead, we have to define a separate `ForkFoundationSubsidy` flag, and make `Network` responsible for setting that flag at the appropriate heights. Oh, but you also need a `ForkFoundationInitialSubsidy`, which is set exactly once, on the hardfork activation block itself! Similarly, you need two or three distinct flags for the ASIC hardfork, because there are specific actions that must occur on the activation block *and* on the block immediately prior to activation.

Like I said... it *could* work, but it forces you to move what *feels like* consensus code (e.g. Foundation subsidies) outside of the `consensus` package, which makes me uncomfortable. I got about halfway through the implementation before it started feeling so messy that I just got sad and scrapped it all. If I were implementing a *new* blockchain, I might take this approach, but it just doesn't work very well for the blockchain we have. :/