### PR TITLE
Network Name

### DIFF
--- a/chain/network.go
+++ b/chain/network.go
@@ -19,6 +19,8 @@ func parseAddr(s string) types.Address {
 // blockchain.
 func Mainnet() (*consensus.Network, types.Block) {
 	n := &consensus.Network{
+		Name: "mainnet",
+
 		InitialCoinbase: types.Siacoins(300000),
 		MinimumCoinbase: types.Siacoins(30000),
 		InitialTarget:   types.BlockID{4: 32},
@@ -105,6 +107,8 @@ func Mainnet() (*consensus.Network, types.Block) {
 // testnet chain.
 func TestnetZen() (*consensus.Network, types.Block) {
 	n := &consensus.Network{
+		Name: "testnetzen",
+
 		InitialCoinbase: types.Siacoins(300000),
 		MinimumCoinbase: types.Siacoins(300000),
 		InitialTarget:   types.BlockID{4: 32},

--- a/chain/network.go
+++ b/chain/network.go
@@ -107,7 +107,7 @@ func Mainnet() (*consensus.Network, types.Block) {
 // testnet chain.
 func TestnetZen() (*consensus.Network, types.Block) {
 	n := &consensus.Network{
-		Name: "testnetzen",
+		Name: "zen",
 
 		InitialCoinbase: types.Siacoins(300000),
 		MinimumCoinbase: types.Siacoins(300000),

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -36,6 +36,8 @@ type Store interface {
 
 // A Network specifies the fixed parameters of a Sia blockchain.
 type Network struct {
+	Name string `json:"name"`
+
 	InitialCoinbase types.Currency `json:"initialCoinbase"`
 	MinimumCoinbase types.Currency `json:"minimumCoinbase"`
 	InitialTarget   types.BlockID  `json:"initialTarget"`


### PR DESCRIPTION
This PR adds a `Name` field to the `Network` object in the `consensus` package. By adding the network name the UI can differentiate between the `mainnet` and the `testnet` and adjust accordingly.