### PR TITLE
Update RPCRenewSignatures to match siad type

### DIFF
--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -530,6 +530,6 @@ type (
 	// the renew contract RPC.
 	RPCRenewSignatures struct {
 		TransactionSignatures []types.TransactionSignature
-		RevisionSignature     types.Signature
+		RevisionSignature     types.TransactionSignature
 	}
 )


### PR DESCRIPTION
Right now `RPCRenewSignatures` doesn't match `RPCRenewContractRenterSignatures` and `RPCRenewContractHostSignatures` from `siad`. So rhpv3 renewals fail due to a decoding error.