### PR TITLE
MidState

### DIFF
--- a/chain/db_test.go
+++ b/chain/db_test.go
@@ -277,9 +277,7 @@ func TestChainManager(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := dbStore.RevertDiff(cm.TipState(), *s.cau); err != nil {
-		t.Fatal(err)
-	}
+	dbStore.RevertDiff(cm.TipState(), *s.cau)
 
 	if err := db.View(checkDBOutputs(txn)); err == nil {
 		t.Fatal("should be missing siacoin/siafund outputs from reverted block")
@@ -517,14 +515,11 @@ func TestConsensusValidate(t *testing.T) {
 			signTxn(cm.TipState(), giftPrivateKey, &corruptBlock.Transactions[0])
 			FindBlockNonce(cs, &corruptBlock)
 
-			if err := dbStore.WithConsensus(func(cstore consensus.Store) error {
+			dbStore.WithConsensus(func(cstore consensus.Store) {
 				if err := consensus.ValidateBlock(cs, cstore, corruptBlock); err == nil {
-					return fmt.Errorf("accepted block with %v", test.desc)
+					t.Fatalf("accepted block with %v", test.desc)
 				}
-				return nil
-			}); err != nil {
-				t.Fatal(err)
-			}
+			})
 		}
 	}
 	{
@@ -750,14 +745,11 @@ func TestConsensusValidate(t *testing.T) {
 			signTxn(cm.TipState(), giftPrivateKey, &corruptBlock.Transactions[0])
 			FindBlockNonce(cs, &corruptBlock)
 
-			if err := dbStore.WithConsensus(func(cstore consensus.Store) error {
+			dbStore.WithConsensus(func(cstore consensus.Store) {
 				if err := consensus.ValidateBlock(cs, cstore, corruptBlock); err == nil {
-					return fmt.Errorf("accepted block with %v", test.desc)
+					t.Fatalf("accepted block with %v", test.desc)
 				}
-				return nil
-			}); err != nil {
-				t.Fatal(err)
-			}
+			})
 		}
 	}
 }

--- a/chain/db_test.go
+++ b/chain/db_test.go
@@ -2,35 +2,16 @@ package chain
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"math"
 	"reflect"
 	"testing"
-	"time"
 
 	"go.sia.tech/core/consensus"
 	rhpv2 "go.sia.tech/core/rhp/v2"
 	"go.sia.tech/core/types"
-	"lukechampine.com/frand"
 )
 
