### PR TITLE
Remove quotes from Specifier.String()

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -599,7 +599,7 @@ func ParseChainIndex(s string) (ci ChainIndex, err error) {
 }
 
 // String implements fmt.Stringer.
-func (s Specifier) String() string { return strconv.Quote(string(bytes.Trim(s[:], "\x00"))) }
+func (s Specifier) String() string { return string(bytes.Trim(s[:], "\x00")) }
 
 // MarshalText implements encoding.TextMarshaler.
 func (s Specifier) MarshalText() ([]byte, error) { return []byte(s.String()), nil }
@@ -608,8 +608,9 @@ func (s Specifier) MarshalText() ([]byte, error) { return []byte(s.String()), ni
 func (s *Specifier) UnmarshalText(b []byte) error {
 	str, err := strconv.Unquote(string(b))
 	if err != nil {
-		return err
-	} else if len(str) > len(s) {
+		str = string(b)
+	}
+	if len(str) > len(s) {
 		return fmt.Errorf("specifier %s too long", str)
 	}
 	copy(s[:], str)


### PR DESCRIPTION
```go
// MarshalText implements encoding.TextMarshaler.
func (uk UnlockKey) MarshalText() ([]byte, error) {
	return marshalHex(uk.Algorithm.String(), uk.Key[:])
}
```

Causes UnlockKey to JSON encode as `"\"ed25519\":48a468d62e48e27ef24707bd1f467476e9605954e201834c659e614b9704d041"`

This will likely break a bunch of things in `hostd` and `renterd`. Is adding compatibility code for this in `core` worth it?