### PR TITLE
JSON

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -36,36 +36,36 @@ type Store interface {
 
 // A Network specifies the fixed parameters of a Sia blockchain.
 type Network struct {
-	InitialCoinbase types.Currency
-	MinimumCoinbase types.Currency
-	InitialTarget   types.BlockID
+	InitialCoinbase types.Currency `json:"initialCoinbase"`
+	MinimumCoinbase types.Currency `json:"minimumCoinbase"`
+	InitialTarget   types.BlockID  `json:"initialTarget"`
 
 	HardforkDevAddr struct {
-		Height     uint64
-		OldAddress types.Address
-		NewAddress types.Address
-	}
+		Height     uint64        `json:"height"`
+		OldAddress types.Address `json:"oldAddress"`
+		NewAddress types.Address `json:"newAddress"`
+	} `json:"hardforkDevAddr"`
 	HardforkTax struct {
-		Height uint64
-	}
+		Height uint64 `json:"height"`
+	} `json:"hardforkTax"`
 	HardforkStorageProof struct {
-		Height uint64
-	}
+		Height uint64 `json:"height"`
+	} `json:"hardforkStorageProof"`
 	HardforkOak struct {
-		Height           uint64
-		FixHeight        uint64
-		GenesisTimestamp time.Time
-	}
+		Height           uint64    `json:"height"`
+		FixHeight        uint64    `json:"fixHeight"`
+		GenesisTimestamp time.Time `json:"genesisTimestamp"`
+	} `json:"hardforkOak"`
 	HardforkASIC struct {
-		Height    uint64
-		OakTime   time.Duration
-		OakTarget types.BlockID
-	}
+		Height    uint64        `json:"height"`
+		OakTime   time.Duration `json:"oakTime"`
+		OakTarget types.BlockID `json:"oakTarget"`
+	} `json:"hardforkASIC"`
 	HardforkFoundation struct {
-		Height          uint64
-		PrimaryAddress  types.Address
-		FailsafeAddress types.Address
-	}
+		Height          uint64        `json:"height"`
+		PrimaryAddress  types.Address `json:"primaryAddress"`
+		FailsafeAddress types.Address `json:"failsafeAddress"`
+	} `json:"hardforkFoundation"`
 }
 
 // GenesisState returns the state to which the genesis block should be applied.

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -267,14 +267,38 @@ func (d DelayedOutputSource) String() string {
 	}[d]
 }
 
