### PR TITLE
Add alternative Marshalling Tests for consensus

### DIFF
--- a/consensus/alt_marshal_test.go
+++ b/consensus/alt_marshal_test.go
@@ -1,0 +1,87 @@
+package consensus_test
+
+import (
+    "testing"
+    "math/big"
+
+    "go.sia.tech/core/consensus"
+)
+
+// Constants for test cases and error messages.
+const (
+    testBigIntValue        = 12345
+    errMsgNegativeValue    = "value cannot be negative"
+    errMsgValueOverflows   = "value overflows Work representation"
+    maxBigIntString        = "115792089237316195423570985008687907853269984665640564039457584007913129639936" // 2^256 - 1
+    invalidByteSliceString = "invalid"
+)
+
+func TestWorkMarshalText(t *testing.T) {
+    var work consensus.Work
+    testValue := big.NewInt(testBigIntValue)
+
+    // Initialization of Work object using UnmarshalText
+    if err := work.UnmarshalText([]byte(testValue.String())); err != nil {
+        t.Fatalf("failed to unmarshal text: %v", err)
+    }
+
+    // Testing MarshalText
+    got, err := work.MarshalText()
+    if err != nil {
+        t.Fatalf("expected nil error, got %v", err)
+    }
+
+    expected, err := testValue.MarshalText()
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+
+    if string(got) != string(expected) {
+        t.Errorf("expected %s, got %s", expected, got)
+    }
+}
+
+func TestWorkUnmarshalText(t *testing.T) {
+    var work consensus.Work
+
+    // Case 1: Valid byte slice
+    if err := work.UnmarshalText([]byte(big.NewInt(testBigIntValue).String())); err != nil {
+        t.Fatalf("expected nil error, got %v", err)
+    }
+
+    // Case 2: Negative value
+    if err := work.UnmarshalText([]byte(big.NewInt(-testBigIntValue).String())); err == nil || err.Error() != errMsgNegativeValue {
+        t.Fatalf("expected error: %s, got: %v", errMsgNegativeValue, err)
+    }
+
+    // Case 3: Overflow value
+    if err := work.UnmarshalText([]byte(maxBigIntString)); err == nil || err.Error() != errMsgValueOverflows {
+        t.Fatalf("expected error: %s, got: %v", errMsgValueOverflows, err)
+    }
+
+    // Case 4: Invalid byte slice
+    if err := work.UnmarshalText([]byte(invalidByteSliceString)); err == nil {
+        t.Fatal("expected an error, got nil")
+    }
+}
+
+func TestWorkJSONSerialization(t *testing.T) {
+    var work consensus.Work
+    if err := work.UnmarshalText([]byte("11")); err != nil {
+        t.Fatalf("failed to unmarshal text: %v", err)
+    }
+
+    jsonData, err := work.MarshalJSON()
+    if err != nil {
+        t.Fatalf("failed to marshal JSON: %v", err)
+    }
+
+    var work2 consensus.Work
+    if err := work2.UnmarshalJSON(jsonData); err != nil {
+        t.Fatalf("failed to unmarshal JSON: %v", err)
+    }
+
+    if work.String() != work2.String() {
+        t.Errorf("expected %v, got %v", work, work2)
+    }
+}


### PR DESCRIPTION
I finished working on these tests last weekend, but due to _unforeseen_ circumstances, I couldn't submit the pull request.
Today I can finally do it, but I noticed that just yesterday another contributor, who coincidentally worked on some of the same test features as I did, submitted his PR #132 

I wasn't sure how to proceed in this situation, so I decided to run test coverage. In my case, the overall coverage percentage was 77.3%, while @chris124567's was 79.8%, which I congratulate him on. However, if we combine our PRs, the rate reaches 80.1%

Chris and I approached the task and code-writing differently, and to be honest, I'm not sure how you'll handle our PRs after comparing and analyzing them; nonetheless, I decided to offer alternative tests for the Marshaler and Unmarshaler functions and submit this PR.