### PR TITLE
Add `RenewalCosts` to rhpv3 

### DIFF
--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -81,7 +81,7 @@ func ContractRenewalCollateral(fc types.FileContract, expectedNewStorage uint64,
 	if endHeight < fc.EndHeight() {
 		panic("endHeight should be at least the current end height of the contract")
 	}
-	extension := endHeight - fc.EndHeight()
+	extension := endHeight - fc.WindowEnd
 	if endHeight < blockHeight {
 		panic("current blockHeight should be lower than the endHeight")
 	}

--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -155,7 +155,7 @@ func CalculateHostPayouts(fc types.FileContract, newCollateral types.Currency, s
 
 	// if the contract height did not increase both prices are zero
 	if contractEnd := uint64(endHeight + settings.WindowSize); contractEnd > fc.WindowEnd {
-		timeExtension := uint64(contractEnd - fc.WindowEnd)
+		timeExtension := uint64(contractEnd - fc.EndHeight())
 		basePrice = settings.StoragePrice.Mul64(fc.Filesize).Mul64(timeExtension)
 		baseCollateral = settings.Collateral.Mul64(fc.Filesize).Mul64(timeExtension)
 	}

--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -155,7 +155,7 @@ func CalculateHostPayouts(fc types.FileContract, newCollateral types.Currency, s
 
 	// if the contract height did not increase both prices are zero
 	if contractEnd := uint64(endHeight + settings.WindowSize); contractEnd > fc.WindowEnd {
-		timeExtension := uint64(contractEnd - fc.EndHeight())
+		timeExtension := uint64(contractEnd - fc.WindowEnd)
 		basePrice = settings.StoragePrice.Mul64(fc.Filesize).Mul64(timeExtension)
 		baseCollateral = settings.Collateral.Mul64(fc.Filesize).Mul64(timeExtension)
 	}

--- a/rhp/v3/contracts.go
+++ b/rhp/v3/contracts.go
@@ -80,13 +80,13 @@ func RenewalCosts(fc types.FileContract, pt HostPriceTable, expectedNewStorage, 
 
 	// if the contract height did not increase both prices are zero
 	if contractEnd := uint64(endHeight + pt.WindowSize); contractEnd > fc.WindowEnd {
-		timeExtension := uint64(contractEnd - fc.EndHeight())
+		timeExtension := uint64(contractEnd - fc.WindowEnd)
 		basePrice = basePrice.Add(pt.WriteStoreCost.Mul64(fc.Filesize).Mul64(timeExtension))
 		baseCollateral = baseCollateral.Add(pt.CollateralCost.Mul64(fc.Filesize).Mul64(timeExtension))
 	}
 
 	// calculate the new collateral
-	newCollateral := pt.CollateralCost.Mul64(expectedNewStorage).Mul64(endHeight - pt.HostBlockHeight)
+	newCollateral := pt.CollateralCost.Mul64(expectedNewStorage).Mul64(endHeight + pt.WindowSize - pt.HostBlockHeight)
 
 	// cap collateral
 	if baseCollateral.Cmp(pt.MaxCollateral) > 0 {

--- a/rhp/v3/contracts.go
+++ b/rhp/v3/contracts.go
@@ -1,6 +1,7 @@
 package rhp
 
 import (
+	"errors"
 	"math/bits"
 
 	"go.sia.tech/core/consensus"
@@ -15,8 +16,11 @@ func ContractRenewalCost(cs consensus.State, pt HostPriceTable, fc types.FileCon
 }
 
 // PrepareContractRenewal constructs a contract renewal transaction.
-func PrepareContractRenewal(currentRevision types.FileContractRevision, hostAddress, renterAddress types.Address, renterPayout, newCollateral types.Currency, pt HostPriceTable, endHeight uint64) (types.FileContract, types.Currency) {
-	hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice := CalculateHostPayouts(currentRevision.FileContract, newCollateral, pt, endHeight)
+func PrepareContractRenewal(currentRevision types.FileContractRevision, hostAddress, renterAddress types.Address, renterPayout, minNewCollateral types.Currency, pt HostPriceTable, expectedNewStorage, endHeight uint64) (types.FileContract, types.Currency, error) {
+	hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice, err := CalculateHostPayouts(currentRevision.FileContract, minNewCollateral, pt, expectedNewStorage, endHeight)
+	if err != nil {
+		return types.FileContract{}, types.ZeroCurrency, err
+	}
 
 	return types.FileContract{
 		Filesize:       currentRevision.Filesize,
@@ -35,32 +39,63 @@ func PrepareContractRenewal(currentRevision types.FileContractRevision, hostAddr
 			{Value: hostMissedPayout, Address: hostAddress},
 			{Value: voidMissedPayout, Address: types.Address{}},
 		},
-	}, basePrice
+	}, basePrice, nil
 }
 
 // CalculateHostPayouts calculates the contract payouts for the host.
-func CalculateHostPayouts(fc types.FileContract, newCollateral types.Currency, pt HostPriceTable, endHeight uint64) (types.Currency, types.Currency, types.Currency, types.Currency) {
-	// Calculate the base price and base collateral. The price always includes
-	// the fee for renewing the contract.
-	basePrice := pt.RenewContractCost
-	var baseCollateral types.Currency
+func CalculateHostPayouts(fc types.FileContract, minNewCollateral types.Currency, pt HostPriceTable, expectedNewStorage, endHeight uint64) (types.Currency, types.Currency, types.Currency, types.Currency, error) {
+	// sanity check the inputs
+	if endHeight < fc.EndHeight() {
+		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, errors.New("endHeight should be at least the current end height of the contract")
+	} else if endHeight < pt.HostBlockHeight {
+		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, errors.New("current blockHeight should be lower than the endHeight")
+	}
 
-	// if the contract height did not increase both prices are zero
-	if contractEnd := uint64(endHeight + pt.WindowSize); contractEnd > fc.WindowEnd {
-		timeExtension := uint64(contractEnd - fc.WindowEnd)
-		basePrice = basePrice.Add(pt.WriteStoreCost.Mul64(fc.Filesize).Mul64(timeExtension))
-		baseCollateral = baseCollateral.Add(pt.CollateralCost.Mul64(fc.Filesize).Mul64(timeExtension))
+	// calculate the base costs
+	basePrice, baseCollateral, newCollateral := RenewalCosts(fc, pt, expectedNewStorage, endHeight)
+
+	// make sure the minimum amount of new collateral is added
+	if newCollateral.Cmp(minNewCollateral) < 0 {
+		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, errors.New("new collateral is too low")
 	}
 
 	// calculate payouts
 	hostValidPayout := pt.ContractPrice.Add(basePrice).Add(baseCollateral).Add(newCollateral)
 	voidMissedPayout := basePrice.Add(baseCollateral)
 	if hostValidPayout.Cmp(voidMissedPayout) < 0 {
-		// TODO: detect this elsewhere
-		panic("host's settings are unsatisfiable")
+		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, errors.New("host's settings are unsatisfiable")
 	}
 	hostMissedPayout := hostValidPayout.Sub(voidMissedPayout)
-	return hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice
+	return hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice, nil
+}
+
+// RenewalCosts calculates the base price, base collateral and new collateral
+// for a contract renewal taking into account the host's MaxCollateral setting
+// and contract price.
+func RenewalCosts(fc types.FileContract, pt HostPriceTable, expectedNewStorage, endHeight uint64) (_, _, _ types.Currency) {
+	// calculate the base price and base collateral. The price always includes
+	// the fee for renewing the contract
+	basePrice := pt.RenewContractCost
+	var baseCollateral types.Currency
+
+	// if the contract height did not increase both prices are zero
+	if contractEnd := uint64(endHeight + pt.WindowSize); contractEnd > fc.WindowEnd {
+		timeExtension := uint64(contractEnd - fc.EndHeight())
+		basePrice = basePrice.Add(pt.WriteStoreCost.Mul64(fc.Filesize).Mul64(timeExtension))
+		baseCollateral = baseCollateral.Add(pt.CollateralCost.Mul64(fc.Filesize).Mul64(timeExtension))
+	}
+
+	// calculate the new collateral
+	newCollateral := pt.CollateralCost.Mul64(expectedNewStorage).Mul64(endHeight - pt.HostBlockHeight)
+
+	// cap collateral
+	if baseCollateral.Cmp(pt.MaxCollateral) > 0 {
+		baseCollateral = pt.MaxCollateral
+		newCollateral = types.ZeroCurrency
+	} else if baseCollateral.Add(newCollateral).Cmp(pt.MaxCollateral) > 0 {
+		newCollateral = pt.MaxCollateral.Sub(baseCollateral)
+	}
+	return basePrice, baseCollateral, newCollateral
 }
 
 // NOTE: due to a bug in the transaction validation code, calculating payouts


### PR DESCRIPTION
We ran into bugs related to determining the right amount of collateral when renewing contracts. Most notably exceeding the max collateral setting of hosts.

There were multiple reasons for that. I was able to get rid of most errors by postponing computing the collateral until after we have acquired a contract.

The other issue, which is the reason for this PR, is the fact that we used `ContractRenewalCollateral` to compute the `newCollateral` and then `CalculateHostPayouts` to create the payouts and both of these functions perform the same math but slightly different. (one uses fc.EndHeight() and the other one fc.WindowEnd` for determining the extension of the renewal).

Since we don't use rhpv2 renewals I'm not going to bother refactoring that but I'm updating rhpv3 to make sure there is no duplicate code anymore and that everything, including the capping of the `collateral` according to the host's `MaxCollateral` happens in one place.

Right now this is deployed on Arequipa and there are no more collateral errors.