### PR TITLE
Refactor DB

### DIFF
--- a/chain/db.go
+++ b/chain/db.go
@@ -14,14 +14,9 @@ import (
 
 // A DB is a generic key-value database.
 type DB interface {
-	Begin() (DBTx, error)
-}
-
-// A DBTx is a transaction executed on a key-value database.
-type DBTx interface {
 	Bucket(name []byte) DBBucket
 	CreateBucket(name []byte) (DBBucket, error)
-	Commit() error
+	Flush() error
 	Cancel()
 }
 
@@ -35,117 +30,160 @@ type DBBucket interface {
 // MemDB implements DB with an in-memory map.
 type MemDB struct {
 	buckets map[string]map[string][]byte
+	puts    map[string]map[string][]byte
+	dels    map[string]map[string]struct{}
 }
 
-// Begin implements DB.
-func (db *MemDB) Begin() (DBTx, error) {
-	tx := &memTx{
-		puts: make(map[string]map[string][]byte),
-		dels: make(map[string]map[string]struct{}),
-		db:   db,
-	}
-	for name := range db.buckets {
-		tx.puts[name] = make(map[string][]byte)
-		tx.dels[name] = make(map[string]struct{})
-	}
-	return tx, nil
-}
-
-type memTx struct {
-	puts map[string]map[string][]byte
-	dels map[string]map[string]struct{}
-	db   *MemDB
-}
-
-// Commit implements DBTx.
-func (tx *memTx) Commit() error {
-	for bucket, puts := range tx.puts {
-		if tx.db.buckets[bucket] == nil {
-			tx.db.buckets[bucket] = make(map[string][]byte)
+// Flush implements DB.
+func (db *MemDB) Flush() error {
+	for bucket, puts := range db.puts {
+		if db.buckets[bucket] == nil {
+			db.buckets[bucket] = make(map[string][]byte)
 		}
 		for key, val := range puts {
-			tx.db.buckets[bucket][key] = val
+			db.buckets[bucket][key] = val
 		}
+		delete(db.puts, bucket)
 	}
-	for bucket, dels := range tx.dels {
-		if tx.db.buckets[bucket] == nil {
-			tx.db.buckets[bucket] = make(map[string][]byte)
+	for bucket, dels := range db.dels {
+		if db.buckets[bucket] == nil {
+			db.buckets[bucket] = make(map[string][]byte)
 		}
 		for key := range dels {
-			delete(tx.db.buckets[bucket], key)
+			delete(db.buckets[bucket], key)
 		}
+		delete(db.dels, bucket)
 	}
 	return nil
 }
 
-func (tx *memTx) Cancel() {
-	tx.puts = nil
-	tx.dels = nil
+// Cancel implements DB.
+func (db *MemDB) Cancel() {
+	for k := range db.puts {
+		delete(db.puts, k)
+	}
+	for k := range db.dels {
+		delete(db.dels, k)
+	}
 }
 
-func (tx *memTx) get(bucket string, key []byte) []byte {
-	if val, ok := tx.puts[bucket][string(key)]; ok {
+func (db *MemDB) get(bucket string, key []byte) []byte {
+	if val, ok := db.puts[bucket][string(key)]; ok {
 		return val
-	} else if _, ok := tx.dels[bucket][string(key)]; ok {
+	} else if _, ok := db.dels[bucket][string(key)]; ok {
 		return nil
 	}
-	return tx.db.buckets[bucket][string(key)]
+	return db.buckets[bucket][string(key)]
 }
 
-func (tx *memTx) put(bucket string, key, value []byte) error {
-	if tx.puts[bucket] == nil {
-		if tx.db.buckets[bucket] == nil {
+func (db *MemDB) put(bucket string, key, value []byte) error {
+	if db.puts[bucket] == nil {
+		if db.buckets[bucket] == nil {
 			return errors.New("bucket does not exist")
 		}
-		tx.puts[bucket] = make(map[string][]byte)
+		db.puts[bucket] = make(map[string][]byte)
 	}
-	tx.puts[bucket][string(key)] = value
-	delete(tx.dels[bucket], string(key))
+	db.puts[bucket][string(key)] = value
+	delete(db.dels[bucket], string(key))
 	return nil
 }
 
-func (tx *memTx) delete(bucket string, key []byte) error {
-	if tx.dels[bucket] == nil {
-		if tx.db.buckets[bucket] == nil {
+func (db *MemDB) delete(bucket string, key []byte) error {
+	if db.dels[bucket] == nil {
+		if db.buckets[bucket] == nil {
 			return errors.New("bucket does not exist")
 		}
-		tx.dels[bucket] = make(map[string]struct{})
+		db.dels[bucket] = make(map[string]struct{})
 	}
-	tx.dels[bucket][string(key)] = struct{}{}
-	delete(tx.puts[bucket], string(key))
+	db.dels[bucket][string(key)] = struct{}{}
+	delete(db.puts[bucket], string(key))
 	return nil
 }
 
-func (tx *memTx) Bucket(name []byte) DBBucket {
-	if tx.db.buckets[string(name)] == nil && tx.puts[string(name)] == nil && tx.dels[string(name)] == nil {
+// Bucket implements DB.
+func (db *MemDB) Bucket(name []byte) DBBucket {
+	if db.buckets[string(name)] == nil && db.puts[string(name)] == nil && db.dels[string(name)] == nil {
 		return nil
 	}
-	return memBucket{string(name), tx}
+	return memBucket{string(name), db}
 }
 
-func (tx *memTx) CreateBucket(name []byte) (DBBucket, error) {
-	if tx.db.buckets[string(name)] != nil {
+// CreateBucket implements DB.
+func (db *MemDB) CreateBucket(name []byte) (DBBucket, error) {
+	if db.buckets[string(name)] != nil {
 		return nil, errors.New("bucket already exists")
 	}
-	tx.puts[string(name)] = make(map[string][]byte)
-	tx.dels[string(name)] = make(map[string]struct{})
-	return tx.Bucket(name), nil
+	db.puts[string(name)] = make(map[string][]byte)
+	db.dels[string(name)] = make(map[string]struct{})
+	return db.Bucket(name), nil
 }
 
 type memBucket struct {
 	name string
-	tx   *memTx
+	db   *MemDB
 }
 
-func (b memBucket) Get(key []byte) []byte       { return b.tx.get(b.name, key) }
-func (b memBucket) Put(key, value []byte) error { return b.tx.put(b.name, key, value) }
-func (b memBucket) Delete(key []byte) error     { return b.tx.delete(b.name, key) }
+func (b memBucket) Get(key []byte) []byte       { return b.db.get(b.name, key) }
+func (b memBucket) Put(key, value []byte) error { return b.db.put(b.name, key, value) }
+func (b memBucket) Delete(key []byte) error     { return b.db.delete(b.name, key) }
 
 // NewMemDB returns an in-memory DB for use with DBStore.
 func NewMemDB() *MemDB {
 	return &MemDB{
 		buckets: make(map[string]map[string][]byte),
+		puts:    make(map[string]map[string][]byte),
+		dels:    make(map[string]map[string]struct{}),
 	}
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// dbBucket is a helper type for implementing Store.
+type dbBucket struct {
+	b  DBBucket
+	db *DBStore
+}
+
+func (b *dbBucket) getRaw(key []byte) []byte {
+	if b.b == nil {
+		return nil
+	}
+	return b.b.Get(key)
+}
+
+func (b *dbBucket) get(key []byte, v types.DecoderFrom) bool {
+	val := b.getRaw(key)
+	if val == nil {
+		return false
+	}
+	d := types.NewBufDecoder(val)
+	v.DecodeFrom(d)
+	if d.Err() != nil {
+		check(fmt.Errorf("error decoding %T: %w", v, d.Err()))
+		return false
+	}
+	return true
+}
+
+func (b *dbBucket) putRaw(key, value []byte) {
+	check(b.b.Put(key, value))
+	b.db.unflushed += len(value)
+}
+
+func (b *dbBucket) put(key []byte, v types.EncoderTo) {
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+	v.EncodeTo(e)
+	e.Flush()
+	b.putRaw(key, buf.Bytes())
+}
+
+func (b *dbBucket) delete(key []byte) {
+	check(b.b.Delete(key))
 }
 
 var (
@@ -163,319 +201,72 @@ var (
 // DBStore implements Store using a key-value database.
 type DBStore struct {
 	db DB
-	tx *dbTx
+	n  *consensus.Network // for getCheckpoint
 
-	lastCommit int64
+	unflushed int
+	lastFlush time.Time
 }
 
-func (db *DBStore) shouldCommit() bool {
-	const (
-		// minimum number of bytes written in the transaction until we commit
-		commitSizeThreshold = 1 << 20 // ~1 MB
-		// ...or we will also commit if a certain amount of time has passed
-		commitDurationThreshold = 5 // seconds
-	)
-	return db.tx.size >= commitSizeThreshold || (time.Now().Unix()-db.lastCommit) >= commitDurationThreshold
+func (db *DBStore) bucket(name []byte) *dbBucket {
+	return &dbBucket{db.db.Bucket(name), db}
 }
 
-func (db *DBStore) commit() {
-	db.tx.commit()
-	tx, err := db.db.Begin()
-	if err != nil {
-		panic(err)
-	}
-	db.tx.tx = tx
-	db.lastCommit = time.Now().Unix()
-}
-
-// ApplyDiff implements Store.
-func (db *DBStore) Close() error {
-	if db.tx != nil {
-		db.tx.commit()
-		db.tx = nil
-	}
-	return nil
-}
-
-// ApplyDiff implements Store.
-func (db *DBStore) ApplyDiff(s consensus.State, diff consensus.BlockDiff, mustCommit bool) (committed bool) {
-	db.tx.applyState(s)
-	db.tx.applyDiff(s, diff)
-	committed = mustCommit || db.shouldCommit()
-	if committed {
-		db.commit()
-	}
-	return
-}
-
-// RevertDiff implements Store.
-func (db *DBStore) RevertDiff(s consensus.State, diff consensus.BlockDiff) {
-	db.tx.revertDiff(s, diff)
-	db.tx.revertState(s)
-	if db.shouldCommit() {
-		db.commit()
-	}
-}
-
-// WithConsensus implements Store.
-func (db *DBStore) WithConsensus(fn func(consensus.Store)) {
-	fn(db.tx)
-}
-
-// AddCheckpoint implements Store.
-func (db *DBStore) AddCheckpoint(c Checkpoint) {
-	db.tx.putCheckpoint(c)
-}
-
-// Checkpoint implements Store.
-func (db *DBStore) Checkpoint(id types.BlockID) (c Checkpoint, ok bool) {
-	return db.tx.getCheckpoint(id)
-}
-
-// BestIndex implements Store.
-func (db *DBStore) BestIndex(height uint64) (index types.ChainIndex, ok bool) {
-	return db.tx.BestIndex(height)
-}
-
-// NewDBStore creates a new DBStore using the provided database. The current
-// checkpoint is also returned.
-func NewDBStore(db DB, n *consensus.Network, genesisBlock types.Block) (*DBStore, Checkpoint, error) {
-	dtx, err := db.Begin()
-	if err != nil {
-		return nil, Checkpoint{}, err
-	}
-	tx := &dbTx{tx: dtx, n: n}
-
-	// during initialization, we should return an error instead of panicking
-	var txErr error
-	defer func() {
-		if r := recover(); r != nil {
-			txErr = fmt.Errorf("panic during database initialization: %v", r)
-		}
-	}()
-
-	// don't accidentally overwrite a siad database
-	if dtx.Bucket([]byte("ChangeLog")) != nil {
-		return nil, Checkpoint{}, errors.New("detected siad database, refusing to proceed")
-	}
-
-	// if the db is empty, initialize it; otherwise, check that the genesis
-	// block is correct
-	if dbGenesis, ok := tx.BestIndex(0); !ok {
-		for _, bucket := range [][]byte{
-			bVersion,
-			bMainChain,
-			bCheckpoints,
-			bFileContracts,
-			bSiacoinOutputs,
-			bSiafundOutputs,
-		} {
-			if _, err := dtx.CreateBucket(bucket); err != nil {
-				dtx.Cancel()
-				return nil, Checkpoint{}, err
-			}
-		}
-		tx.bucket(bVersion).putRaw(bVersion, []byte{1})
-
-		// store genesis checkpoint and its effects, catching panic
-		genesisState := n.GenesisState()
-		cs := consensus.ApplyState(genesisState, tx, genesisBlock)
-		diff := consensus.ApplyDiff(genesisState, tx, genesisBlock)
-		tx.putCheckpoint(Checkpoint{genesisBlock, cs, &diff})
-		tx.applyState(cs)
-		tx.applyDiff(cs, diff)
-		tx.commit()
-		tx.tx, err = db.Begin()
-		if err != nil {
-			return nil, Checkpoint{}, err
-		}
-	} else if dbGenesis.ID != genesisBlock.ID() {
-		_, mainnetGenesis := Mainnet()
-		_, zenGenesis := TestnetZen()
-		if genesisBlock.ID() == mainnetGenesis.ID() && dbGenesis.ID == zenGenesis.ID() {
-			return nil, Checkpoint{}, errors.New("cannot use Zen testnet database on mainnet")
-		} else if genesisBlock.ID() == zenGenesis.ID() && dbGenesis.ID == mainnetGenesis.ID() {
-			return nil, Checkpoint{}, errors.New("cannot use mainnet database on Zen testnet")
-		} else {
-			return nil, Checkpoint{}, errors.New("database previously initialized with different genesis block")
-		}
-	}
-
-	// load current checkpoint
-	index, _ := tx.BestIndex(tx.getHeight())
-	c, _ := tx.getCheckpoint(index.ID)
-
-	return &DBStore{
-		db:         db,
-		tx:         tx,
-		lastCommit: time.Now().Unix(),
-	}, c, txErr
-}
-
-// wrappers with sticky errors and helper methods
-
-type dbBucket struct {
-	b  DBBucket
-	tx *dbTx
-}
-
-func (b *dbBucket) getRaw(key []byte) []byte {
-	return b.b.Get(key)
-}
-
-func (b *dbBucket) get(key []byte, v types.DecoderFrom) bool {
-	val := b.getRaw(key)
-	if val == nil {
-		return false
-	}
-	d := types.NewBufDecoder(val)
-	v.DecodeFrom(d)
-	if d.Err() != nil {
-		b.tx.check(fmt.Errorf("error decoding %T: %w", v, d.Err()))
-		return false
-	}
-	return true
-}
-
-func (b *dbBucket) putRaw(key, value []byte) {
-	b.tx.check(b.b.Put(key, value))
-	b.tx.size += len(value)
-}
-
-func (b *dbBucket) put(key []byte, v types.EncoderTo) {
-	var buf bytes.Buffer
-	e := types.NewEncoder(&buf)
-	v.EncodeTo(e)
-	e.Flush()
-	b.putRaw(key, buf.Bytes())
-}
-
-func (b *dbBucket) delete(key []byte) {
-	b.tx.check(b.b.Delete(key))
-}
-
-type dbTx struct {
-	tx   DBTx
-	n    *consensus.Network // for getCheckpoint
-	size int
-}
-
-func (tx *dbTx) check(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
-
-func (tx *dbTx) commit() {
-	tx.check(tx.tx.Commit())
-	tx.size = 0
-}
-
-func (tx *dbTx) bucket(name []byte) *dbBucket {
-	return &dbBucket{tx.tx.Bucket(name), tx}
-}
-
-func (tx *dbTx) encHeight(height uint64) []byte {
+func (db *DBStore) encHeight(height uint64) []byte {
 	var buf [8]byte
 	binary.BigEndian.PutUint64(buf[:], height)
 	return buf[:]
 }
 
-func (tx *dbTx) BestIndex(height uint64) (index types.ChainIndex, ok bool) {
-	index.Height = height
-	ok = tx.bucket(bMainChain).get(tx.encHeight(height), &index.ID)
-	return
+func (db *DBStore) putBestIndex(index types.ChainIndex) {
+	db.bucket(bMainChain).put(db.encHeight(index.Height), &index.ID)
 }
 
-func (tx *dbTx) putBestIndex(index types.ChainIndex) {
-	tx.bucket(bMainChain).put(tx.encHeight(index.Height), &index.ID)
+func (db *DBStore) deleteBestIndex(height uint64) {
+	db.bucket(bMainChain).delete(db.encHeight(height))
 }
 
-func (tx *dbTx) deleteBestIndex(height uint64) {
-	tx.bucket(bMainChain).delete(tx.encHeight(height))
-}
-
-func (tx *dbTx) getHeight() (height uint64) {
-	if val := tx.bucket(bMainChain).getRaw(keyHeight); len(val) == 8 {
+func (db *DBStore) getHeight() (height uint64) {
+	if val := db.bucket(bMainChain).getRaw(keyHeight); len(val) == 8 {
 		height = binary.BigEndian.Uint64(val)
 	}
 	return
 }
 
-func (tx *dbTx) putHeight(height uint64) {
-	tx.bucket(bMainChain).putRaw(keyHeight, tx.encHeight(height))
+func (db *DBStore) putHeight(height uint64) {
+	db.bucket(bMainChain).putRaw(keyHeight, db.encHeight(height))
 }
 
-func (tx *dbTx) getCheckpoint(id types.BlockID) (c Checkpoint, ok bool) {
-	ok = tx.bucket(bCheckpoints).get(id[:], &c)
-	c.State.Network = tx.n
-	return
+func (db *DBStore) putCheckpoint(c Checkpoint) {
+	db.bucket(bCheckpoints).put(c.State.Index.ID[:], c)
 }
 
-func (tx *dbTx) putCheckpoint(c Checkpoint) {
-	tx.bucket(bCheckpoints).put(c.State.Index.ID[:], c)
+func (db *DBStore) putSiacoinOutput(id types.SiacoinOutputID, sco types.SiacoinOutput) {
+	db.bucket(bSiacoinOutputs).put(id[:], sco)
 }
 
-func (tx *dbTx) AncestorTimestamp(id types.BlockID, n uint64) time.Time {
-	c, _ := tx.getCheckpoint(id)
-	for i := uint64(1); i < n; i++ {
-		// if we're on the best path, we can jump to the n'th block directly
-		if index, _ := tx.BestIndex(c.State.Index.Height); index.ID == id {
-			ancestorIndex, _ := tx.BestIndex(c.State.Index.Height - (n - i))
-			c, _ = tx.getCheckpoint(ancestorIndex.ID)
-			break
-		}
-		c, _ = tx.getCheckpoint(c.Block.ParentID)
-	}
-	return c.Block.Timestamp
+func (db *DBStore) deleteSiacoinOutput(id types.SiacoinOutputID) {
+	db.bucket(bSiacoinOutputs).delete(id[:])
 }
 
-func (tx *dbTx) SiacoinOutput(id types.SiacoinOutputID) (sco types.SiacoinOutput, ok bool) {
-	ok = tx.bucket(bSiacoinOutputs).get(id[:], &sco)
-	return
-}
-
-func (tx *dbTx) putSiacoinOutput(id types.SiacoinOutputID, sco types.SiacoinOutput) {
-	tx.bucket(bSiacoinOutputs).put(id[:], sco)
-}
-
-func (tx *dbTx) deleteSiacoinOutput(id types.SiacoinOutputID) {
-	tx.bucket(bSiacoinOutputs).delete(id[:])
-}
-
-func (tx *dbTx) FileContract(id types.FileContractID) (fc types.FileContract, ok bool) {
-	ok = tx.bucket(bFileContracts).get(id[:], &fc)
-	return
-}
-
-func (tx *dbTx) MissedFileContracts(height uint64) (fcids []types.FileContractID) {
-	ids := tx.bucket(bFileContracts).getRaw(tx.encHeight(height))
-	for i := 0; i < len(ids); i += 32 {
-		fcids = append(fcids, *(*types.FileContractID)(ids[i:]))
-	}
-	return
-}
-
-func (tx *dbTx) putFileContract(id types.FileContractID, fc types.FileContract) {
-	b := tx.bucket(bFileContracts)
+func (db *DBStore) putFileContract(id types.FileContractID, fc types.FileContract) {
+	b := db.bucket(bFileContracts)
 	b.put(id[:], fc)
 
-	key := tx.encHeight(fc.WindowEnd)
+	key := db.encHeight(fc.WindowEnd)
 	b.putRaw(key, append(b.getRaw(key), id[:]...))
 }
 
-func (tx *dbTx) reviseFileContract(id types.FileContractID, fc types.FileContract) {
-	b := tx.bucket(bFileContracts)
-	b.put(id[:], fc)
+func (db *DBStore) reviseFileContract(id types.FileContractID, fc types.FileContract) {
+	db.bucket(bFileContracts).put(id[:], fc)
 }
 
-func (tx *dbTx) deleteFileContracts(fcds []consensus.FileContractDiff) {
+func (db *DBStore) deleteFileContracts(fcds []consensus.FileContractDiff) {
 	byHeight := make(map[uint64][]types.FileContractID)
-	b := tx.bucket(bFileContracts)
+	b := db.bucket(bFileContracts)
 	for _, fcd := range fcds {
 		var fc types.FileContract
 		if !b.get(fcd.ID[:], &fc) {
-			tx.check(fmt.Errorf("missing file contract %v", fcd.ID))
+			check(fmt.Errorf("missing file contract %v", fcd.ID))
 		}
 		b.delete(fcd.ID[:])
 		byHeight[fc.WindowEnd] = append(byHeight[fc.WindowEnd], fcd.ID)
@@ -486,7 +277,7 @@ func (tx *dbTx) deleteFileContracts(fcds []consensus.FileContractDiff) {
 		for _, id := range ids {
 			toDelete[id] = struct{}{}
 		}
-		key := tx.encHeight(height)
+		key := db.encHeight(height)
 		val := append([]byte(nil), b.getRaw(key)...)
 		for i := 0; i < len(val); i += 32 {
 			id := *(*types.FileContractID)(val[i:])
@@ -499,7 +290,7 @@ func (tx *dbTx) deleteFileContracts(fcds []consensus.FileContractDiff) {
 		}
 		b.putRaw(key, val)
 		if len(toDelete) != 0 {
-			tx.check(errors.New("missing expired file contract(s)"))
+			check(errors.New("missing expired file contract(s)"))
 		}
 	}
 }
@@ -519,22 +310,235 @@ func (sfo *claimSFO) DecodeFrom(d *types.Decoder) {
 	sfo.ClaimStart.DecodeFrom(d)
 }
 
-func (tx *dbTx) SiafundOutput(id types.SiafundOutputID) (sfo types.SiafundOutput, claimStart types.Currency, ok bool) {
+func (db *DBStore) putSiafundOutput(id types.SiafundOutputID, sfo types.SiafundOutput, claimStart types.Currency) {
+	db.bucket(bSiafundOutputs).put(id[:], claimSFO{Output: sfo, ClaimStart: claimStart})
+}
+
+func (db *DBStore) deleteSiafundOutput(id types.SiafundOutputID) {
+	db.bucket(bSiafundOutputs).delete(id[:])
+}
+
+func (db *DBStore) putDelayedSiacoinOutputs(dscods []consensus.DelayedSiacoinOutputDiff) {
+	if len(dscods) == 0 {
+		return
+	}
+	maturityHeight := dscods[0].MaturityHeight
+	b := db.bucket(bSiacoinOutputs)
+	key := db.encHeight(maturityHeight)
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+	for _, dscod := range dscods {
+		if dscod.MaturityHeight != maturityHeight {
+			check(errors.New("mismatched maturity heights"))
+			return
+		}
+		dscod.EncodeTo(e)
+	}
+	e.Flush()
+	b.putRaw(key, append(b.getRaw(key), buf.Bytes()[:]...))
+}
+
+func (db *DBStore) deleteDelayedSiacoinOutputs(dscods []consensus.DelayedSiacoinOutputDiff) {
+	if len(dscods) == 0 {
+		return
+	}
+	maturityHeight := dscods[0].MaturityHeight
+	toDelete := make(map[types.SiacoinOutputID]struct{})
+	for _, dscod := range dscods {
+		if dscod.MaturityHeight != maturityHeight {
+			check(errors.New("mismatched maturity heights"))
+			return
+		}
+		toDelete[dscod.ID] = struct{}{}
+	}
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+	for _, mdscod := range db.MaturedSiacoinOutputs(maturityHeight) {
+		if _, ok := toDelete[mdscod.ID]; !ok {
+			mdscod.EncodeTo(e)
+		}
+		delete(toDelete, mdscod.ID)
+	}
+	if len(toDelete) != 0 {
+		check(errors.New("missing delayed siacoin output(s)"))
+		return
+	}
+	e.Flush()
+	db.bucket(bSiacoinOutputs).putRaw(db.encHeight(maturityHeight), buf.Bytes())
+}
+
+func (db *DBStore) putFoundationOutput(id types.SiacoinOutputID) {
+	b := db.bucket(bSiacoinOutputs)
+	b.putRaw(keyFoundationOutputs, append(b.getRaw(keyFoundationOutputs), id[:]...))
+}
+
+func (db *DBStore) deleteFoundationOutput(id types.SiacoinOutputID) {
+	b := db.bucket(bSiacoinOutputs)
+	ids := append([]byte(nil), b.getRaw(keyFoundationOutputs)...)
+	for i := 0; i < len(ids); i += 32 {
+		if *(*types.SiacoinOutputID)(ids[i:]) == id {
+			copy(ids[i:], ids[len(ids)-32:])
+			b.putRaw(keyFoundationOutputs, ids[:len(ids)-32])
+			return
+		}
+	}
+	check(fmt.Errorf("missing Foundation output %v", id))
+}
+
+func (db *DBStore) moveFoundationOutputs(addr types.Address) {
+	ids := db.bucket(bSiacoinOutputs).getRaw(keyFoundationOutputs)
+	for i := 0; i < len(ids); i += 32 {
+		id := *(*types.SiacoinOutputID)(ids[i:])
+		if sco, ok := db.SiacoinOutput(id); ok {
+			if sco.Address == addr {
+				return // address unchanged; no migration necessary
+			}
+			sco.Address = addr
+			db.putSiacoinOutput(id, sco)
+		}
+	}
+}
+
+func (db *DBStore) applyState(next consensus.State) {
+	db.moveFoundationOutputs(next.FoundationPrimaryAddress)
+	db.putBestIndex(next.Index)
+	db.putHeight(next.Index.Height)
+}
+
+func (db *DBStore) revertState(prev consensus.State) {
+	db.moveFoundationOutputs(prev.FoundationPrimaryAddress)
+	db.deleteBestIndex(prev.Index.Height + 1)
+	db.putHeight(prev.Index.Height)
+}
+
+func (db *DBStore) applyDiff(s consensus.State, diff consensus.BlockDiff) {
+	for _, td := range diff.Transactions {
+		for _, scod := range td.CreatedSiacoinOutputs {
+			db.putSiacoinOutput(scod.ID, scod.Output)
+		}
+		db.putDelayedSiacoinOutputs(td.ImmatureSiacoinOutputs)
+		for _, sfod := range td.CreatedSiafundOutputs {
+			db.putSiafundOutput(sfod.ID, sfod.Output, sfod.ClaimStart)
+		}
+		for _, fcd := range td.CreatedFileContracts {
+			db.putFileContract(fcd.ID, fcd.Contract)
+		}
+		for _, scod := range td.SpentSiacoinOutputs {
+			db.deleteSiacoinOutput(scod.ID)
+		}
+		for _, sfod := range td.SpentSiafundOutputs {
+			db.deleteSiafundOutput(sfod.ID)
+		}
+		for _, fcrd := range td.RevisedFileContracts {
+			db.reviseFileContract(fcrd.ID, fcrd.NewContract)
+		}
+		db.deleteFileContracts(td.ValidFileContracts)
+	}
+	db.putDelayedSiacoinOutputs(diff.ImmatureSiacoinOutputs)
+	for _, dscod := range diff.ImmatureSiacoinOutputs {
+		if dscod.Source == consensus.OutputSourceFoundation {
+			db.putFoundationOutput(dscod.ID)
+		}
+	}
+	db.deleteDelayedSiacoinOutputs(diff.MaturedSiacoinOutputs)
+	for _, scod := range diff.MaturedSiacoinOutputs {
+		db.putSiacoinOutput(scod.ID, scod.Output)
+	}
+	db.deleteFileContracts(diff.MissedFileContracts)
+}
+
+func (db *DBStore) revertDiff(s consensus.State, diff consensus.BlockDiff) {
+	for _, fcd := range diff.MissedFileContracts {
+		db.putFileContract(fcd.ID, fcd.Contract)
+	}
+	for _, scod := range diff.MaturedSiacoinOutputs {
+		db.deleteSiacoinOutput(scod.ID)
+	}
+	db.putDelayedSiacoinOutputs(diff.MaturedSiacoinOutputs)
+	for _, dscod := range diff.ImmatureSiacoinOutputs {
+		if dscod.Source == consensus.OutputSourceFoundation {
+			db.deleteFoundationOutput(dscod.ID)
+		}
+	}
+	db.deleteDelayedSiacoinOutputs(diff.ImmatureSiacoinOutputs)
+	for i := len(diff.Transactions) - 1; i >= 0; i-- {
+		td := diff.Transactions[i]
+		for _, fcd := range td.ValidFileContracts {
+			db.putFileContract(fcd.ID, fcd.Contract)
+		}
+		for _, fcrd := range td.RevisedFileContracts {
+			db.reviseFileContract(fcrd.ID, fcrd.OldContract)
+		}
+		for _, sfod := range td.SpentSiafundOutputs {
+			db.putSiafundOutput(sfod.ID, sfod.Output, sfod.ClaimStart)
+		}
+		for _, scod := range td.SpentSiacoinOutputs {
+			db.putSiacoinOutput(scod.ID, scod.Output)
+		}
+		db.deleteFileContracts(td.CreatedFileContracts)
+		for _, sfod := range td.CreatedSiafundOutputs {
+			db.deleteSiafundOutput(sfod.ID)
+		}
+		db.deleteDelayedSiacoinOutputs(td.ImmatureSiacoinOutputs)
+		for _, scod := range td.CreatedSiacoinOutputs {
+			db.deleteSiacoinOutput(scod.ID)
+		}
+	}
+}
+
+// BestIndex implements consensus.Store.
+func (db *DBStore) BestIndex(height uint64) (index types.ChainIndex, ok bool) {
+	index.Height = height
+	ok = db.bucket(bMainChain).get(db.encHeight(height), &index.ID)
+	return
+}
+
+// AncestorTimestamp implements consensus.Store.
+func (db *DBStore) AncestorTimestamp(id types.BlockID, n uint64) time.Time {
+	c, _ := db.Checkpoint(id)
+	for i := uint64(1); i < n; i++ {
+		// if we're on the best path, we can jump to the n'th block directly
+		if index, _ := db.BestIndex(c.State.Index.Height); index.ID == id {
+			ancestorIndex, _ := db.BestIndex(c.State.Index.Height - (n - i))
+			c, _ = db.Checkpoint(ancestorIndex.ID)
+			break
+		}
+		c, _ = db.Checkpoint(c.Block.ParentID)
+	}
+	return c.Block.Timestamp
+}
+
+// SiacoinOutput implements consensus.Store.
+func (db *DBStore) SiacoinOutput(id types.SiacoinOutputID) (sco types.SiacoinOutput, ok bool) {
+	ok = db.bucket(bSiacoinOutputs).get(id[:], &sco)
+	return
+}
+
+// FileContract implements consensus.Store.
+func (db *DBStore) FileContract(id types.FileContractID) (fc types.FileContract, ok bool) {
+	ok = db.bucket(bFileContracts).get(id[:], &fc)
+	return
+}
+
+// MissedFileContracts implements consensus.Store.
+func (db *DBStore) MissedFileContracts(height uint64) (fcids []types.FileContractID) {
+	ids := db.bucket(bFileContracts).getRaw(db.encHeight(height))
+	for i := 0; i < len(ids); i += 32 {
+		fcids = append(fcids, *(*types.FileContractID)(ids[i:]))
+	}
+	return
+}
+
+// SiafundOutput implements consensus.Store.
+func (db *DBStore) SiafundOutput(id types.SiafundOutputID) (sfo types.SiafundOutput, claimStart types.Currency, ok bool) {
 	var csfo claimSFO
-	ok = tx.bucket(bSiafundOutputs).get(id[:], &csfo)
+	ok = db.bucket(bSiafundOutputs).get(id[:], &csfo)
 	return csfo.Output, csfo.ClaimStart, ok
 }
 
-func (tx *dbTx) putSiafundOutput(id types.SiafundOutputID, sfo types.SiafundOutput, claimStart types.Currency) {
-	tx.bucket(bSiafundOutputs).put(id[:], claimSFO{Output: sfo, ClaimStart: claimStart})
-}
-
-func (tx *dbTx) deleteSiafundOutput(id types.SiafundOutputID) {
-	tx.bucket(bSiafundOutputs).delete(id[:])
-}
-
-func (tx *dbTx) MaturedSiacoinOutputs(height uint64) (dscods []consensus.DelayedSiacoinOutputDiff) {
-	dscos := tx.bucket(bSiacoinOutputs).getRaw(tx.encHeight(height))
+// MaturedSiacoinOutputs implements consensus.Store.
+func (db *DBStore) MaturedSiacoinOutputs(height uint64) (dscods []consensus.DelayedSiacoinOutputDiff) {
+	dscos := db.bucket(bSiacoinOutputs).getRaw(db.encHeight(height))
 	d := types.NewBufDecoder(dscos)
 	for {
 		var dscod consensus.DelayedSiacoinOutputDiff
@@ -545,175 +549,120 @@ func (tx *dbTx) MaturedSiacoinOutputs(height uint64) (dscods []consensus.Delayed
 		dscods = append(dscods, dscod)
 	}
 	if !errors.Is(d.Err(), io.EOF) {
-		tx.check(d.Err())
+		check(d.Err())
 	}
 	return
 }
 
-func (tx *dbTx) putDelayedSiacoinOutputs(dscods []consensus.DelayedSiacoinOutputDiff) {
-	if len(dscods) == 0 {
-		return
-	}
-	maturityHeight := dscods[0].MaturityHeight
-	b := tx.bucket(bSiacoinOutputs)
-	key := tx.encHeight(maturityHeight)
-	var buf bytes.Buffer
-	e := types.NewEncoder(&buf)
-	for _, dscod := range dscods {
-		if dscod.MaturityHeight != maturityHeight {
-			tx.check(errors.New("mismatched maturity heights"))
-			return
-		}
-		dscod.EncodeTo(e)
-	}
-	e.Flush()
-	b.putRaw(key, append(b.getRaw(key), buf.Bytes()[:]...))
+// AddCheckpoint implements Store.
+func (db *DBStore) AddCheckpoint(c Checkpoint) {
+	db.bucket(bCheckpoints).put(c.State.Index.ID[:], c)
 }
 
-func (tx *dbTx) deleteDelayedSiacoinOutputs(dscods []consensus.DelayedSiacoinOutputDiff) {
-	if len(dscods) == 0 {
-		return
-	}
-	maturityHeight := dscods[0].MaturityHeight
-	toDelete := make(map[types.SiacoinOutputID]struct{})
-	for _, dscod := range dscods {
-		if dscod.MaturityHeight != maturityHeight {
-			tx.check(errors.New("mismatched maturity heights"))
-			return
-		}
-		toDelete[dscod.ID] = struct{}{}
-	}
-	var buf bytes.Buffer
-	e := types.NewEncoder(&buf)
-	for _, mdscod := range tx.MaturedSiacoinOutputs(maturityHeight) {
-		if _, ok := toDelete[mdscod.ID]; !ok {
-			mdscod.EncodeTo(e)
-		}
-		delete(toDelete, mdscod.ID)
-	}
-	if len(toDelete) != 0 {
-		tx.check(errors.New("missing delayed siacoin output(s)"))
-		return
-	}
-	e.Flush()
-	tx.bucket(bSiacoinOutputs).putRaw(tx.encHeight(maturityHeight), buf.Bytes())
+// Checkpoint implements Store.
+func (db *DBStore) Checkpoint(id types.BlockID) (c Checkpoint, ok bool) {
+	ok = db.bucket(bCheckpoints).get(id[:], &c)
+	c.State.Network = db.n
+	return
 }
 
-func (tx *dbTx) putFoundationOutput(id types.SiacoinOutputID) {
-	b := tx.bucket(bSiacoinOutputs)
-	b.putRaw(keyFoundationOutputs, append(b.getRaw(keyFoundationOutputs), id[:]...))
+func (db *DBStore) shouldFlush() bool {
+	const flushSizeThreshold = 1 << 20 // ~1 MB
+	const flushDurationThreshold = 5 * time.Second
+	return db.unflushed >= flushSizeThreshold || time.Since(db.lastFlush) >= flushDurationThreshold
 }
 
-func (tx *dbTx) deleteFoundationOutput(id types.SiacoinOutputID) {
-	b := tx.bucket(bSiacoinOutputs)
-	ids := append([]byte(nil), b.getRaw(keyFoundationOutputs)...)
-	for i := 0; i < len(ids); i += 32 {
-		if *(*types.SiacoinOutputID)(ids[i:]) == id {
-			copy(ids[i:], ids[len(ids)-32:])
-			b.putRaw(keyFoundationOutputs, ids[:len(ids)-32])
-			return
-		}
+func (db *DBStore) flush() {
+	if err := db.db.Flush(); err != nil {
+		panic(err)
 	}
-	tx.check(fmt.Errorf("missing Foundation output %v", id))
+	db.unflushed = 0
+	db.lastFlush = time.Now()
 }
 
-func (tx *dbTx) moveFoundationOutputs(addr types.Address) {
-	ids := tx.bucket(bSiacoinOutputs).getRaw(keyFoundationOutputs)
-	for i := 0; i < len(ids); i += 32 {
-		id := *(*types.SiacoinOutputID)(ids[i:])
-		if sco, ok := tx.SiacoinOutput(id); ok {
-			if sco.Address == addr {
-				return // address unchanged; no migration necessary
+// ApplyDiff implements Store.
+func (db *DBStore) ApplyDiff(s consensus.State, diff consensus.BlockDiff, mustCommit bool) (committed bool) {
+	db.applyState(s)
+	db.applyDiff(s, diff)
+	committed = mustCommit || db.shouldFlush()
+	if committed {
+		db.flush()
+	}
+	return
+}
+
+// RevertDiff implements Store.
+func (db *DBStore) RevertDiff(s consensus.State, diff consensus.BlockDiff) {
+	db.revertDiff(s, diff)
+	db.revertState(s)
+	if db.shouldFlush() {
+		db.flush()
+	}
+}
+
+// Close flushes any uncommitted data to the underlying DB.
+func (db *DBStore) Close() error {
+	return db.db.Flush()
+}
+
+// NewDBStore creates a new DBStore using the provided database. The current
+// checkpoint is also returned.
+func NewDBStore(db DB, n *consensus.Network, genesisBlock types.Block) (_ *DBStore, _ Checkpoint, err error) {
+	// during initialization, we should return an error instead of panicking
+	defer func() {
+		if r := recover(); r != nil {
+			db.Cancel()
+			err = fmt.Errorf("panic during database initialization: %v", r)
+		}
+	}()
+
+	// don't accidentally overwrite a siad database
+	if db.Bucket([]byte("ChangeLog")) != nil {
+		return nil, Checkpoint{}, errors.New("detected siad database, refusing to proceed")
+	}
+
+	dbs := &DBStore{db: db, n: n}
+
+	// if the db is empty, initialize it; otherwise, check that the genesis
+	// block is correct
+	if dbGenesis, ok := dbs.BestIndex(0); !ok {
+		for _, bucket := range [][]byte{
+			bVersion,
+			bMainChain,
+			bCheckpoints,
+			bFileContracts,
+			bSiacoinOutputs,
+			bSiafundOutputs,
+		} {
+			if _, err := db.CreateBucket(bucket); err != nil {
+				panic(err)
 			}
-			sco.Address = addr
-			tx.putSiacoinOutput(id, sco)
 		}
-	}
-}
+		dbs.bucket(bVersion).putRaw(bVersion, []byte{1})
 
-func (tx *dbTx) applyState(next consensus.State) {
-	tx.moveFoundationOutputs(next.FoundationPrimaryAddress)
-	tx.putBestIndex(next.Index)
-	tx.putHeight(next.Index.Height)
-}
+		// store genesis checkpoint and apply its effects
+		genesisState := n.GenesisState()
+		cs := consensus.ApplyState(genesisState, dbs, genesisBlock)
+		diff := consensus.ApplyDiff(genesisState, dbs, genesisBlock)
+		dbs.putCheckpoint(Checkpoint{genesisBlock, cs, &diff})
+		dbs.applyState(cs)
+		dbs.applyDiff(cs, diff)
+		dbs.flush()
+	} else if dbGenesis.ID != genesisBlock.ID() {
+		// try to detect network so we can provide a more helpful error message
+		_, mainnetGenesis := Mainnet()
+		_, zenGenesis := TestnetZen()
+		if genesisBlock.ID() == mainnetGenesis.ID() && dbGenesis.ID == zenGenesis.ID() {
+			return nil, Checkpoint{}, errors.New("cannot use Zen testnet database on mainnet")
+		} else if genesisBlock.ID() == zenGenesis.ID() && dbGenesis.ID == mainnetGenesis.ID() {
+			return nil, Checkpoint{}, errors.New("cannot use mainnet database on Zen testnet")
+		} else {
+			return nil, Checkpoint{}, errors.New("database previously initialized with different genesis block")
+		}
+	}
 
-func (tx *dbTx) revertState(prev consensus.State) {
-	tx.moveFoundationOutputs(prev.FoundationPrimaryAddress)
-	tx.deleteBestIndex(prev.Index.Height + 1)
-	tx.putHeight(prev.Index.Height)
-}
-
-func (tx *dbTx) applyDiff(s consensus.State, diff consensus.BlockDiff) {
-	for _, td := range diff.Transactions {
-		for _, scod := range td.CreatedSiacoinOutputs {
-			tx.putSiacoinOutput(scod.ID, scod.Output)
-		}
-		tx.putDelayedSiacoinOutputs(td.ImmatureSiacoinOutputs)
-		for _, sfod := range td.CreatedSiafundOutputs {
-			tx.putSiafundOutput(sfod.ID, sfod.Output, sfod.ClaimStart)
-		}
-		for _, fcd := range td.CreatedFileContracts {
-			tx.putFileContract(fcd.ID, fcd.Contract)
-		}
-		for _, scod := range td.SpentSiacoinOutputs {
-			tx.deleteSiacoinOutput(scod.ID)
-		}
-		for _, sfod := range td.SpentSiafundOutputs {
-			tx.deleteSiafundOutput(sfod.ID)
-		}
-		for _, fcrd := range td.RevisedFileContracts {
-			tx.reviseFileContract(fcrd.ID, fcrd.NewContract)
-		}
-		tx.deleteFileContracts(td.ValidFileContracts)
-	}
-	tx.putDelayedSiacoinOutputs(diff.ImmatureSiacoinOutputs)
-	for _, dscod := range diff.ImmatureSiacoinOutputs {
-		if dscod.Source == consensus.OutputSourceFoundation {
-			tx.putFoundationOutput(dscod.ID)
-		}
-	}
-	tx.deleteDelayedSiacoinOutputs(diff.MaturedSiacoinOutputs)
-	for _, scod := range diff.MaturedSiacoinOutputs {
-		tx.putSiacoinOutput(scod.ID, scod.Output)
-	}
-	tx.deleteFileContracts(diff.MissedFileContracts)
-}
-
-func (tx *dbTx) revertDiff(s consensus.State, diff consensus.BlockDiff) {
-	for _, fcd := range diff.MissedFileContracts {
-		tx.putFileContract(fcd.ID, fcd.Contract)
-	}
-	for _, scod := range diff.MaturedSiacoinOutputs {
-		tx.deleteSiacoinOutput(scod.ID)
-	}
-	tx.putDelayedSiacoinOutputs(diff.MaturedSiacoinOutputs)
-	for _, dscod := range diff.ImmatureSiacoinOutputs {
-		if dscod.Source == consensus.OutputSourceFoundation {
-			tx.deleteFoundationOutput(dscod.ID)
-		}
-	}
-	tx.deleteDelayedSiacoinOutputs(diff.ImmatureSiacoinOutputs)
-	for i := len(diff.Transactions) - 1; i >= 0; i-- {
-		td := diff.Transactions[i]
-		for _, fcd := range td.ValidFileContracts {
-			tx.putFileContract(fcd.ID, fcd.Contract)
-		}
-		for _, fcrd := range td.RevisedFileContracts {
-			tx.reviseFileContract(fcrd.ID, fcrd.OldContract)
-		}
-		for _, sfod := range td.SpentSiafundOutputs {
-			tx.putSiafundOutput(sfod.ID, sfod.Output, sfod.ClaimStart)
-		}
-		for _, scod := range td.SpentSiacoinOutputs {
-			tx.putSiacoinOutput(scod.ID, scod.Output)
-		}
-		tx.deleteFileContracts(td.CreatedFileContracts)
-		for _, sfod := range td.CreatedSiafundOutputs {
-			tx.deleteSiafundOutput(sfod.ID)
-		}
-		tx.deleteDelayedSiacoinOutputs(td.ImmatureSiacoinOutputs)
-		for _, scod := range td.CreatedSiacoinOutputs {
-			tx.deleteSiacoinOutput(scod.ID)
-		}
-	}
+	// load current checkpoint
+	index, _ := dbs.BestIndex(dbs.getHeight())
+	c, _ := dbs.Checkpoint(index.ID)
+	return dbs, c, err
 }

--- a/chain/db.go
+++ b/chain/db.go
@@ -567,8 +567,10 @@ func (db *DBStore) Checkpoint(id types.BlockID) (c Checkpoint, ok bool) {
 }
 
 func (db *DBStore) shouldFlush() bool {
-	const flushSizeThreshold = 1 << 20 // ~1 MB
-	const flushDurationThreshold = 5 * time.Second
+	// NOTE: these values were chosen empirically and should constitute a
+	// sensible default; if necessary, we can make them configurable
+	const flushSizeThreshold = 2e6
+	const flushDurationThreshold = 100 * time.Millisecond
 	return db.unflushed >= flushSizeThreshold || time.Since(db.lastFlush) >= flushDurationThreshold
 }
 

--- a/chain/manager.go
+++ b/chain/manager.go
@@ -275,9 +275,9 @@ func (m *Manager) applyTip(index types.ChainIndex) error {
 	}
 
 	// force the store to commit if we're at the tip (or close to it), or at
-	// least every 10 seconds; this ensures that the amount of uncommitted data
+	// least every 2 seconds; this ensures that the amount of uncommitted data
 	// never grows too large
-	forceCommit := time.Since(c.Block.Timestamp) < c.State.BlockInterval()*10 || time.Since(m.lastCommit) > 10*time.Second
+	forceCommit := time.Since(c.Block.Timestamp) < c.State.BlockInterval()*2 || time.Since(m.lastCommit) > 2*time.Second
 	committed := m.store.ApplyDiff(c.State, *c.Diff, forceCommit)
 	if committed {
 		m.lastCommit = time.Now()

--- a/chain/manager_test.go
+++ b/chain/manager_test.go
@@ -60,9 +60,7 @@ func TestManager(t *testing.T) {
 				}},
 			}
 			findBlockNonce(cs, &b)
-			store.WithConsensus(func(cstore consensus.Store) {
-				cs = consensus.ApplyState(cs, cstore, b)
-			})
+			cs = consensus.ApplyState(cs, store, b)
 			blocks = append(blocks, b)
 		}
 		return

--- a/chain/manager_test.go
+++ b/chain/manager_test.go
@@ -43,6 +43,7 @@ func TestManager(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer store.Close()
 	cm := NewManager(store, checkpoint.State)
 
 	var hs historySubscriber

--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -34,6 +34,7 @@ func TestApplyBlock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer dbStore.Close()
 	cs := checkpoint.State
 
 	signTxn := func(txn *types.Transaction) {
@@ -57,13 +58,11 @@ func TestApplyBlock(t *testing.T) {
 		}
 	}
 	addBlock := func(b types.Block) (diff consensus.BlockDiff, err error) {
-		dbStore.WithConsensus(func(cstore consensus.Store) {
-			if err = consensus.ValidateBlock(cs, cstore, b); err != nil {
-				return
-			}
-			diff = consensus.ApplyDiff(cs, cstore, b)
-			cs = consensus.ApplyState(cs, cstore, b)
-		})
+		if err = consensus.ValidateBlock(cs, dbStore, b); err != nil {
+			return
+		}
+		diff = consensus.ApplyDiff(cs, dbStore, b)
+		cs = consensus.ApplyState(cs, dbStore, b)
 		return
 	}
 

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -136,11 +136,9 @@ func TestValidateBlock(t *testing.T) {
 	validBlock := deepCopyBlock(b)
 	signTxn(&validBlock.Transactions[0])
 	findBlockNonce(cs, &validBlock)
-	dbStore.WithConsensus(func(cstore consensus.Store) {
-		if err := consensus.ValidateBlock(cs, cstore, validBlock); err != nil {
-			t.Fatal(err)
-		}
-	})
+	if err := consensus.ValidateBlock(cs, dbStore, validBlock); err != nil {
+		t.Fatal(err)
+	}
 
 	{
 		tests := []struct {
@@ -416,11 +414,9 @@ func TestValidateBlock(t *testing.T) {
 			signTxn(&corruptBlock.Transactions[0])
 			findBlockNonce(cs, &corruptBlock)
 
-			dbStore.WithConsensus(func(cstore consensus.Store) {
-				if err := consensus.ValidateBlock(cs, cstore, corruptBlock); err == nil {
-					t.Fatalf("accepted block with %v", test.desc)
-				}
-			})
+			if err := consensus.ValidateBlock(cs, dbStore, corruptBlock); err == nil {
+				t.Fatalf("accepted block with %v", test.desc)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This began as an effort to make the DB commit less frequently, which is important for speeding up IBD. Currently, we commit (i.e. fsync) after every block, which means hundreds of thousands of fsyncs are required for a full IBD -- often many fsyncs per second. Needless to say, this is enormously wasteful. Ideally, we would fsync once every few seconds, and/or after buffering a large number of writes. So that's what this PR does: it tracks how long it's been since the last fsync, and how many writes we've buffered since then, and only flushes after we cross a threshold.

In the course of implementing this, I realized that our `DB` interface was more powerful than necessary. Specifically, it supports fully-isolated transactions, meaning you can have multiple "views" of the DB open concurrently, and those views won't observe each others effects, and can be committed or rolled back independently. However, our usage of the DB is already serialized by the `chain.Manager`'s mutex, and clients of `chain.Manager` only have limited access to the DB. So we actually don't need transactions; all we need is a way to force an fsync, so that we can guarantee that a subscriber will never commit data that hasn't been committed by the manager itself. That's what this PR does.

This still needs to be tested and benchmarked on an actual node, so I'll hold off on merging until then. Hopefully we'll see a significant speedup!