### PR TITLE
Have SiamuxAddr return an empty string if no host was specified in the settings

### DIFF
--- a/rhp/v2/rhp.go
+++ b/rhp/v2/rhp.go
@@ -112,7 +112,7 @@ func (s HostSettings) MarshalJSON() ([]byte, error) {
 // to the host's siamux.
 func (s HostSettings) SiamuxAddr() string {
 	host, _, err := net.SplitHostPort(s.NetAddress)
-	if err != nil {
+	if err != nil || host == "" {
 		return ""
 	}
 	return net.JoinHostPort(host, s.SiaMuxPort)


### PR DESCRIPTION
To avoid accidentally dialing localhost in case the port is set but the address isn't.