### PR TITLE
Add types for RPCLatestRevision

### DIFF
--- a/rhp/v3/encoding.go
+++ b/rhp/v3/encoding.go
@@ -375,6 +375,26 @@ func (r *RPCFinalizeProgramResponse) DecodeFrom(d *types.Decoder) {
 	copy(r.Signature[:], d.ReadBytes())
 }
 
+// EncodeTo implements ProtocolObject.
+func (r *RPCLatestRevisionRequest) EncodeTo(e *types.Encoder) {
+	r.ContractID.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCLatestRevisionRequest) DecodeFrom(d *types.Decoder) {
+	r.ContractID.DecodeFrom(d)
+}
+
+// EncodeTo implements ProtocolObject.
+func (r *RPCLatestRevisionResponse) EncodeTo(e *types.Encoder) {
+	r.Revision.EncodeTo(e)
+}
+
+// DecodeFrom implements ProtocolObject.
+func (r *RPCLatestRevisionResponse) DecodeFrom(d *types.Decoder) {
+	r.Revision.DecodeFrom(d)
+}
+
 func instructionID(instr Instruction) types.Specifier {
 	switch instr.(type) {
 	case *InstrAppendSector:

--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -499,4 +499,12 @@ type (
 	RPCFinalizeProgramResponse struct {
 		Signature types.Signature
 	}
+
+	RPCLatestRevisionRequest struct {
+		ContractID types.FileContractID
+	}
+
+	RPCLatestRevisionResponse struct {
+		Revision types.FileContractRevision
+	}
 )


### PR DESCRIPTION
Adding the types for the request and response of the RPCLatestRevision RPC to use in renterd.