+// MarshalText implements encoding.TextMarshaler.
+func (d DelayedOutputSource) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (d *DelayedOutputSource) UnmarshalText(b []byte) error {
+	switch string(b) {
+	case OutputSourceMiner.String():
+		*d = OutputSourceMiner
+	case OutputSourceValidContract.String():
+		*d = OutputSourceValidContract
+	case OutputSourceMissedContract.String():
+		*d = OutputSourceMissedContract
+	case OutputSourceSiafundClaim.String():
+		*d = OutputSourceSiafundClaim
+	case OutputSourceFoundation.String():
+		*d = OutputSourceFoundation
+	default:
+		return fmt.Errorf("unrecognized DelayedOutputSource %q", b)
+	}
+	return nil
+}
+
 // A DelayedSiacoinOutputDiff records the creation, deletion, or maturation of a
 // delayed SiacoinOutput. "Delayed" means that the output is immature when
 // created; it may only be spent when the "MaturityHeight" is reached.
 type DelayedSiacoinOutputDiff struct {
-	ID             types.SiacoinOutputID
-	Output         types.SiacoinOutput
-	Source         DelayedOutputSource
-	MaturityHeight uint64
+	ID             types.SiacoinOutputID `json:"ID"`
+	Output         types.SiacoinOutput   `json:"output"`
+	Source         DelayedOutputSource   `json:"source"`
+	MaturityHeight uint64                `json:"maturityHeight"`
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -296,9 +320,9 @@ func (dscod *DelayedSiacoinOutputDiff) DecodeFrom(d *types.Decoder) {
 // A SiafundOutputDiff records the creation, deletion, or spending of a
 // SiafundOutput.
 type SiafundOutputDiff struct {
-	ID         types.SiafundOutputID
-	Output     types.SiafundOutput
-	ClaimStart types.Currency
+	ID         types.SiafundOutputID `json:"ID"`
+	Output     types.SiafundOutput   `json:"output"`
+	ClaimStart types.Currency        `json:"claimStart"`
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -318,8 +342,8 @@ func (sfod *SiafundOutputDiff) DecodeFrom(d *types.Decoder) {
 // A FileContractDiff records the creation, deletion, or resolution of a
 // FileContract.
 type FileContractDiff struct {
-	ID       types.FileContractID
-	Contract types.FileContract
+	ID       types.FileContractID `json:"ID"`
+	Contract types.FileContract   `json:"contract"`
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -336,9 +360,9 @@ func (fcd *FileContractDiff) DecodeFrom(d *types.Decoder) {
 
 // A FileContractRevisionDiff records the revision of a FileContract.
 type FileContractRevisionDiff struct {
-	ID          types.FileContractID
-	OldContract types.FileContract
-	NewContract types.FileContract
+	ID          types.FileContractID `json:"ID"`
+	OldContract types.FileContract   `json:"oldContract"`
+	NewContract types.FileContract   `json:"newContract"`
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -358,15 +382,15 @@ func (fcrd *FileContractRevisionDiff) DecodeFrom(d *types.Decoder) {
 // A TransactionDiff represents the changes to an ElementStore resulting from
 // the application of a transaction.
 type TransactionDiff struct {
-	CreatedSiacoinOutputs  []SiacoinOutputDiff
-	ImmatureSiacoinOutputs []DelayedSiacoinOutputDiff
-	CreatedSiafundOutputs  []SiafundOutputDiff
-	CreatedFileContracts   []FileContractDiff
+	CreatedSiacoinOutputs  []SiacoinOutputDiff        `json:"createdSiacoinOutputs"`
+	ImmatureSiacoinOutputs []DelayedSiacoinOutputDiff `json:"immatureSiacoinOutputs"`
+	CreatedSiafundOutputs  []SiafundOutputDiff        `json:"createdSiafundOutputs"`
+	CreatedFileContracts   []FileContractDiff         `json:"createdFileContracts"`
 
-	SpentSiacoinOutputs  []SiacoinOutputDiff
-	SpentSiafundOutputs  []SiafundOutputDiff
-	RevisedFileContracts []FileContractRevisionDiff
-	ValidFileContracts   []FileContractDiff
+	SpentSiacoinOutputs  []SiacoinOutputDiff        `json:"spentSiacoinOutputs"`
+	SpentSiafundOutputs  []SiafundOutputDiff        `json:"spentSiafundOutputs"`
+	RevisedFileContracts []FileContractRevisionDiff `json:"revisedFileContracts"`
+	ValidFileContracts   []FileContractDiff         `json:"validFileContracts"`
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -444,10 +468,10 @@ func (td *TransactionDiff) DecodeFrom(d *types.Decoder) {
 // A BlockDiff represents the changes to a Store resulting from the application
 // of a block.
 type BlockDiff struct {
-	Transactions           []TransactionDiff
-	MaturedSiacoinOutputs  []DelayedSiacoinOutputDiff
-	ImmatureSiacoinOutputs []DelayedSiacoinOutputDiff
-	MissedFileContracts    []FileContractDiff
+	Transactions           []TransactionDiff          `json:"transactions"`
+	MaturedSiacoinOutputs  []DelayedSiacoinOutputDiff `json:"maturedSiacoinOutputs"`
+	ImmatureSiacoinOutputs []DelayedSiacoinOutputDiff `json:"immatureSiacoinOutputs"`
+	MissedFileContracts    []FileContractDiff         `json:"missedFileContracts"`
 }
 
 // EncodeTo implements types.EncoderTo.

--- a/rhp/v3/encoding.go
+++ b/rhp/v3/encoding.go
@@ -105,16 +105,6 @@ func (a *Account) DecodeFrom(d *types.Decoder) {
 	copy(a[:], spk.Key)
 }
 
-// MarshalJSON implements json.Marshaler.
-func (a Account) MarshalJSON() ([]byte, error) {
-	return types.PublicKey(a).MarshalJSON()
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (a *Account) UnmarshalJSON(b []byte) error {
-	return (*types.PublicKey)(a).UnmarshalJSON(b)
-}
-
 // MarshalText implements encoding.TextUnmarshaler.
 func (a Account) MarshalText() ([]byte, error) { return types.PublicKey(a).MarshalText() }
 

--- a/types/types.go
+++ b/types/types.go
@@ -526,14 +526,6 @@ func unmarshalHex(dst []byte, prefix string, data []byte) error {
 	return nil
 }
 
-func marshalJSONHex(prefix string, data []byte) ([]byte, error) {
-	return []byte(`"` + stringerHex(prefix, data) + `"`), nil
-}
-
-func unmarshalJSONHex(dst []byte, prefix string, data []byte) error {
-	return unmarshalHex(dst, prefix, bytes.Trim(data, `"`))
-}
-
 // String implements fmt.Stringer.
 func (h Hash256) String() string { return stringerHex("h", h[:]) }
 
@@ -542,12 +534,6 @@ func (h Hash256) MarshalText() ([]byte, error) { return marshalHex("h", h[:]) }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (h *Hash256) UnmarshalText(b []byte) error { return unmarshalHex(h[:], "h", b) }
-
-// MarshalJSON implements json.Marshaler.
-func (h Hash256) MarshalJSON() ([]byte, error) { return marshalJSONHex("h", h[:]) }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (h *Hash256) UnmarshalJSON(b []byte) error { return unmarshalJSONHex(h[:], "h", b) }
 
 // String implements fmt.Stringer.
 func (ci ChainIndex) String() string {
@@ -612,12 +598,6 @@ func (s *Specifier) UnmarshalText(b []byte) error {
 	return nil
 }
 
-// MarshalJSON implements json.Marshaler.
-func (s Specifier) MarshalJSON() ([]byte, error) { return []byte(s.String()), nil }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (s *Specifier) UnmarshalJSON(b []byte) error { return s.UnmarshalText(b) }
-
 // String implements fmt.Stringer.
 func (a Address) String() string {
 	checksum := HashBytes(a[:])
@@ -642,17 +622,6 @@ func (a *Address) UnmarshalText(b []byte) (err error) {
 	return
 }
 
-// MarshalJSON implements json.Marshaler.
-func (a Address) MarshalJSON() ([]byte, error) {
-	checksum := HashBytes(a[:])
-	return marshalJSONHex("addr", append(a[:], checksum[:6]...))
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (a *Address) UnmarshalJSON(b []byte) (err error) {
-	return a.UnmarshalText(bytes.Trim(b, `"`))
-}
-
 // ParseAddress parses an address from a prefixed hex encoded string.
 func ParseAddress(s string) (a Address, err error) {
 	err = a.UnmarshalText([]byte(s))
@@ -668,12 +637,6 @@ func (bid BlockID) MarshalText() ([]byte, error) { return marshalHex("bid", bid[
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (bid *BlockID) UnmarshalText(b []byte) error { return unmarshalHex(bid[:], "bid", b) }
 
-// MarshalJSON implements json.Marshaler.
-func (bid BlockID) MarshalJSON() ([]byte, error) { return marshalJSONHex("bid", bid[:]) }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (bid *BlockID) UnmarshalJSON(b []byte) error { return unmarshalJSONHex(bid[:], "bid", b) }
-
 // String implements fmt.Stringer.
 func (pk PublicKey) String() string { return stringerHex("ed25519", pk[:]) }
 
@@ -682,12 +645,6 @@ func (pk PublicKey) MarshalText() ([]byte, error) { return marshalHex("ed25519",
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (pk *PublicKey) UnmarshalText(b []byte) error { return unmarshalHex(pk[:], "ed25519", b) }
-
-// MarshalJSON implements json.Marshaler.
-func (pk PublicKey) MarshalJSON() ([]byte, error) { return marshalJSONHex("ed25519", pk[:]) }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (pk *PublicKey) UnmarshalJSON(b []byte) error { return unmarshalJSONHex(pk[:], "ed25519", b) }
 
 // String implements fmt.Stringer.
 func (tid TransactionID) String() string { return stringerHex("txid", tid[:]) }
@@ -698,12 +655,6 @@ func (tid TransactionID) MarshalText() ([]byte, error) { return marshalHex("txid
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (tid *TransactionID) UnmarshalText(b []byte) error { return unmarshalHex(tid[:], "txid", b) }
 
-// MarshalJSON implements json.Marshaler.
-func (tid TransactionID) MarshalJSON() ([]byte, error) { return marshalJSONHex("txid", tid[:]) }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (tid *TransactionID) UnmarshalJSON(b []byte) error { return unmarshalJSONHex(tid[:], "txid", b) }
-
 // String implements fmt.Stringer.
 func (scoid SiacoinOutputID) String() string { return stringerHex("scoid", scoid[:]) }
 
@@ -713,14 +664,6 @@ func (scoid SiacoinOutputID) MarshalText() ([]byte, error) { return marshalHex("
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (scoid *SiacoinOutputID) UnmarshalText(b []byte) error {
 	return unmarshalHex(scoid[:], "scoid", b)
-}
-
-// MarshalJSON implements json.Marshaler.
-func (scoid SiacoinOutputID) MarshalJSON() ([]byte, error) { return marshalJSONHex("scoid", scoid[:]) }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (scoid *SiacoinOutputID) UnmarshalJSON(b []byte) error {
-	return unmarshalJSONHex(scoid[:], "scoid", b)
 }
 
 // String implements fmt.Stringer.
@@ -734,14 +677,6 @@ func (sfoid *SiafundOutputID) UnmarshalText(b []byte) error {
 	return unmarshalHex(sfoid[:], "sfoid", b)
 }
 
-// MarshalJSON implements json.Marshaler.
-func (sfoid SiafundOutputID) MarshalJSON() ([]byte, error) { return marshalJSONHex("sfoid", sfoid[:]) }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (sfoid *SiafundOutputID) UnmarshalJSON(b []byte) error {
-	return unmarshalJSONHex(sfoid[:], "sfoid", b)
-}
-
 // String implements fmt.Stringer.
 func (fcid FileContractID) String() string { return stringerHex("fcid", fcid[:]) }
 
@@ -751,14 +686,6 @@ func (fcid FileContractID) MarshalText() ([]byte, error) { return marshalHex("fc
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (fcid *FileContractID) UnmarshalText(b []byte) error { return unmarshalHex(fcid[:], "fcid", b) }
 
-// MarshalJSON implements json.Marshaler.
-func (fcid FileContractID) MarshalJSON() ([]byte, error) { return marshalJSONHex("fcid", fcid[:]) }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (fcid *FileContractID) UnmarshalJSON(b []byte) error {
-	return unmarshalJSONHex(fcid[:], "fcid", b)
-}
-
 // String implements fmt.Stringer.
 func (sig Signature) String() string { return stringerHex("sig", sig[:]) }
 
@@ -767,9 +694,3 @@ func (sig Signature) MarshalText() ([]byte, error) { return marshalHex("sig", si
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (sig *Signature) UnmarshalText(b []byte) error { return unmarshalHex(sig[:], "sig", b) }
-
-// MarshalJSON implements json.Marshaler.
-func (sig Signature) MarshalJSON() ([]byte, error) { return marshalJSONHex("sig", sig[:]) }
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (sig *Signature) UnmarshalJSON(b []byte) error { return unmarshalJSONHex(sig[:], "sig", b) }

--- a/types/types.go
+++ b/types/types.go
@@ -117,9 +117,9 @@ type UnlockKey struct {
 // UnlockConditions specify the conditions for spending an output or revising a
 // file contract.
 type UnlockConditions struct {
-	Timelock           uint64
-	PublicKeys         []UnlockKey
-	SignaturesRequired uint64
+	Timelock           uint64      `json:"timelock"`
+	PublicKeys         []UnlockKey `json:"publicKeys"`
+	SignaturesRequired uint64      `json:"signaturesRequired"`
 }
 
 // UnlockHash computes the hash of a set of UnlockConditions. Such hashes are
@@ -192,15 +192,15 @@ type TransactionID Hash256
 
 // A ChainIndex pairs a block's height with its ID.
 type ChainIndex struct {
-	Height uint64
-	ID     BlockID
+	Height uint64  `json:"height"`
+	ID     BlockID `json:"ID"`
 }
 
 // A SiacoinOutput is the recipient of some of the siacoins spent in a
 // transaction.
 type SiacoinOutput struct {
-	Value   Currency
-	Address Address
+	Value   Currency `json:"value"`
+	Address Address  `json:"address"`
 }
 
 // A SiacoinOutputID uniquely identifies a siacoin output.
@@ -209,15 +209,15 @@ type SiacoinOutputID Hash256
 // A SiacoinInput spends an unspent SiacoinOutput in the UTXO set by
 // revealing and satisfying its unlock conditions.
 type SiacoinInput struct {
-	ParentID         SiacoinOutputID
-	UnlockConditions UnlockConditions
+	ParentID         SiacoinOutputID  `json:"parentID"`
+	UnlockConditions UnlockConditions `json:"unlockConditions"`
 }
 
 // A SiafundOutput is the recipient of some of the siafunds spent in a
 // transaction.
 type SiafundOutput struct {
-	Value   uint64
-	Address Address
+	Value   uint64  `json:"value"`
+	Address Address `json:"address"`
 }
 
 // A SiafundOutputID uniquely identifies a siafund output.
@@ -234,9 +234,9 @@ func (sfoid SiafundOutputID) ClaimOutputID() SiacoinOutputID {
 // ClaimAddress, specifying the recipient of the siacoins that were earned by
 // the output.
 type SiafundInput struct {
-	ParentID         SiafundOutputID
-	UnlockConditions UnlockConditions
-	ClaimAddress     Address
+	ParentID         SiafundOutputID  `json:"parentID"`
+	UnlockConditions UnlockConditions `json:"unlockConditions"`
+	ClaimAddress     Address          `json:"claimAddress"`
 }
 
 // A FileContract is a storage agreement between a renter and a host. It
@@ -244,15 +244,15 @@ type SiafundInput struct {
 // "missed" depending on whether a valid StorageProof is submitted for the
 // contract.
 type FileContract struct {
-	Filesize           uint64
-	FileMerkleRoot     Hash256
-	WindowStart        uint64
-	WindowEnd          uint64
-	Payout             Currency
-	ValidProofOutputs  []SiacoinOutput
-	MissedProofOutputs []SiacoinOutput
-	UnlockHash         Hash256
-	RevisionNumber     uint64
+	Filesize           uint64          `json:"filesize"`
+	FileMerkleRoot     Hash256         `json:"fileMerkleRoot"`
+	WindowStart        uint64          `json:"windowStart"`
+	WindowEnd          uint64          `json:"windowEnd"`
+	Payout             Currency        `json:"payout"`
+	ValidProofOutputs  []SiacoinOutput `json:"validProofOutputs"`
+	MissedProofOutputs []SiacoinOutput `json:"missedProofOutputs"`
+	UnlockHash         Hash256         `json:"unlockHash"`
+	RevisionNumber     uint64          `json:"revisionNumber"`
 }
 
 // EndHeight returns the height at which the contract's host is no longer
@@ -320,8 +320,8 @@ func (fcid FileContractID) MissedOutputID(i int) SiacoinOutputID {
 
 // A FileContractRevision updates the state of an existing file contract.
 type FileContractRevision struct {
-	ParentID         FileContractID
-	UnlockConditions UnlockConditions
+	ParentID         FileContractID   `json:"parentID"`
+	UnlockConditions UnlockConditions `json:"unlockConditions"`
 	// NOTE: the Payout field of the contract is not "really" part of a
 	// revision. A revision cannot change the total payout, so the original siad
 	// code defines FileContractRevision as an entirely separate struct without
@@ -342,48 +342,48 @@ type StorageProof struct {
 // A FoundationAddressUpdate updates the primary and failsafe Foundation subsidy
 // addresses.
 type FoundationAddressUpdate struct {
-	NewPrimary  Address
-	NewFailsafe Address
+	NewPrimary  Address `json:"newPrimary"`
+	NewFailsafe Address `json:"newFailsafe"`
 }
 
 // CoveredFields indicates which fields of a transaction are covered by a
 // signature.
 type CoveredFields struct {
-	WholeTransaction      bool
-	SiacoinInputs         []uint64
-	SiacoinOutputs        []uint64
-	FileContracts         []uint64
-	FileContractRevisions []uint64
-	StorageProofs         []uint64
-	SiafundInputs         []uint64
-	SiafundOutputs        []uint64
-	MinerFees             []uint64
-	ArbitraryData         []uint64
-	Signatures            []uint64
+	WholeTransaction      bool     `json:"wholeTransaction,omitempty"`
+	SiacoinInputs         []uint64 `json:"siacoinInputs,omitempty"`
+	SiacoinOutputs        []uint64 `json:"siacoinOutputs,omitempty"`
+	FileContracts         []uint64 `json:"fileContracts,omitempty"`
+	FileContractRevisions []uint64 `json:"fileContractRevisions,omitempty"`
+	StorageProofs         []uint64 `json:"storageProofs,omitempty"`
+	SiafundInputs         []uint64 `json:"siafundInputs,omitempty"`
+	SiafundOutputs        []uint64 `json:"siafundOutputs,omitempty"`
+	MinerFees             []uint64 `json:"minerFees,omitempty"`
+	ArbitraryData         []uint64 `json:"arbitraryData,omitempty"`
+	Signatures            []uint64 `json:"signatures,omitempty"`
 }
 
 // A TransactionSignature signs transaction data.
 type TransactionSignature struct {
-	ParentID       Hash256
-	PublicKeyIndex uint64
-	Timelock       uint64
-	CoveredFields  CoveredFields
-	Signature      []byte
+	ParentID       Hash256       `json:"parentID"`
+	PublicKeyIndex uint64        `json:"publicKeyIndex"`
+	Timelock       uint64        `json:"timelock,omitempty"`
+	CoveredFields  CoveredFields `json:"coveredFields"`
+	Signature      []byte        `json:"signature"`
 }
 
 // A Transaction transfers value by consuming existing Outputs and creating new
 // Outputs.
 type Transaction struct {
-	SiacoinInputs         []SiacoinInput
-	SiacoinOutputs        []SiacoinOutput
-	FileContracts         []FileContract
-	FileContractRevisions []FileContractRevision
-	StorageProofs         []StorageProof
-	SiafundInputs         []SiafundInput
-	SiafundOutputs        []SiafundOutput
-	MinerFees             []Currency
-	ArbitraryData         [][]byte
-	Signatures            []TransactionSignature
+	SiacoinInputs         []SiacoinInput         `json:"siacoinInputs,omitempty"`
+	SiacoinOutputs        []SiacoinOutput        `json:"siacoinOutputs,omitempty"`
+	FileContracts         []FileContract         `json:"fileContracts,omitempty"`
+	FileContractRevisions []FileContractRevision `json:"fileContractRevisions,omitempty"`
+	StorageProofs         []StorageProof         `json:"storageProofs,omitempty"`
+	SiafundInputs         []SiafundInput         `json:"siafundInputs,omitempty"`
+	SiafundOutputs        []SiafundOutput        `json:"siafundOutputs,omitempty"`
+	MinerFees             []Currency             `json:"minerFees,omitempty"`
+	ArbitraryData         [][]byte               `json:"arbitraryData,omitempty"`
+	Signatures            []TransactionSignature `json:"signatures,omitempty"`
 }
 
 // ID returns the "semantic hash" of the transaction, covering all of the
@@ -441,10 +441,10 @@ func (txn *Transaction) FileContractID(i int) FileContractID {
 
 // A BlockHeader contains a Block's non-transaction data.
 type BlockHeader struct {
-	ParentID   BlockID
-	Nonce      uint64
-	Timestamp  time.Time
-	MerkleRoot Hash256
+	ParentID   BlockID   `json:"parentID"`
+	Nonce      uint64    `json:"nonce"`
+	Timestamp  time.Time `json:"timestamp"`
+	MerkleRoot Hash256   `json:"merkleRoot"`
 }
 
 // ID returns a hash that uniquely identifies a block.
@@ -463,11 +463,11 @@ func CurrentTimestamp() time.Time { return time.Now().Round(time.Second).UTC() }
 
 // A Block is a set of transactions grouped under a header.
 type Block struct {
-	ParentID     BlockID
-	Nonce        uint64
-	Timestamp    time.Time
-	MinerPayouts []SiacoinOutput
-	Transactions []Transaction
+	ParentID     BlockID         `json:"parentID"`
+	Nonce        uint64          `json:"nonce"`
+	Timestamp    time.Time       `json:"timestamp"`
+	MinerPayouts []SiacoinOutput `json:"minerPayouts"`
+	Transactions []Transaction   `json:"transactions"`
 }
 
 // Header returns the header for the block.
@@ -598,6 +598,24 @@ func (s *Specifier) UnmarshalText(b []byte) error {
 	return nil
 }
 
+// MarshalText implements encoding.TextMarshaler.
+func (uk UnlockKey) MarshalText() ([]byte, error) {
+	return marshalHex(uk.Algorithm.String(), uk.Key[:])
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (uk *UnlockKey) UnmarshalText(b []byte) error {
+	parts := bytes.Split(b, []byte(":"))
+	if len(parts) != 2 {
+		return fmt.Errorf("decoding <algorithm>::<key> failed: wrong number of separators")
+	} else if err := uk.Algorithm.UnmarshalText(parts[0]); err != nil {
+		return fmt.Errorf("decoding <algorithm>::<key> failed: %w", err)
+	} else if uk.Key, err = hex.DecodeString(string(parts[1])); err != nil {
+		return fmt.Errorf("decoding <algorithm>::<key> failed: %w", err)
+	}
+	return nil
+}
+
 // String implements fmt.Stringer.
 func (a Address) String() string {
 	checksum := HashBytes(a[:])
@@ -694,3 +712,30 @@ func (sig Signature) MarshalText() ([]byte, error) { return marshalHex("sig", si
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (sig *Signature) UnmarshalText(b []byte) error { return unmarshalHex(sig[:], "sig", b) }
+
+// MarshalJSON implements json.Marshaler.
+func (sp StorageProof) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ParentID FileContractID `json:"parentID"`
+		Leaf     string         `json:"leaf"`
+		Proof    []Hash256      `json:"proof"`
+	}{sp.ParentID, hex.EncodeToString(sp.Leaf[:]), sp.Proof})
+}
+
+// UnmarshalJSON implements json.Marshaler.
+func (sp *StorageProof) UnmarshalJSON(b []byte) error {
+	var leaf string
+	err := json.Unmarshal(b, &struct {
+		ParentID *FileContractID
+		Leaf     *string
+		Proof    *[]Hash256
+	}{&sp.ParentID, &leaf, &sp.Proof})
+	if err != nil {
+		return err
+	} else if len(leaf) != len(sp.Leaf)*2 {
+		return errors.New("invalid storage proof leaf length")
+	} else if _, err = hex.Decode(sp.Leaf[:], []byte(leaf)); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Turns out if you have a `MarshalText` method, you don't need `MarshalJSON` too. So that's nice.

I still want to write a JSON encoder at some point; it would be really nice if we could autogenerate fast encode/decode functions, with options like `useCamelCase` and `noNullSlices` -- but for now, struct tags will have to do.