### PR TITLE
Remove unused hostKey from renewal params

### DIFF
--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -111,7 +111,7 @@ func ContractRenewalCollateral(fc types.FileContract, expectedNewStorage uint64,
 }
 
 // PrepareContractRenewal constructs a contract renewal transaction.
-func PrepareContractRenewal(currentRevision types.FileContractRevision, renterAddress types.Address, renterPayout, newCollateral types.Currency, hostKey types.PublicKey, host HostSettings, endHeight uint64) (types.FileContract, types.Currency) {
+func PrepareContractRenewal(currentRevision types.FileContractRevision, renterAddress types.Address, renterPayout, newCollateral types.Currency, host HostSettings, endHeight uint64) (types.FileContract, types.Currency) {
 	hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice := CalculateHostPayouts(currentRevision.FileContract, newCollateral, host, endHeight)
 
 	return types.FileContract{

--- a/rhp/v3/contracts.go
+++ b/rhp/v3/contracts.go
@@ -15,7 +15,7 @@ func ContractRenewalCost(cs consensus.State, pt HostPriceTable, fc types.FileCon
 }
 
 // PrepareContractRenewal constructs a contract renewal transaction.
-func PrepareContractRenewal(currentRevision types.FileContractRevision, hostAddress, renterAddress types.Address, renterPayout, newCollateral types.Currency, hostKey types.PublicKey, pt HostPriceTable, endHeight uint64) (types.FileContract, types.Currency) {
+func PrepareContractRenewal(currentRevision types.FileContractRevision, hostAddress, renterAddress types.Address, renterPayout, newCollateral types.Currency, pt HostPriceTable, endHeight uint64) (types.FileContract, types.Currency) {
 	hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice := CalculateHostPayouts(currentRevision.FileContract, newCollateral, pt, endHeight)
 
 	return types.FileContract{


### PR DESCRIPTION
`hostKey` is passed to `PrepareContractRenewal`, although it is not used there.