### PR TITLE
Add InitProgramCost helper 

### DIFF
--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -230,7 +230,7 @@ type (
 )
 
 // Add adds two ResourceCosts together.
-func (a *ResourceCost) Add(b ResourceCost) ResourceCost {
+func (a ResourceCost) Add(b ResourceCost) ResourceCost {
 	return ResourceCost{
 		Base:       a.Base.Add(b.Base),
 		Storage:    a.Storage.Add(b.Storage),
@@ -241,7 +241,7 @@ func (a *ResourceCost) Add(b ResourceCost) ResourceCost {
 }
 
 // Total returns the total cost and collateral of a ResourceCost.
-func (a *ResourceCost) Total() (cost, collateral types.Currency) {
+func (a ResourceCost) Total() (cost, collateral types.Currency) {
 	cost = a.Base.Add(a.Storage).Add(a.Egress).Add(a.Ingress)
 	collateral = a.Collateral
 	return

--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -307,8 +307,8 @@ func (pt *HostPriceTable) HasSectorCost() ResourceCost {
 	}
 }
 
-// InitProgramCost is the cost of initialising an mdm program.
-func (pt *HostPriceTable) InitProgramCost() ResourceCost {
+// BaseCost is the cost of initialising an mdm program.
+func (pt *HostPriceTable) BaseCost() ResourceCost {
 	return ResourceCost{
 		Base: pt.InitBaseCost,
 	}

--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -307,6 +307,13 @@ func (pt *HostPriceTable) HasSectorCost() ResourceCost {
 	}
 }
 
+// InitProgramCost is the cost of initialising an mdm program.
+func (pt *HostPriceTable) InitProgramCost() ResourceCost {
+	return ResourceCost{
+		Base: pt.InitBaseCost,
+	}
+}
+
 // ReadOffsetCost returns the cost of executing the ReadOffset instruction.
 func (pt *HostPriceTable) ReadOffsetCost(length uint64) ResourceCost {
 	return ResourceCost{


### PR DESCRIPTION
This PR adds the `InitProgramHelper` which makes it a bit nicer to compute costs for programs.

e.g. computing the cost of a read sector program becomes this
```go
rc := pt.InitProgramCost()
rc.Add(pt.ReadSectorCost(rhpv2.SectorSize))
cost, _ := rc.Total()
```
where previously we couldn't make use of the `ResourceCost` type for the base cost.


Also snuck in a receiver change that Nate proposed. 