### PR TITLE
RPCCost (RHPv2)

### DIFF
--- a/rhp/v2/rhp.go
+++ b/rhp/v2/rhp.go
@@ -336,7 +336,7 @@ func (hs *HostSettings) RPCReadCost(sections []RPCReadRequestSection, proof bool
 		case sec.Length == 0:
 			return RPCCost{}, errors.New("length cannot be zero")
 		case proof && (sec.Offset%LeafSize != 0 || sec.Length%LeafSize != 0):
-			return RPCCost{}, errors.New("offset and length must be multiples of SegmentSize when requesting a Merkle proof")
+			return RPCCost{}, errors.New("offset and length must be multiples of LeafSize when requesting a Merkle proof")
 		}
 
 		bandwidth += uint64(sec.Length)


### PR DESCRIPTION
This PR adds the `rpcCost` type from `hostd`. We can move it over to `core` and get rid of some of the very rough estimates for proof sizes and replace them by exact values we get from `DiffProofSize`.