-// AppendTransactionSignature appends a TransactionSignature to txn and signs it
-// with key.
-func AppendTransactionSignature(cs consensus.State, key types.PrivateKey, parentID types.Hash256, txn *types.Transaction) {
-	sig := types.TransactionSignature{
-		ParentID:       parentID,
-		CoveredFields:  types.CoveredFields{WholeTransaction: true},
-		PublicKeyIndex: 0,
-	}
-	sigHash := key.SignHash(cs.WholeSigHash(*txn, sig.ParentID, sig.PublicKeyIndex, sig.Timelock, sig.CoveredFields.Signatures))
-	sig.Signature = sigHash[:]
-
-	txn.Signatures = append(txn.Signatures, sig)
-}
-
-// FindBlockNonce finds a block nonce meeting current target.
-func FindBlockNonce(cs consensus.State, b *types.Block) {
+func findBlockNonce(cs consensus.State, b *types.Block) {
 	// ensure nonce meets factor requirement
 	for b.Nonce%cs.NonceFactor() != 0 {
 		b.Nonce++
@@ -40,36 +21,40 @@ func FindBlockNonce(cs consensus.State, b *types.Block) {
 	}
 }
 
-func addBlock(cm *Manager, b *types.Block) error {
-	var minerAddress types.Address
-	frand.Read(minerAddress[:])
-
-	cs := cm.TipState()
-	b.MinerPayouts = []types.SiacoinOutput{{Address: minerAddress, Value: cs.BlockReward()}}
-	FindBlockNonce(cs, b)
-	return cm.AddBlocks([]types.Block{*b})
+func addBlock(cm *Manager, b types.Block) error {
+	findBlockNonce(cm.TipState(), &b)
+	return cm.AddBlocks([]types.Block{b})
 }
 
-func deepCopyBlock(block types.Block) (types.Block, error) {
-	b, err := json.Marshal(block)
-	if err != nil {
-		return types.Block{}, err
+func deepCopyBlock(b types.Block) (b2 types.Block) {
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+	b.EncodeTo(e)
+	e.Flush()
+	d := types.NewBufDecoder(buf.Bytes())
+	b2.DecodeFrom(d)
+	return
+}
+
+func signTxn(cs consensus.State, key types.PrivateKey, txn *types.Transaction) {
+	appendSig := func(parentID types.Hash256) {
+		sig := key.SignHash(cs.WholeSigHash(*txn, parentID, 0, 0, nil))
+		txn.Signatures = append(txn.Signatures, types.TransactionSignature{
+			ParentID:       parentID,
+			CoveredFields:  types.CoveredFields{WholeTransaction: true},
+			PublicKeyIndex: 0,
+			Signature:      sig[:],
+		})
 	}
 
-	var result types.Block
-	err = json.Unmarshal(b, &result)
-	return result, err
-}
-
-func signTxn(cs consensus.State, privateKey types.PrivateKey, txn *types.Transaction) {
 	for i := range txn.SiacoinInputs {
-		AppendTransactionSignature(cs, privateKey, types.Hash256(txn.SiacoinInputs[i].ParentID), txn)
+		appendSig(types.Hash256(txn.SiacoinInputs[i].ParentID))
 	}
 	for i := range txn.SiafundInputs {
-		AppendTransactionSignature(cs, privateKey, types.Hash256(txn.SiafundInputs[i].ParentID), txn)
+		appendSig(types.Hash256(txn.SiafundInputs[i].ParentID))
 	}
 	for i := range txn.FileContractRevisions {
-		AppendTransactionSignature(cs, privateKey, types.Hash256(txn.FileContractRevisions[i].ParentID), txn)
+		appendSig(types.Hash256(txn.FileContractRevisions[i].ParentID))
 	}
 }
 
@@ -156,10 +141,11 @@ func TestChainManager(t *testing.T) {
 
 	// block with nothing except block reward
 	b1 := types.Block{
-		ParentID:  genesisBlock.ID(),
-		Timestamp: time.Now(),
+		ParentID:     genesisBlock.ID(),
+		Timestamp:    types.CurrentTimestamp(),
+		MinerPayouts: []types.SiacoinOutput{{Address: types.VoidAddress, Value: cm.TipState().BlockReward()}},
 	}
-	if err := addBlock(cm, &b1); err != nil {
+	if err := addBlock(cm, b1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -207,10 +193,11 @@ func TestChainManager(t *testing.T) {
 
 	b2 := types.Block{
 		ParentID:     b1.ID(),
-		Timestamp:    time.Now(),
+		Timestamp:    types.CurrentTimestamp(),
+		MinerPayouts: []types.SiacoinOutput{{Address: types.VoidAddress, Value: cm.TipState().BlockReward()}},
 		Transactions: []types.Transaction{txn},
 	}
-	if err := addBlock(cm, &b2); err != nil {
+	if err := addBlock(cm, b2); err != nil {
 		t.Fatal(err)
 	}
 
@@ -337,18 +324,20 @@ func TestConsensusValidate(t *testing.T) {
 
 	// block with nothing except block reward
 	b1 := types.Block{
-		ParentID:  genesisBlock.ID(),
-		Timestamp: time.Now(),
+		ParentID:     genesisBlock.ID(),
+		Timestamp:    types.CurrentTimestamp(),
+		MinerPayouts: []types.SiacoinOutput{{Address: types.VoidAddress, Value: cm.TipState().BlockReward()}},
 	}
-	if err := addBlock(cm, &b1); err != nil {
+	if err := addBlock(cm, b1); err != nil {
 		t.Fatal(err)
 	}
 	for i := 0; i < 30; i++ {
 		b1 = types.Block{
-			ParentID:  b1.ID(),
-			Timestamp: time.Now(),
+			ParentID:     b1.ID(),
+			Timestamp:    types.CurrentTimestamp(),
+			MinerPayouts: []types.SiacoinOutput{{Address: types.VoidAddress, Value: cm.TipState().BlockReward()}},
 		}
-		if err := addBlock(cm, &b1); err != nil {
+		if err := addBlock(cm, b1); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -382,10 +371,11 @@ func TestConsensusValidate(t *testing.T) {
 	cs := cm.TipState()
 	b2 := types.Block{
 		ParentID:     b1.ID(),
-		Timestamp:    time.Now(),
+		Timestamp:    types.CurrentTimestamp(),
+		MinerPayouts: []types.SiacoinOutput{{Address: types.VoidAddress, Value: cm.TipState().BlockReward()}},
 		Transactions: []types.Transaction{txnB2},
 	}
-	if err := addBlock(cm, &b2); err != nil {
+	if err := addBlock(cm, b2); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.View(checkDBOutputs(txnB2)); err != nil {
@@ -398,7 +388,7 @@ func TestConsensusValidate(t *testing.T) {
 	fc.UnlockHash = types.Hash256(giftPublicKey.StandardUnlockConditions().UnlockHash())
 
 	revision := giftFC
-	revision.RevisionNumber += 1
+	revision.RevisionNumber++
 	revision.WindowStart = cs.Index.Height + 1
 	revision.WindowEnd = revision.WindowStart + 100
 
@@ -435,7 +425,7 @@ func TestConsensusValidate(t *testing.T) {
 
 	b3 := types.Block{
 		ParentID:     b2.ID(),
-		Timestamp:    time.Now(),
+		Timestamp:    types.CurrentTimestamp(),
 		Transactions: []types.Transaction{txnB3},
 		MinerPayouts: []types.SiacoinOutput{{
 			Address: types.VoidAddress,
@@ -496,24 +486,18 @@ func TestConsensusValidate(t *testing.T) {
 			{
 				"overflowing miner payout",
 				func(b *types.Block) {
-					b.MinerPayouts = []types.SiacoinOutput{{
-						Address: types.VoidAddress,
-						Value:   types.Currency{math.MaxUint64, math.MaxUint64},
-					}, {
-						Address: types.VoidAddress,
-						Value:   types.Currency{math.MaxUint64, math.MaxUint64},
-					}}
+					b.MinerPayouts = []types.SiacoinOutput{
+						{Address: types.VoidAddress, Value: types.MaxCurrency},
+						{Address: types.VoidAddress, Value: types.MaxCurrency},
+					}
 				},
 			},
 		}
 		for _, test := range tests {
-			corruptBlock, err := deepCopyBlock(b3)
-			if err != nil {
-				t.Fatal(err)
-			}
+			corruptBlock := deepCopyBlock(b3)
 			test.corrupt(&corruptBlock)
 			signTxn(cm.TipState(), giftPrivateKey, &corruptBlock.Transactions[0])
-			FindBlockNonce(cs, &corruptBlock)
+			findBlockNonce(cs, &corruptBlock)
 
 			dbStore.WithConsensus(func(cstore consensus.Store) {
 				if err := consensus.ValidateBlock(cs, cstore, corruptBlock); err == nil {
@@ -535,7 +519,6 @@ func TestConsensusValidate(t *testing.T) {
 					}
 					txn.SiacoinInputs = nil
 					txn.FileContracts = nil
-					return
 				},
 			},
 			{
@@ -545,99 +528,85 @@ func TestConsensusValidate(t *testing.T) {
 						txn.SiafundOutputs[i].Value = 0
 					}
 					txn.SiafundInputs = nil
-					return
 				},
 			},
 			{
 				"zero-valued MinerFee",
 				func(txn *types.Transaction) {
 					txn.MinerFees = append(txn.MinerFees, types.ZeroCurrency)
-					return
 				},
 			},
 			{
 				"overflowing MinerFees",
 				func(txn *types.Transaction) {
-					txn.MinerFees = append(txn.MinerFees, types.Currency{math.MaxUint64, math.MaxUint64})
-					txn.MinerFees = append(txn.MinerFees, types.Currency{math.MaxUint64, math.MaxUint64})
-					return
+					txn.MinerFees = append(txn.MinerFees, types.MaxCurrency)
+					txn.MinerFees = append(txn.MinerFees, types.MaxCurrency)
 				},
 			},
 			{
 				"siacoin outputs exceed inputs",
 				func(txn *types.Transaction) {
 					txn.SiacoinOutputs[0].Value = txn.SiacoinOutputs[0].Value.Add(types.NewCurrency64(1))
-					return
 				},
 			},
 			{
 				"siacoin outputs less than inputs",
 				func(txn *types.Transaction) {
 					txn.SiacoinOutputs[0].Value = txn.SiacoinOutputs[0].Value.Sub(types.NewCurrency64(1))
-					return
 				},
 			},
 			{
 				"siafund outputs exceed inputs",
 				func(txn *types.Transaction) {
 					txn.SiafundOutputs[0].Value = txn.SiafundOutputs[0].Value + 1
-					return
 				},
 			},
 			{
 				"siafund outputs less than inputs",
 				func(txn *types.Transaction) {
 					txn.SiafundOutputs[0].Value = txn.SiafundOutputs[0].Value - 1
-					return
 				},
 			},
 			{
 				"two of the same siacoin input",
 				func(txn *types.Transaction) {
 					txn.SiacoinInputs = append(txn.SiacoinInputs, txn.SiacoinInputs[0])
-					return
 				},
 			},
 			{
 				"two of the same siafund input",
 				func(txn *types.Transaction) {
 					txn.SiafundInputs = append(txn.SiafundInputs, txn.SiafundInputs[0])
-					return
 				},
 			},
 			{
 				"already spent siacoin input",
 				func(txn *types.Transaction) {
 					txn.SiacoinInputs = append([]types.SiacoinInput(nil), txnB2.SiacoinInputs...)
-					return
 				},
 			},
 			{
 				"already spent siafund input",
 				func(txn *types.Transaction) {
 					txn.SiafundInputs = append([]types.SiafundInput(nil), txnB2.SiafundInputs...)
-					return
 				},
 			},
 			{
 				"siacoin input claiming incorrect unlock conditions",
 				func(txn *types.Transaction) {
 					txn.SiacoinInputs[0].UnlockConditions.PublicKeys[0].Key[0] ^= 255
-					return
 				},
 			},
 			{
 				"siafund input claiming incorrect unlock conditions",
 				func(txn *types.Transaction) {
 					txn.SiafundInputs[0].UnlockConditions.PublicKeys[0].Key[0] ^= 255
-					return
 				},
 			},
 			{
 				"improperly-encoded FoundationAddressUpdate",
 				func(txn *types.Transaction) {
 					txn.ArbitraryData = append(txn.ArbitraryData, append(types.SpecifierFoundation[:], []byte{255, 255, 255, 255, 255}...))
-					return
 				},
 			},
 			{
@@ -648,7 +617,6 @@ func TestConsensusValidate(t *testing.T) {
 					types.FoundationAddressUpdate{}.EncodeTo(e)
 					e.Flush()
 					txn.ArbitraryData = append(txn.ArbitraryData, append(types.SpecifierFoundation[:], buf.Bytes()...))
-					return
 				},
 			},
 			{
@@ -656,10 +624,12 @@ func TestConsensusValidate(t *testing.T) {
 				func(txn *types.Transaction) {
 					var buf bytes.Buffer
 					e := types.NewEncoder(&buf)
-					types.FoundationAddressUpdate{giftAddress, giftAddress}.EncodeTo(e)
+					types.FoundationAddressUpdate{
+						NewPrimary:  giftAddress,
+						NewFailsafe: giftAddress,
+					}.EncodeTo(e)
 					e.Flush()
 					txn.ArbitraryData = append(txn.ArbitraryData, append(types.SpecifierFoundation[:], buf.Bytes()...))
-					return
 				},
 			},
 			{
@@ -737,13 +707,10 @@ func TestConsensusValidate(t *testing.T) {
 			},
 		}
 		for _, test := range tests {
-			corruptBlock, err := deepCopyBlock(b3)
-			if err != nil {
-				t.Fatal(err)
-			}
+			corruptBlock := deepCopyBlock(b3)
 			test.corrupt(&corruptBlock.Transactions[0])
 			signTxn(cm.TipState(), giftPrivateKey, &corruptBlock.Transactions[0])
-			FindBlockNonce(cs, &corruptBlock)
+			findBlockNonce(cs, &corruptBlock)
 
 			dbStore.WithConsensus(func(cstore consensus.Store) {
 				if err := consensus.ValidateBlock(cs, cstore, corruptBlock); err == nil {

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -354,7 +354,6 @@ func (m *Manager) AddSubscriber(s Subscriber, tip types.ChainIndex) error {
 		if !ok {
 			return fmt.Errorf("missing revert parent checkpoint %v", c.Block.ParentID)
 		}
-
 		if err := s.ProcessChainRevertUpdate(&RevertUpdate{c.Block, pc.State, *c.Diff}); err != nil {
 			return fmt.Errorf("couldn't process revert update: %w", err)
 		}
@@ -374,6 +373,13 @@ func (m *Manager) AddSubscriber(s Subscriber, tip types.ChainIndex) error {
 	}
 	m.subscribers = append(m.subscribers, s)
 	return nil
+}
+
+// WithConsensusStore calls fn on the current tip state and consensus store.
+func (m *Manager) WithConsensusStore(fn func(s consensus.State, cstore consensus.Store)) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.store.WithConsensus(func(cstore consensus.Store) { fn(m.tipState, cstore) })
 }
 
 // NewManager returns a Manager initialized with the provided Store and State.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -214,7 +214,7 @@ func (s State) NonceFactor() uint64 {
 }
 
 // MaxBlockWeight is the maximum "weight" of a valid child block.
-func (s State) MaxBlockWeight() int {
+func (s State) MaxBlockWeight() uint64 {
 	return 2_000_000
 }
 

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -490,49 +490,45 @@ func (bd *BlockDiff) DecodeFrom(d *types.Decoder) {
 	}
 }
 
+// ApplyTransaction applies a transaction to the MidState.
+func (ms *MidState) ApplyTransaction(store Store, txn types.Transaction) {
+	txid := txn.ID()
+	for _, sci := range txn.SiacoinInputs {
+		ms.spends[types.Hash256(sci.ParentID)] = txid
+	}
+	for i, sco := range txn.SiacoinOutputs {
+		ms.scos[txn.SiacoinOutputID(i)] = sco
+	}
+	for _, sfi := range txn.SiafundInputs {
+		ms.spends[types.Hash256(sfi.ParentID)] = txid
+	}
+	for i, sfo := range txn.SiafundOutputs {
+		sfoid := txn.SiafundOutputID(i)
+		ms.sfos[sfoid] = sfo
+		ms.claims[sfoid] = ms.siafundPool
+	}
+	for i, fc := range txn.FileContracts {
+		ms.fcs[txn.FileContractID(i)] = fc
+		ms.siafundPool = ms.siafundPool.Add(ms.base.FileContractTax(fc))
+	}
+	for _, fcr := range txn.FileContractRevisions {
+		fc := ms.mustFileContract(store, fcr.ParentID)
+		newContract := fcr.FileContract
+		newContract.Payout = fc.Payout // see types.FileContractRevision docstring
+		ms.fcs[fcr.ParentID] = newContract
+	}
+	for _, sp := range txn.StorageProofs {
+		ms.spends[types.Hash256(sp.ParentID)] = txid
+	}
+}
+
 // ApplyDiff applies b to s, returning the resulting effects.
 func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 	if s.Index.Height > 0 && s.Index.ID != b.ParentID {
 		panic("consensus: cannot apply non-child block")
 	}
 
-	siafundPool := s.SiafundPool
-	ephemeralSC := make(map[types.SiacoinOutputID]types.SiacoinOutput)
-	ephemeralSF := make(map[types.SiafundOutputID]types.SiafundOutput)
-	ephemeralClaims := make(map[types.SiafundOutputID]types.Currency)
-	ephemeralFC := make(map[types.FileContractID]types.FileContract)
-	hasStorageProof := make(map[types.FileContractID]bool)
-	getSC := func(id types.SiacoinOutputID) types.SiacoinOutput {
-		sco, ok := ephemeralSC[id]
-		if !ok {
-			sco, ok = store.SiacoinOutput(id)
-			if !ok {
-				panic("missing SiacoinOutput")
-			}
-		}
-		return sco
-	}
-	getSF := func(id types.SiafundOutputID) (types.SiafundOutput, types.Currency) {
-		sfo, ok := ephemeralSF[id]
-		claim := ephemeralClaims[id]
-		if !ok {
-			sfo, claim, ok = store.SiafundOutput(id)
-			if !ok {
-				panic("missing SiafundOutput")
-			}
-		}
-		return sfo, claim
-	}
-	getFC := func(id types.FileContractID) types.FileContract {
-		fc, ok := ephemeralFC[id]
-		if !ok {
-			fc, ok = store.FileContract(id)
-			if !ok {
-				panic("missing FileContract")
-			}
-		}
-		return fc
-	}
+	ms := NewMidState(s)
 
 	var diff BlockDiff
 	for _, txn := range b.Transactions {
@@ -540,7 +536,7 @@ func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 		for _, sci := range txn.SiacoinInputs {
 			tdiff.SpentSiacoinOutputs = append(tdiff.SpentSiacoinOutputs, SiacoinOutputDiff{
 				ID:     sci.ParentID,
-				Output: getSC(sci.ParentID),
+				Output: ms.mustSiacoinOutput(store, sci.ParentID),
 			})
 		}
 		for i, sco := range txn.SiacoinOutputs {
@@ -549,7 +545,6 @@ func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 				ID:     scoid,
 				Output: sco,
 			})
-			ephemeralSC[scoid] = sco
 		}
 		for i, fc := range txn.FileContracts {
 			fcid := txn.FileContractID(i)
@@ -557,17 +552,14 @@ func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 				ID:       fcid,
 				Contract: fc,
 			})
-			ephemeralFC[fcid] = fc
-			siafundPool = siafundPool.Add(s.FileContractTax(fc))
 		}
 		for _, sfi := range txn.SiafundInputs {
-			sfo, claimStart := getSF(sfi.ParentID)
+			sfo, claimStart, claimPortion := ms.mustSiafundOutput(store, sfi.ParentID)
 			tdiff.SpentSiafundOutputs = append(tdiff.SpentSiafundOutputs, SiafundOutputDiff{
 				ID:         sfi.ParentID,
 				Output:     sfo,
 				ClaimStart: claimStart,
 			})
-			claimPortion := siafundPool.Sub(claimStart).Div64(s.SiafundCount()).Mul64(sfo.Value)
 			tdiff.ImmatureSiacoinOutputs = append(tdiff.ImmatureSiacoinOutputs, DelayedSiacoinOutputDiff{
 				ID:             sfi.ParentID.ClaimOutputID(),
 				Output:         types.SiacoinOutput{Value: claimPortion, Address: sfi.ClaimAddress},
@@ -580,13 +572,11 @@ func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 			tdiff.CreatedSiafundOutputs = append(tdiff.CreatedSiafundOutputs, SiafundOutputDiff{
 				ID:         sfoid,
 				Output:     sfo,
-				ClaimStart: siafundPool,
+				ClaimStart: ms.siafundPool,
 			})
-			ephemeralSF[sfoid] = sfo
-			ephemeralClaims[sfoid] = siafundPool
 		}
 		for _, fcr := range txn.FileContractRevisions {
-			fc := getFC(fcr.ParentID)
+			fc := ms.mustFileContract(store, fcr.ParentID)
 			newContract := fcr.FileContract
 			newContract.Payout = fc.Payout // see types.FileContractRevision docstring
 			tdiff.RevisedFileContracts = append(tdiff.RevisedFileContracts, FileContractRevisionDiff{
@@ -594,10 +584,9 @@ func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 				OldContract: fc,
 				NewContract: newContract,
 			})
-			ephemeralFC[fcr.ParentID] = newContract
 		}
 		for _, sp := range txn.StorageProofs {
-			fc := getFC(sp.ParentID)
+			fc := ms.mustFileContract(store, sp.ParentID)
 			tdiff.ValidFileContracts = append(tdiff.ValidFileContracts, FileContractDiff{
 				ID:       sp.ParentID,
 				Contract: fc,
@@ -610,9 +599,9 @@ func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 					MaturityHeight: s.MaturityHeight(),
 				})
 			}
-			hasStorageProof[sp.ParentID] = true
 		}
 		diff.Transactions = append(diff.Transactions, tdiff)
+		ms.ApplyTransaction(store, txn)
 	}
 
 	bid := b.ID()
@@ -626,10 +615,10 @@ func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 		})
 	}
 	for _, fcid := range store.MissedFileContracts(s.childHeight()) {
-		if hasStorageProof[fcid] {
+		if _, ok := ms.spent(types.Hash256(fcid)); ok {
 			continue
 		}
-		fc := getFC(fcid)
+		fc := ms.mustFileContract(store, fcid)
 		diff.MissedFileContracts = append(diff.MissedFileContracts, FileContractDiff{
 			ID:       fcid,
 			Contract: fc,

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -448,7 +448,6 @@ type BlockDiff struct {
 	MaturedSiacoinOutputs  []DelayedSiacoinOutputDiff
 	ImmatureSiacoinOutputs []DelayedSiacoinOutputDiff
 	MissedFileContracts    []FileContractDiff
-	FoundationSubsidy      *DelayedSiacoinOutputDiff
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -645,12 +644,12 @@ func ApplyDiff(s State, store Store, b types.Block) BlockDiff {
 		}
 	}
 	if subsidy := s.FoundationSubsidy(); !subsidy.Value.IsZero() {
-		diff.FoundationSubsidy = &DelayedSiacoinOutputDiff{
+		diff.ImmatureSiacoinOutputs = append(diff.ImmatureSiacoinOutputs, DelayedSiacoinOutputDiff{
 			ID:             bid.FoundationOutputID(),
 			Output:         subsidy,
 			Source:         OutputSourceFoundation,
 			MaturityHeight: s.MaturityHeight(),
-		}
+		})
 	}
 
 	return diff

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -56,13 +56,117 @@ func validateMinerPayouts(s State, b types.Block) error {
 	return nil
 }
 
-func validateCurrencyOverflow(s State, txns []types.Transaction) error {
-	// Check that the sum of all currency values in the transaction set will not
+// ValidateOrphan validates b in the context of s.
+func ValidateOrphan(s State, b types.Block) error {
+	// TODO: calculate size more efficiently
+	if uint64(types.EncodedLen(b)) > s.MaxBlockWeight() {
+		return errors.New("block exceeds maximum weight")
+	} else if err := ValidateHeader(s, b.Header()); err != nil {
+		return err
+	} else if err := validateMinerPayouts(s, b); err != nil {
+		return err
+	}
+	return nil
+}
+
+// A MidState represents the state of the blockchain within a block.
+type MidState struct {
+	base        State
+	scos        map[types.SiacoinOutputID]types.SiacoinOutput
+	sfos        map[types.SiafundOutputID]types.SiafundOutput
+	claims      map[types.SiafundOutputID]types.Currency
+	fcs         map[types.FileContractID]types.FileContract
+	spends      map[types.Hash256]types.TransactionID
+	siafundPool types.Currency
+}
+
+// Index returns the index of the MidState's base state.
+func (ms *MidState) Index() types.ChainIndex {
+	return ms.base.Index
+}
+
+func (ms *MidState) siacoinOutput(store Store, id types.SiacoinOutputID) (types.SiacoinOutput, bool) {
+	sco, ok := ms.scos[id]
+	if !ok {
+		sco, ok = store.SiacoinOutput(id)
+	}
+	return sco, ok
+}
+
+func (ms *MidState) siafundOutput(store Store, id types.SiafundOutputID) (types.SiafundOutput, types.Currency, types.Currency, bool) {
+	sfo, ok := ms.sfos[id]
+	claimStart := ms.claims[id]
+	if !ok {
+		sfo, claimStart, ok = store.SiafundOutput(id)
+	}
+	claimPortion := ms.siafundPool.Sub(claimStart).Div64(ms.base.SiafundCount()).Mul64(sfo.Value)
+	return sfo, claimStart, claimPortion, ok
+}
+
+func (ms *MidState) fileContract(store Store, id types.FileContractID) (types.FileContract, bool) {
+	fc, ok := ms.fcs[id]
+	if !ok {
+		fc, ok = store.FileContract(id)
+	}
+	return fc, ok
+}
+
+func (ms *MidState) mustSiacoinOutput(store Store, id types.SiacoinOutputID) types.SiacoinOutput {
+	sco, ok := ms.siacoinOutput(store, id)
+	if !ok {
+		panic("missing SiacoinOutput")
+	}
+	return sco
+}
+
+func (ms *MidState) mustSiafundOutput(store Store, id types.SiafundOutputID) (types.SiafundOutput, types.Currency, types.Currency) {
+	sfo, claimStart, claimPortion, ok := ms.siafundOutput(store, id)
+	if !ok {
+		panic("missing SiafundOutput")
+	}
+	return sfo, claimStart, claimPortion
+}
+
+func (ms *MidState) mustFileContract(store Store, id types.FileContractID) types.FileContract {
+	fc, ok := ms.fileContract(store, id)
+	if !ok {
+		panic("missing FileContract")
+	}
+	return fc
+}
+
+func (ms *MidState) spent(id types.Hash256) (types.TransactionID, bool) {
+	txid, ok := ms.spends[id]
+	return txid, ok
+}
+
+// NewMidState constructs a MidState initialized to the provided base state.
+func NewMidState(s State) *MidState {
+	return &MidState{
+		base:        s,
+		scos:        make(map[types.SiacoinOutputID]types.SiacoinOutput),
+		sfos:        make(map[types.SiafundOutputID]types.SiafundOutput),
+		claims:      make(map[types.SiafundOutputID]types.Currency),
+		fcs:         make(map[types.FileContractID]types.FileContract),
+		spends:      make(map[types.Hash256]types.TransactionID),
+		siafundPool: s.SiafundPool,
+	}
+}
+
+func validateCurrencyOverflow(ms *MidState, txn types.Transaction) error {
+	// Check that the sum of all currency values in the transaction will not
 	// overflow our 128-bit representation. This allows us to safely add
 	// currency values in other validation checks without fear of overflow.
 	//
 	// NOTE: Assuming emission is unchanged, the total supply won't hit 2^128
 	// Hastings for another 10,000 years.
+	//
+	// NOTE: We are only checking for overflow within a single transaction, but
+	// that's okay. Later, we check that the transaction's inputs equal its
+	// outputs, which is an even stricter check: it means a transaction's
+	// currency values can't exceed the current total supply. Thus, even if you
+	// sum up values multiple transactions, there's still no risk of overflow as
+	// long as the transactions are individually valid.
 
 	var sum types.Currency
 	var overflow bool
@@ -71,68 +175,38 @@ func validateCurrencyOverflow(s State, txns []types.Transaction) error {
 			sum, overflow = sum.AddWithOverflow(c)
 		}
 	}
-	for _, txn := range txns {
-		for _, sco := range txn.SiacoinOutputs {
-			add(sco.Value)
+	for _, sco := range txn.SiacoinOutputs {
+		add(sco.Value)
+	}
+	for _, sfo := range txn.SiafundOutputs {
+		overflow = overflow || sfo.Value > ms.base.SiafundCount()
+	}
+	for _, fc := range txn.FileContracts {
+		add(fc.Payout)
+		for _, in := range fc.ValidProofOutputs {
+			add(in.Value)
 		}
-		for _, sfo := range txn.SiafundOutputs {
-			overflow = overflow || sfo.Value > s.SiafundCount()
-		}
-		for _, fc := range txn.FileContracts {
-			add(fc.Payout)
-			for _, in := range fc.ValidProofOutputs {
-				add(in.Value)
-			}
-			for _, in := range fc.MissedProofOutputs {
-				add(in.Value)
-			}
-		}
-		for _, fcr := range txn.FileContractRevisions {
-			// NOTE: Payout is skipped; see types.FileContractRevision docstring
-			for _, in := range fcr.FileContract.ValidProofOutputs {
-				add(in.Value)
-			}
-			for _, in := range fcr.FileContract.MissedProofOutputs {
-				add(in.Value)
-			}
+		for _, in := range fc.MissedProofOutputs {
+			add(in.Value)
 		}
 	}
+	for _, fcr := range txn.FileContractRevisions {
+		// NOTE: Payout is skipped; see types.FileContractRevision docstring
+		for _, in := range fcr.FileContract.ValidProofOutputs {
+			add(in.Value)
+		}
+		for _, in := range fcr.FileContract.MissedProofOutputs {
+			add(in.Value)
+		}
+	}
+
 	if overflow {
-		return errors.New("transaction outputs exceed inputs") // technically true, if unhelpful
+		return errors.New("transaction outputs exceed inputs") // technically true
 	}
 	return nil
 }
 
-func validateDoubleSpends(s State, txns []types.Transaction) error {
-	seen := make(map[types.Hash256]bool)
-	doubleSpent := func(id types.Hash256) bool {
-		if seen[id] {
-			return true
-		}
-		seen[id] = true
-		return false
-	}
-	for i, txn := range txns {
-		for _, sci := range txn.SiacoinInputs {
-			if doubleSpent(types.Hash256(sci.ParentID)) {
-				return fmt.Errorf("transaction %v double-spends siacoin input %v", i, sci.ParentID)
-			}
-		}
-		for _, sfi := range txn.SiafundInputs {
-			if doubleSpent(types.Hash256(sfi.ParentID)) {
-				return fmt.Errorf("transaction %v double-spends siafund input %v", i, sfi.ParentID)
-			}
-		}
-		for _, sp := range txn.StorageProofs {
-			if doubleSpent(types.Hash256(sp.ParentID)) {
-				return fmt.Errorf("transaction %v double-resolves file contract %v", i, sp.ParentID)
-			}
-		}
-	}
-	return nil
-}
-
-func validateMinimumValues(s State, txn types.Transaction) error {
+func validateMinimumValues(ms *MidState, txn types.Transaction) error {
 	zero := false
 	for _, sco := range txn.SiacoinOutputs {
 		zero = zero || sco.Value.IsZero()
@@ -152,161 +226,75 @@ func validateMinimumValues(s State, txn types.Transaction) error {
 	return nil
 }
 
-func validateSiacoins(s State, store Store, txns []types.Transaction) error {
+func validateSiacoins(ms *MidState, store Store, txn types.Transaction) error {
 	// NOTE: storage proofs and siafund claim outputs can also create new
 	// siacoin outputs, but we don't need to account for them here because they
 	// have a maturity delay and are thus unspendable within the same block
 
-	ephemeralSC := make(map[types.SiacoinOutputID]types.SiacoinOutput)
-	spent := make(map[types.SiacoinOutputID]int)
-	for i, txn := range txns {
-		var inputSum types.Currency
-		for _, sci := range txn.SiacoinInputs {
-			if prev, ok := spent[sci.ParentID]; ok {
-				return fmt.Errorf("transaction %v double-spends siacoin output %v (previously spent in transaction %v)", i, sci.ParentID, prev)
-			}
-			spent[sci.ParentID] = i
-			parent, ok := ephemeralSC[sci.ParentID]
-			if !ok {
-				parent, ok = store.SiacoinOutput(sci.ParentID)
-				if !ok {
-					return fmt.Errorf("transaction %v spends nonexistent siacoin output %v", i, sci.ParentID)
-				}
-			}
-			if sci.UnlockConditions.UnlockHash() != parent.Address {
-				return fmt.Errorf("transaction %v claims incorrect unlock conditions for siacoin output %v", i, sci.ParentID)
-			}
-			inputSum = inputSum.Add(parent.Value)
-		}
-		var outputSum types.Currency
-		for i, out := range txn.SiacoinOutputs {
-			ephemeralSC[txn.SiacoinOutputID(i)] = out
-			outputSum = outputSum.Add(out.Value)
-		}
-		for _, fc := range txn.FileContracts {
-			outputSum = outputSum.Add(fc.Payout)
-		}
-		for _, fee := range txn.MinerFees {
-			outputSum = outputSum.Add(fee)
-		}
-		if inputSum.Cmp(outputSum) != 0 {
-			return fmt.Errorf("transaction %v is invalid: siacoin inputs (%d H) do not equal outputs (%d H)", i, inputSum, outputSum)
-		}
-	}
-	return nil
-}
-
-func validateSiafunds(s State, store Store, txns []types.Transaction) error {
-	ephemeralSF := make(map[types.SiafundOutputID]types.SiafundOutput)
-	spent := make(map[types.SiafundOutputID]int)
-	for i, txn := range txns {
-		var inputSum uint64
-		for _, sfi := range txn.SiafundInputs {
-			if prev, ok := spent[sfi.ParentID]; ok {
-				return fmt.Errorf("transaction %v double-spends siafund output %v (previously spent in transaction %v)", i, sfi.ParentID, prev)
-			}
-			spent[sfi.ParentID] = i
-			parent, ok := ephemeralSF[sfi.ParentID]
-			if !ok {
-				parent, _, ok = store.SiafundOutput(sfi.ParentID)
-				if !ok {
-					return fmt.Errorf("transaction %v spends nonexistent siafund output %v", i, sfi.ParentID)
-				}
-			}
-			if sfi.UnlockConditions.UnlockHash() != parent.Address &&
-				// override old developer siafund address
-				!(s.childHeight() >= s.Network.HardforkDevAddr.Height &&
-					parent.Address == s.Network.HardforkDevAddr.OldAddress &&
-					sfi.UnlockConditions.UnlockHash() == s.Network.HardforkDevAddr.NewAddress) {
-				return fmt.Errorf("transaction %v claims incorrect unlock conditions for siafund output %v", i, sfi.ParentID)
-			}
-
-			inputSum += parent.Value
-		}
-		var outputSum uint64
-		for i, out := range txn.SiafundOutputs {
-			ephemeralSF[txn.SiafundOutputID(i)] = out
-			outputSum += out.Value
-		}
-		if inputSum != outputSum {
-			return fmt.Errorf("transaction %v is invalid: siafund inputs (%v) do not equal outputs (%v)", i, inputSum, outputSum)
-		}
-	}
-	return nil
-}
-
-func validateContracts(s State, store Store, txns []types.Transaction) error {
-	ephemeralFC := make(map[types.FileContractID]types.FileContract)
-	for _, txn := range txns {
-		for i, fc := range txn.FileContracts {
-			ephemeralFC[txn.FileContractID(i)] = fc
-		}
-	}
-	for txnIndex, txn := range txns {
-		for i, fcr := range txn.FileContractRevisions {
-			parent, ok := ephemeralFC[fcr.ParentID]
-			if !ok {
-				parent, ok = store.FileContract(fcr.ParentID)
-				if !ok {
-					return fmt.Errorf("transaction %v is invalid: file contract revision %v revises nonexistent file contract %v", txnIndex, i, fcr.ParentID)
-				}
-			}
-			fcr.FileContract.Payout = parent.Payout // see FileContractRevision docstring
-			if fcr.FileContract.RevisionNumber <= parent.RevisionNumber {
-				return fmt.Errorf("transaction %v is invalid: file contract revision %v does not have a higher revision number than its parent", txnIndex, i)
-			} else if types.Hash256(fcr.UnlockConditions.UnlockHash()) != parent.UnlockHash {
-				return fmt.Errorf("transaction %v is invalid: file contract revision %v claims incorrect unlock conditions", txnIndex, i)
-			}
-			outputSum := func(outputs []types.SiacoinOutput) (sum types.Currency) {
-				for _, output := range outputs {
-					sum = sum.Add(output.Value)
-				}
-				return sum
-			}
-			if outputSum(fcr.FileContract.ValidProofOutputs) != outputSum(parent.ValidProofOutputs) {
-				return fmt.Errorf("transaction %v is invalid: file contract revision %v changes valid payout sum", txnIndex, i)
-			} else if outputSum(fcr.FileContract.MissedProofOutputs) != outputSum(parent.MissedProofOutputs) {
-				return fmt.Errorf("transaction %v is invalid: file contract revision %v changes missed payout sum", txnIndex, i)
-			}
-			ephemeralFC[fcr.ParentID] = fcr.FileContract
-		}
-	}
-
-	// check for duplicate storage proofs
-	seen := make(map[types.FileContractID]bool)
-	for txnIndex, txn := range txns {
-		for i, sp := range txn.StorageProofs {
-			if seen[sp.ParentID] {
-				return fmt.Errorf("transaction %v is invalid: storage proof %v conflicts with earlier proof in transaction set", txnIndex, i)
-			}
-			seen[sp.ParentID] = true
-		}
-	}
-
-	return nil
-}
-
-func validateSiacoinInputs(s State, txn types.Transaction) error {
+	var inputSum types.Currency
 	for i, sci := range txn.SiacoinInputs {
-		if sci.UnlockConditions.Timelock > s.childHeight() {
+		if sci.UnlockConditions.Timelock > ms.base.childHeight() {
 			return fmt.Errorf("siacoin input %v has timelocked parent", i)
+		} else if txid, ok := ms.spent(types.Hash256(sci.ParentID)); ok {
+			return fmt.Errorf("siacoin input %v double-spends parent output (previously spent in %v)", i, txid)
 		}
+		parent, ok := ms.siacoinOutput(store, sci.ParentID)
+		if !ok {
+			return fmt.Errorf("siacoin input %v spends nonexistent siacoin output %v", i, sci.ParentID)
+		} else if sci.UnlockConditions.UnlockHash() != parent.Address {
+			return fmt.Errorf("siacoin input %v claims incorrect unlock conditions for siacoin output %v", i, sci.ParentID)
+		}
+		inputSum = inputSum.Add(parent.Value)
+	}
+	var outputSum types.Currency
+	for _, out := range txn.SiacoinOutputs {
+		outputSum = outputSum.Add(out.Value)
+	}
+	for _, fc := range txn.FileContracts {
+		outputSum = outputSum.Add(fc.Payout)
+	}
+	for _, fee := range txn.MinerFees {
+		outputSum = outputSum.Add(fee)
+	}
+	if inputSum.Cmp(outputSum) != 0 {
+		return fmt.Errorf("siacoin inputs (%d H) do not equal outputs (%d H)", inputSum, outputSum)
 	}
 	return nil
 }
 
-func validateSiafundInputs(s State, txn types.Transaction) error {
+func validateSiafunds(ms *MidState, store Store, txn types.Transaction) error {
+	var inputSum uint64
 	for i, sfi := range txn.SiafundInputs {
-		if sfi.UnlockConditions.Timelock > s.childHeight() {
+		if sfi.UnlockConditions.Timelock > ms.base.childHeight() {
 			return fmt.Errorf("siafund input %v has timelocked parent", i)
+		} else if txid, ok := ms.spent(types.Hash256(sfi.ParentID)); ok {
+			return fmt.Errorf("siafund input %v double-spends parent output (previously spent in %v)", i, txid)
 		}
+		parent, _, _, ok := ms.siafundOutput(store, sfi.ParentID)
+		if !ok {
+			return fmt.Errorf("siafund input %v spends nonexistent siafund output %v", i, sfi.ParentID)
+		} else if sfi.UnlockConditions.UnlockHash() != parent.Address &&
+			// override old developer siafund address
+			!(ms.base.childHeight() >= ms.base.Network.HardforkDevAddr.Height &&
+				parent.Address == ms.base.Network.HardforkDevAddr.OldAddress &&
+				sfi.UnlockConditions.UnlockHash() == ms.base.Network.HardforkDevAddr.NewAddress) {
+			return fmt.Errorf("siafund input %v claims incorrect unlock conditions for siafund output %v", i, sfi.ParentID)
+		}
+		inputSum += parent.Value
+	}
+	var outputSum uint64
+	for _, out := range txn.SiafundOutputs {
+		outputSum += out.Value
+	}
+	if inputSum != outputSum {
+		return fmt.Errorf("siafund inputs (%v) do not equal outputs (%v)", inputSum, outputSum)
 	}
 	return nil
 }
 
-func validateFileContracts(s State, txn types.Transaction) error {
+func validateFileContracts(ms *MidState, store Store, txn types.Transaction) error {
 	for i, fc := range txn.FileContracts {
-		if fc.WindowStart < s.childHeight() {
+		if fc.WindowStart < ms.base.childHeight() {
 			return fmt.Errorf("file contract %v has window that starts in the past", i)
 		} else if fc.WindowEnd <= fc.WindowStart {
 			return fmt.Errorf("file contract %v has window that ends before it begins", i)
@@ -320,53 +308,92 @@ func validateFileContracts(s State, txn types.Transaction) error {
 		}
 		if !validSum.Equals(missedSum) {
 			return fmt.Errorf("file contract %v has valid payout that does not equal missed payout", i)
-		} else if !fc.Payout.Equals(validSum.Add(s.FileContractTax(fc))) {
+		} else if !fc.Payout.Equals(validSum.Add(ms.base.FileContractTax(fc))) {
 			return fmt.Errorf("file contract %v has payout with incorrect tax", i)
 		}
 	}
-	return nil
-}
 
-func validateFileContractRevisions(s State, txn types.Transaction) error {
-	seen := make(map[types.FileContractID]bool)
-	for _, sp := range txn.StorageProofs {
-		seen[sp.ParentID] = true
-	}
 	for i, fcr := range txn.FileContractRevisions {
-		if seen[fcr.ParentID] {
-			return fmt.Errorf("file contract revision %v conflicts with previous proof or revision in same transaction", i)
-		}
-		seen[fcr.ParentID] = true
-
-		if fcr.UnlockConditions.Timelock > s.childHeight() {
+		if fcr.UnlockConditions.Timelock > ms.base.childHeight() {
 			return fmt.Errorf("file contract revision %v has timelocked parent", i)
-		} else if fcr.FileContract.WindowStart < s.childHeight() {
+		} else if fcr.FileContract.WindowStart < ms.base.childHeight() {
 			return fmt.Errorf("file contract revision %v has window that starts in the past", i)
 		} else if fcr.FileContract.WindowEnd <= fcr.FileContract.WindowStart {
 			return fmt.Errorf("file contract revision %v has window that ends before it begins", i)
+		} else if txid, ok := ms.spent(types.Hash256(fcr.ParentID)); ok {
+			return fmt.Errorf("file contract revision %v conflicts with previous proof or revision (in %v)", i, txid)
+		}
+		parent, ok := ms.fileContract(store, fcr.ParentID)
+		if !ok {
+			return fmt.Errorf("file contract revision %v revises nonexistent file contract %v", i, fcr.ParentID)
+		}
+		if fcr.FileContract.RevisionNumber <= parent.RevisionNumber {
+			return fmt.Errorf("file contract revision %v does not have a higher revision number than its parent", i)
+		} else if types.Hash256(fcr.UnlockConditions.UnlockHash()) != parent.UnlockHash {
+			return fmt.Errorf("file contract revision %v claims incorrect unlock conditions", i)
+		}
+		outputSum := func(outputs []types.SiacoinOutput) (sum types.Currency) {
+			for _, output := range outputs {
+				sum = sum.Add(output.Value)
+			}
+			return sum
+		}
+		if outputSum(fcr.FileContract.ValidProofOutputs) != outputSum(parent.ValidProofOutputs) {
+			return fmt.Errorf("file contract revision %v changes valid payout sum", i)
+		} else if outputSum(fcr.FileContract.MissedProofOutputs) != outputSum(parent.MissedProofOutputs) {
+			return fmt.Errorf("file contract revision %v changes missed payout sum", i)
 		}
 	}
-	return nil
-}
-
-func validateStorageProofs(s State, store Store, txn types.Transaction) error {
-	const leafSize = uint64(len(types.StorageProof{}.Leaf))
 
 	// Storage proofs are height-sensitive, and thus can be invalidated by
 	// shallow reorgs; to minimize disruption, we require that transactions
 	// containing a storage proof do not contain siacoin outputs, siafund
 	// outputs, new file contracts, or file contract revisions.
-	numOutputs := len(txn.SiacoinOutputs) + len(txn.SiafundOutputs) + len(txn.FileContracts) + len(txn.FileContractRevisions)
-	if len(txn.StorageProofs) > 0 && numOutputs > 0 {
-		return errors.New("transaction has both a storage proof and other outputs")
+	if len(txn.StorageProofs) > 0 &&
+		(len(txn.SiacoinOutputs) > 0 || len(txn.SiafundOutputs) > 0 ||
+			len(txn.FileContracts) > 0 || len(txn.FileContractRevisions) > 0) {
+		return errors.New("transaction contains both a storage proof and other outputs")
+	}
+	// A contract can only have a single storage proof.
+	for i := range txn.StorageProofs {
+		for j := i + 1; j < len(txn.StorageProofs); j++ {
+			if txn.StorageProofs[i].ParentID == txn.StorageProofs[j].ParentID {
+				return fmt.Errorf("storage proof %v resolves contract (%v) already resolved by storage proof %v", j, txn.StorageProofs[i].ParentID, i)
+			}
+		}
 	}
 
-	storageProofRoot := func(leafIndex uint64, totalLeaves uint64, leaf []byte, proof []types.Hash256) types.Hash256 {
+	const leafSize = uint64(len(types.StorageProof{}.Leaf))
+	lastLeafIndex := func(filesize uint64) uint64 {
+		if filesize%leafSize != 0 {
+			return filesize / leafSize
+		}
+		return (filesize / leafSize) - 1
+	}
+	storageProofLeaf := func(leafIndex, filesize uint64, leaf [64]byte) []byte {
+		switch {
+		case ms.base.childHeight() < ms.base.Network.HardforkTax.Height:
+			return leaf[:]
+		case ms.base.childHeight() < ms.base.Network.HardforkStorageProof.Height:
+			if leafIndex == lastLeafIndex(filesize) {
+				return leaf[:filesize%leafSize]
+			}
+			return leaf[:]
+		default:
+			if filesize == 0 {
+				return nil
+			} else if leafIndex == lastLeafIndex(filesize) && filesize%leafSize != 0 {
+				return leaf[:filesize%leafSize]
+			}
+			return leaf[:]
+		}
+	}
+	storageProofRoot := func(leafIndex uint64, filesize uint64, leaf []byte, proof []types.Hash256) types.Hash256 {
 		buf := make([]byte, 1+leafSize)
 		buf[0] = 0 // leaf hash prefix
 		copy(buf[1:], leaf)
 		root := types.HashBytes(buf)
-		subtreeHeight := bits.Len64(leafIndex ^ (totalLeaves - 1))
+		subtreeHeight := bits.Len64(leafIndex ^ (lastLeafIndex(filesize)))
 		for i, h := range proof {
 			if leafIndex&(1<<i) != 0 || i >= subtreeHeight {
 				root = blake2b.SumPair(h, root)
@@ -377,17 +404,11 @@ func validateStorageProofs(s State, store Store, txn types.Transaction) error {
 		return root
 	}
 
-	seen := make(map[types.FileContractID]bool)
-	for _, fcr := range txn.FileContractRevisions {
-		seen[fcr.ParentID] = true
-	}
 	for i, sp := range txn.StorageProofs {
-		if seen[sp.ParentID] {
-			return fmt.Errorf("storage proof %v conflicts with previous proof or revision in same transaction", i)
+		if txid, ok := ms.spent(types.Hash256(sp.ParentID)); ok {
+			return fmt.Errorf("storage proof %v conflicts with previous proof or revision (in %v)", i, txid)
 		}
-		seen[sp.ParentID] = true
-
-		fc, ok := store.FileContract(sp.ParentID)
+		fc, ok := ms.fileContract(store, sp.ParentID)
 		if !ok {
 			return fmt.Errorf("storage proof %v references nonexistent file contract", i)
 		}
@@ -395,29 +416,11 @@ func validateStorageProofs(s State, store Store, txn types.Transaction) error {
 		if !ok {
 			return fmt.Errorf("missing index for contract window start %v", fc.WindowStart)
 		}
-		leafIndex := s.StorageProofLeafIndex(fc.Filesize, windowStart, sp.ParentID)
-		totalLeaves := fc.Filesize / leafSize
-		if fc.Filesize%leafSize != 0 {
-			totalLeaves++
-		}
-		var leafLen uint64
-		if s.childHeight() < s.Network.HardforkTax.Height {
-			leafLen = leafSize
-		} else if s.childHeight() < s.Network.HardforkStorageProof.Height {
-			leafLen = leafSize
-			if leafIndex == totalLeaves-1 {
-				leafLen = fc.Filesize % leafSize
-			}
-		} else {
-			if fc.Filesize == 0 {
-				continue // proof is not checked
-			}
-			leafLen = leafSize
-			if leafIndex == totalLeaves-1 && fc.Filesize%leafSize != 0 {
-				leafLen = fc.Filesize % leafSize
-			}
-		}
-		if storageProofRoot(leafIndex, totalLeaves, sp.Leaf[:leafLen], sp.Proof) != fc.FileMerkleRoot {
+		leafIndex := ms.base.StorageProofLeafIndex(fc.Filesize, windowStart, sp.ParentID)
+		leaf := storageProofLeaf(leafIndex, fc.Filesize, sp.Leaf)
+		if leaf == nil {
+			continue
+		} else if storageProofRoot(leafIndex, fc.Filesize, leaf, sp.Proof) != fc.FileMerkleRoot {
 			return fmt.Errorf("storage proof %v has root that does not match contract Merkle root", i)
 		}
 	}
@@ -425,8 +428,8 @@ func validateStorageProofs(s State, store Store, txn types.Transaction) error {
 	return nil
 }
 
-func validateArbitraryData(s State, store Store, txn types.Transaction) error {
-	if s.childHeight() < s.Network.HardforkFoundation.Height {
+func validateArbitraryData(ms *MidState, store Store, txn types.Transaction) error {
+	if ms.base.childHeight() < ms.base.Network.HardforkFoundation.Height {
 		return nil
 	}
 	for _, arb := range txn.ArbitraryData {
@@ -441,7 +444,7 @@ func validateArbitraryData(s State, store Store, txn types.Transaction) error {
 			// check that the transaction is signed by a current key
 			var signed bool
 			for _, sci := range txn.SiacoinInputs {
-				if uh := sci.UnlockConditions.UnlockHash(); uh != s.FoundationPrimaryAddress && uh != s.FoundationFailsafeAddress {
+				if uh := sci.UnlockConditions.UnlockHash(); uh != ms.base.FoundationPrimaryAddress && uh != ms.base.FoundationFailsafeAddress {
 					continue
 				}
 				for _, sig := range txn.Signatures {
@@ -459,7 +462,7 @@ func validateArbitraryData(s State, store Store, txn types.Transaction) error {
 	return nil
 }
 
-func validateSignatures(s State, txn types.Transaction) error {
+func validateSignatures(ms *MidState, txn types.Transaction) error {
 	// build a map of all outstanding signatures
 	//
 	// NOTE: siad checks for double-spends here, but this is redundant
@@ -494,7 +497,7 @@ func validateSignatures(s State, txn types.Transaction) error {
 			return fmt.Errorf("signature %v points to a nonexistent public key", i)
 		} else if e.need == 0 || e.used[sig.PublicKeyIndex] {
 			return fmt.Errorf("signature %v is redundant", i)
-		} else if sig.Timelock > s.childHeight() {
+		} else if sig.Timelock > ms.base.childHeight() {
 			return fmt.Errorf("timelock of signature %v has not expired", i)
 		}
 		e.used[sig.PublicKeyIndex] = true
@@ -508,9 +511,9 @@ func validateSignatures(s State, txn types.Transaction) error {
 			copy(esig[:], sig.Signature)
 			var sigHash types.Hash256
 			if sig.CoveredFields.WholeTransaction {
-				sigHash = s.WholeSigHash(txn, sig.ParentID, sig.PublicKeyIndex, sig.Timelock, sig.CoveredFields.Signatures)
+				sigHash = ms.base.WholeSigHash(txn, sig.ParentID, sig.PublicKeyIndex, sig.Timelock, sig.CoveredFields.Signatures)
 			} else {
-				sigHash = s.PartialSigHash(txn, sig.CoveredFields)
+				sigHash = ms.base.PartialSigHash(txn, sig.CoveredFields)
 			}
 			if !epk.VerifyHash(sigHash, esig) {
 				return fmt.Errorf("signature %v is invalid", i)
@@ -531,56 +534,21 @@ func validateSignatures(s State, txn types.Transaction) error {
 	return nil
 }
 
-func validateTransaction(s State, store Store, txn types.Transaction) error {
-	if err := validateMinimumValues(s, txn); err != nil {
+// ValidateTransaction validates txn within the context of ms and store.
+func ValidateTransaction(ms *MidState, store Store, txn types.Transaction) error {
+	if err := validateCurrencyOverflow(ms, txn); err != nil {
 		return err
-	} else if err := validateSiacoinInputs(s, txn); err != nil {
+	} else if err := validateMinimumValues(ms, txn); err != nil {
 		return err
-	} else if err := validateSiafundInputs(s, txn); err != nil {
+	} else if err := validateSiacoins(ms, store, txn); err != nil {
 		return err
-	} else if err := validateFileContracts(s, txn); err != nil {
+	} else if err := validateSiafunds(ms, store, txn); err != nil {
 		return err
-	} else if err := validateFileContractRevisions(s, txn); err != nil {
+	} else if err := validateFileContracts(ms, store, txn); err != nil {
 		return err
-	} else if err := validateStorageProofs(s, store, txn); err != nil {
+	} else if err := validateArbitraryData(ms, store, txn); err != nil {
 		return err
-	} else if err := validateArbitraryData(s, store, txn); err != nil {
-		return err
-	} else if err := validateSignatures(s, txn); err != nil {
-		return err
-	}
-	return nil
-}
-
-// ValidateTransactionSet validates txns within the context of s and store.
-func ValidateTransactionSet(s State, store Store, txns []types.Transaction) error {
-	if err := validateCurrencyOverflow(s, txns); err != nil {
-		return err
-	} else if err := validateDoubleSpends(s, txns); err != nil {
-		return err
-	} else if err := validateSiacoins(s, store, txns); err != nil {
-		return err
-	} else if err := validateSiafunds(s, store, txns); err != nil {
-		return err
-	} else if err := validateContracts(s, store, txns); err != nil {
-		return err
-	}
-	for i, txn := range txns {
-		if err := validateTransaction(s, store, txn); err != nil {
-			return fmt.Errorf("transaction %v is invalid: %w", i, err)
-		}
-	}
-	return nil
-}
-
-// ValidateOrphan validates b in the context of s.
-func ValidateOrphan(s State, b types.Block) error {
-	// TODO: calculate size more efficiently
-	if uint64(types.EncodedLen(b)) > s.MaxBlockWeight() {
-		return errors.New("block exceeds maximum weight")
-	} else if err := ValidateHeader(s, b.Header()); err != nil {
-		return err
-	} else if err := validateMinerPayouts(s, b); err != nil {
+	} else if err := validateSignatures(ms, txn); err != nil {
 		return err
 	}
 	return nil
@@ -594,8 +562,13 @@ func ValidateOrphan(s State, b types.Block) error {
 func ValidateBlock(s State, store Store, b types.Block) error {
 	if err := ValidateOrphan(s, b); err != nil {
 		return err
-	} else if err := ValidateTransactionSet(s, store, b.Transactions); err != nil {
-		return err
+	}
+	ms := NewMidState(s)
+	for _, txn := range b.Transactions {
+		if err := ValidateTransaction(ms, store, txn); err != nil {
+			return err
+		}
+		ms.ApplyTransaction(store, txn)
 	}
 	return nil
 }


### PR DESCRIPTION
This is an unfortunately-messy diff, but the gist is that consensus now has a `MidState` type that tracks the state of the blockchain *within* a block.

When we verify or apply a transaction, we do so relative to the prior block's state *and the effects of all previous transactions in the current block*. For example, if transaction 0 spends an input, we don't want to allow transaction 1 to spend it too, even though both spends are valid in the context of *just* the prior block's state.

`siad` handles this by directly applying the effects of each transaction to its `consensus.db`, rolling back if an error is encountered. But in `core`, we want to cleanly separate validation from application; the `Validate` functions do not have write-access to the consensus database. Thus, any tracking of mid-block effects has to be handled in memory. Previously, this was done on an ad-hoc basis. For example, `validateSiacoins` iterated over a list of transactions, inserting the relevant parent IDs into a `map[types.SiacoinOutputID]int`, while `validateContracts` performed a similar operation with a `map[types.FileContractID]types.FileContract`. The new `MidState` type essentially collects all of these maps into one place, so that the validation functions can focus on, well, validation, rather than updating state. This also results in some nice unification of code that was duplicated across the `validate` functions and `ApplyDiff`.

The actual *motivation* for this change, however, came from the txpool. Part of the txpool's job is to produce a list of transactions that could potentially form a block; therefore, it naturally needs to do the same sort of mid-state validation/application as consensus. Furthermore, for efficiency, we really want to *store* this mid-state somehow, rather than having to recompute it every time a new transaction is submitted to the txpool. It all seems obvious in retrospect, but I had to stumble through a few different approaches to this problem before finally identifying "mid-state" as the unifying concept. :)

I have re-synced a `core` node with these changes and it validated to tip without any problems, so I'm pretty confident in its correctness. That said, we'll want to do a final pass on all consensus code before deploying anything on mainnet.