### PR TITLE
Add more compact v2 encodings

### DIFF
--- a/consensus/merkle.go
+++ b/consensus/merkle.go
@@ -81,13 +81,13 @@ func chainIndexLeaf(e *types.ChainIndexElement) elementLeaf {
 
 // siacoinLeaf returns the elementLeaf for a SiacoinElement.
 func siacoinLeaf(e *types.SiacoinElement, spent bool) elementLeaf {
-	elemHash := hashAll("leaf/siacoin", e.ID, e.SiacoinOutput, e.MaturityHeight)
+	elemHash := hashAll("leaf/siacoin", e.ID, types.V2SiacoinOutput(e.SiacoinOutput), e.MaturityHeight)
 	return elementLeaf{&e.StateElement, elemHash, spent}
 }
 
 // siafundLeaf returns the elementLeaf for a SiafundElement.
 func siafundLeaf(e *types.SiafundElement, spent bool) elementLeaf {
-	elemHash := hashAll("leaf/siafund", e.ID, e.SiafundOutput, e.ClaimStart)
+	elemHash := hashAll("leaf/siafund", e.ID, types.V2SiafundOutput(e.SiafundOutput), types.V2Currency(e.ClaimStart))
 	return elementLeaf{&e.StateElement, elemHash, spent}
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -137,7 +137,7 @@ func (s State) EncodeTo(e *types.Encoder) {
 	}
 	s.Depth.EncodeTo(e)
 	s.ChildTarget.EncodeTo(e)
-	s.SiafundPool.EncodeTo(e)
+	types.V2Currency(s.SiafundPool).EncodeTo(e)
 
 	e.WriteUint64(uint64(s.OakTime))
 	s.OakTarget.EncodeTo(e)
@@ -158,7 +158,7 @@ func (s *State) DecodeFrom(d *types.Decoder) {
 	}
 	s.Depth.DecodeFrom(d)
 	s.ChildTarget.DecodeFrom(d)
-	s.SiafundPool.DecodeFrom(d)
+	(*types.V2Currency)(&s.SiafundPool).DecodeFrom(d)
 
 	s.OakTime = time.Duration(d.ReadUint64())
 	s.OakTarget.DecodeFrom(d)
@@ -284,14 +284,14 @@ func (s State) V2TransactionWeight(txn types.V2Transaction) uint64 {
 		sci.EncodeTo(e)
 	}
 	for _, sco := range txn.SiacoinOutputs {
-		sco.EncodeTo(e)
+		types.V2SiacoinOutput(sco).EncodeTo(e)
 	}
 	for _, sfi := range txn.SiafundInputs {
 		sfi.Parent.MerkleProof = nil
 		sfi.EncodeTo(e)
 	}
 	for _, sfo := range txn.SiafundOutputs {
-		sfo.EncodeTo(e)
+		types.V2SiafundOutput(sfo).EncodeTo(e)
 	}
 	for _, fc := range txn.FileContracts {
 		fc.EncodeTo(e)
@@ -414,7 +414,7 @@ func (s State) WholeSigHash(txn types.Transaction, parentID types.Hash256, pubke
 	}
 	h.E.WritePrefix(len((txn.SiacoinOutputs)))
 	for i := range txn.SiacoinOutputs {
-		txn.SiacoinOutputs[i].EncodeTo(h.E)
+		types.V1SiacoinOutput(txn.SiacoinOutputs[i]).EncodeTo(h.E)
 	}
 	h.E.WritePrefix(len((txn.FileContracts)))
 	for i := range txn.FileContracts {
@@ -435,11 +435,11 @@ func (s State) WholeSigHash(txn types.Transaction, parentID types.Hash256, pubke
 	}
 	h.E.WritePrefix(len((txn.SiafundOutputs)))
 	for i := range txn.SiafundOutputs {
-		txn.SiafundOutputs[i].EncodeTo(h.E)
+		types.V1SiafundOutput(txn.SiafundOutputs[i]).EncodeTo(h.E)
 	}
 	h.E.WritePrefix(len((txn.MinerFees)))
 	for i := range txn.MinerFees {
-		txn.MinerFees[i].EncodeTo(h.E)
+		types.V1Currency(txn.MinerFees[i]).EncodeTo(h.E)
 	}
 	h.E.WritePrefix(len((txn.ArbitraryData)))
 	for i := range txn.ArbitraryData {
@@ -469,7 +469,7 @@ func (s State) PartialSigHash(txn types.Transaction, cf types.CoveredFields) typ
 		txn.SiacoinInputs[i].EncodeTo(h.E)
 	}
 	for _, i := range cf.SiacoinOutputs {
-		txn.SiacoinOutputs[i].EncodeTo(h.E)
+		types.V1SiacoinOutput(txn.SiacoinOutputs[i]).EncodeTo(h.E)
 	}
 	for _, i := range cf.FileContracts {
 		txn.FileContracts[i].EncodeTo(h.E)
@@ -485,10 +485,10 @@ func (s State) PartialSigHash(txn types.Transaction, cf types.CoveredFields) typ
 		txn.SiafundInputs[i].EncodeTo(h.E)
 	}
 	for _, i := range cf.SiafundOutputs {
-		txn.SiafundOutputs[i].EncodeTo(h.E)
+		types.V1SiafundOutput(txn.SiafundOutputs[i]).EncodeTo(h.E)
 	}
 	for _, i := range cf.MinerFees {
-		txn.MinerFees[i].EncodeTo(h.E)
+		types.V1Currency(txn.MinerFees[i]).EncodeTo(h.E)
 	}
 	for _, i := range cf.ArbitraryData {
 		h.E.WriteBytes(txn.ArbitraryData[i])

--- a/rhp/v2/encoding.go
+++ b/rhp/v2/encoding.go
@@ -111,7 +111,7 @@ func (r *RPCFormContractAdditions) EncodeTo(e *types.Encoder) {
 	}
 	e.WritePrefix(len(r.Outputs))
 	for i := range r.Outputs {
-		r.Outputs[i].EncodeTo(e)
+		types.V1SiacoinOutput(r.Outputs[i]).EncodeTo(e)
 	}
 }
 
@@ -127,7 +127,7 @@ func (r *RPCFormContractAdditions) DecodeFrom(d *types.Decoder) {
 	}
 	r.Outputs = make([]types.SiacoinOutput, d.ReadPrefix())
 	for i := range r.Outputs {
-		r.Outputs[i].DecodeFrom(d)
+		(*types.V1SiacoinOutput)(&r.Outputs[i]).DecodeFrom(d)
 	}
 }
 
@@ -160,11 +160,11 @@ func (r *RPCRenewAndClearContractRequest) EncodeTo(e *types.Encoder) {
 	r.RenterKey.EncodeTo(e)
 	e.WritePrefix(len(r.FinalValidProofValues))
 	for i := range r.FinalValidProofValues {
-		r.FinalValidProofValues[i].EncodeTo(e)
+		types.V1Currency(r.FinalValidProofValues[i]).EncodeTo(e)
 	}
 	e.WritePrefix(len(r.FinalMissedProofValues))
 	for i := range r.FinalMissedProofValues {
-		r.FinalMissedProofValues[i].EncodeTo(e)
+		types.V1Currency(r.FinalMissedProofValues[i]).EncodeTo(e)
 	}
 }
 
@@ -177,11 +177,11 @@ func (r *RPCRenewAndClearContractRequest) DecodeFrom(d *types.Decoder) {
 	r.RenterKey.DecodeFrom(d)
 	r.FinalValidProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.FinalValidProofValues {
-		r.FinalValidProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.FinalValidProofValues[i]).DecodeFrom(d)
 	}
 	r.FinalMissedProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.FinalMissedProofValues {
-		r.FinalMissedProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.FinalMissedProofValues[i]).DecodeFrom(d)
 	}
 }
 
@@ -257,11 +257,11 @@ func (r *RPCReadRequest) EncodeTo(e *types.Encoder) {
 	e.WriteUint64(r.RevisionNumber)
 	e.WritePrefix(len(r.ValidProofValues))
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].EncodeTo(e)
+		types.V1Currency(r.ValidProofValues[i]).EncodeTo(e)
 	}
 	e.WritePrefix(len(r.MissedProofValues))
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].EncodeTo(e)
+		types.V1Currency(r.MissedProofValues[i]).EncodeTo(e)
 	}
 	e.WriteBytes(r.Signature[:])
 }
@@ -278,11 +278,11 @@ func (r *RPCReadRequest) DecodeFrom(d *types.Decoder) {
 	r.RevisionNumber = d.ReadUint64()
 	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.ValidProofValues[i]).DecodeFrom(d)
 	}
 	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.MissedProofValues[i]).DecodeFrom(d)
 	}
 	copy(r.Signature[:], d.ReadBytes())
 }
@@ -328,11 +328,11 @@ func (r *RPCSectorRootsRequest) EncodeTo(e *types.Encoder) {
 	e.WriteUint64(r.RevisionNumber)
 	e.WritePrefix(len(r.ValidProofValues))
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].EncodeTo(e)
+		types.V1Currency(r.ValidProofValues[i]).EncodeTo(e)
 	}
 	e.WritePrefix(len(r.MissedProofValues))
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].EncodeTo(e)
+		types.V1Currency(r.MissedProofValues[i]).EncodeTo(e)
 	}
 	e.WriteBytes(r.Signature[:])
 }
@@ -344,11 +344,11 @@ func (r *RPCSectorRootsRequest) DecodeFrom(d *types.Decoder) {
 	r.RevisionNumber = d.ReadUint64()
 	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.ValidProofValues[i]).DecodeFrom(d)
 	}
 	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.MissedProofValues[i]).DecodeFrom(d)
 	}
 	copy(r.Signature[:], d.ReadBytes())
 }
@@ -406,11 +406,11 @@ func (r *RPCWriteRequest) EncodeTo(e *types.Encoder) {
 	e.WriteUint64(r.RevisionNumber)
 	e.WritePrefix(len(r.ValidProofValues))
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].EncodeTo(e)
+		types.V1Currency(r.ValidProofValues[i]).EncodeTo(e)
 	}
 	e.WritePrefix(len(r.MissedProofValues))
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].EncodeTo(e)
+		types.V1Currency(r.MissedProofValues[i]).EncodeTo(e)
 	}
 }
 
@@ -427,11 +427,11 @@ func (r *RPCWriteRequest) DecodeFrom(d *types.Decoder) {
 	r.RevisionNumber = d.ReadUint64()
 	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.ValidProofValues[i]).DecodeFrom(d)
 	}
 	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.MissedProofValues[i]).DecodeFrom(d)
 	}
 }
 

--- a/rhp/v2/rhp.go
+++ b/rhp/v2/rhp.go
@@ -80,42 +80,42 @@ type HostSettings struct {
 
 // MarshalJSON encodes the HostSettings as JSON. The Address field is overridden
 // for compatibility with siad renters.
-func (s HostSettings) MarshalJSON() ([]byte, error) {
+func (hs HostSettings) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
-		"acceptingcontracts":         s.AcceptingContracts,
-		"maxdownloadbatchsize":       s.MaxDownloadBatchSize,
-		"maxduration":                s.MaxDuration,
-		"maxrevisebatchsize":         s.MaxReviseBatchSize,
-		"netaddress":                 s.NetAddress,
-		"remainingstorage":           s.RemainingStorage,
-		"sectorsize":                 s.SectorSize,
-		"totalstorage":               s.TotalStorage,
-		"unlockhash":                 strings.TrimPrefix(s.Address.String(), "addr:"), // trim the "addr:" prefix for compatibility with siad
-		"windowsize":                 s.WindowSize,
-		"collateral":                 s.Collateral,
-		"maxcollateral":              s.MaxCollateral,
-		"baserpcprice":               s.BaseRPCPrice,
-		"contractprice":              s.ContractPrice,
-		"downloadbandwidthprice":     s.DownloadBandwidthPrice,
-		"sectoraccessprice":          s.SectorAccessPrice,
-		"storageprice":               s.StoragePrice,
-		"uploadbandwidthprice":       s.UploadBandwidthPrice,
-		"ephemeralaccountexpiry":     s.EphemeralAccountExpiry,
-		"maxephemeralaccountbalance": s.MaxEphemeralAccountBalance,
-		"revisionnumber":             s.RevisionNumber,
-		"version":                    s.Version,
-		"siamuxport":                 s.SiaMuxPort,
+		"acceptingcontracts":         hs.AcceptingContracts,
+		"maxdownloadbatchsize":       hs.MaxDownloadBatchSize,
+		"maxduration":                hs.MaxDuration,
+		"maxrevisebatchsize":         hs.MaxReviseBatchSize,
+		"netaddress":                 hs.NetAddress,
+		"remainingstorage":           hs.RemainingStorage,
+		"sectorsize":                 hs.SectorSize,
+		"totalstorage":               hs.TotalStorage,
+		"unlockhash":                 strings.TrimPrefix(hs.Address.String(), "addr:"), // trim the "addr:" prefix for compatibility with siad
+		"windowsize":                 hs.WindowSize,
+		"collateral":                 hs.Collateral,
+		"maxcollateral":              hs.MaxCollateral,
+		"baserpcprice":               hs.BaseRPCPrice,
+		"contractprice":              hs.ContractPrice,
+		"downloadbandwidthprice":     hs.DownloadBandwidthPrice,
+		"sectoraccessprice":          hs.SectorAccessPrice,
+		"storageprice":               hs.StoragePrice,
+		"uploadbandwidthprice":       hs.UploadBandwidthPrice,
+		"ephemeralaccountexpiry":     hs.EphemeralAccountExpiry,
+		"maxephemeralaccountbalance": hs.MaxEphemeralAccountBalance,
+		"revisionnumber":             hs.RevisionNumber,
+		"version":                    hs.Version,
+		"siamuxport":                 hs.SiaMuxPort,
 	})
 }
 
 // SiamuxAddr is a helper which returns an address that can be used to connect
 // to the host's siamux.
-func (s HostSettings) SiamuxAddr() string {
-	host, _, err := net.SplitHostPort(s.NetAddress)
+func (hs HostSettings) SiamuxAddr() string {
+	host, _, err := net.SplitHostPort(hs.NetAddress)
 	if err != nil || host == "" {
 		return ""
 	}
-	return net.JoinHostPort(host, s.SiaMuxPort)
+	return net.JoinHostPort(host, hs.SiaMuxPort)
 }
 
 // RPC IDs

--- a/rhp/v3/encoding.go
+++ b/rhp/v3/encoding.go
@@ -118,7 +118,7 @@ func (a Account) String() string { return types.PublicKey(a).String() }
 func (r *PayByEphemeralAccountRequest) EncodeTo(e *types.Encoder) {
 	r.Account.EncodeTo(e)
 	e.WriteUint64(r.Expiry)
-	r.Amount.EncodeTo(e)
+	types.V1Currency(r.Amount).EncodeTo(e)
 	e.Write(r.Nonce[:])
 	r.Signature.EncodeTo(e)
 	e.WriteUint64(uint64(r.Priority))
@@ -128,7 +128,7 @@ func (r *PayByEphemeralAccountRequest) EncodeTo(e *types.Encoder) {
 func (r *PayByEphemeralAccountRequest) DecodeFrom(d *types.Decoder) {
 	r.Account.DecodeFrom(d)
 	r.Expiry = d.ReadUint64()
-	r.Amount.DecodeFrom(d)
+	(*types.V1Currency)(&r.Amount).DecodeFrom(d)
 	d.Read(r.Nonce[:])
 	r.Signature.DecodeFrom(d)
 	r.Priority = int64(d.ReadUint64())
@@ -140,11 +140,11 @@ func (r *PayByContractRequest) EncodeTo(e *types.Encoder) {
 	e.WriteUint64(r.RevisionNumber)
 	e.WritePrefix(len(r.ValidProofValues))
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].EncodeTo(e)
+		types.V1Currency(r.ValidProofValues[i]).EncodeTo(e)
 	}
 	e.WritePrefix(len(r.MissedProofValues))
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].EncodeTo(e)
+		types.V1Currency(r.MissedProofValues[i]).EncodeTo(e)
 	}
 	r.RefundAccount.EncodeTo(e)
 	e.WriteBytes(r.Signature[:])
@@ -156,11 +156,11 @@ func (r *PayByContractRequest) DecodeFrom(d *types.Decoder) {
 	r.RevisionNumber = d.ReadUint64()
 	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.ValidProofValues[i]).DecodeFrom(d)
 	}
 	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.MissedProofValues[i]).DecodeFrom(d)
 	}
 	r.RefundAccount.DecodeFrom(d)
 	copy(r.Signature[:], d.ReadBytes())
@@ -206,7 +206,7 @@ func (r *RPCFundAccountRequest) DecodeFrom(d *types.Decoder) {
 func (r *FundAccountReceipt) EncodeTo(e *types.Encoder) {
 	r.Host.EncodeTo(e)
 	r.Account.EncodeTo(e)
-	r.Amount.EncodeTo(e)
+	types.V1Currency(r.Amount).EncodeTo(e)
 	e.WriteTime(r.Timestamp)
 }
 
@@ -214,20 +214,20 @@ func (r *FundAccountReceipt) EncodeTo(e *types.Encoder) {
 func (r *FundAccountReceipt) DecodeFrom(d *types.Decoder) {
 	r.Host.DecodeFrom(d)
 	r.Account.DecodeFrom(d)
-	r.Amount.DecodeFrom(d)
+	(*types.V1Currency)(&r.Amount).DecodeFrom(d)
 	r.Timestamp = d.ReadTime()
 }
 
 // EncodeTo implements ProtocolObject.
 func (r *RPCFundAccountResponse) EncodeTo(e *types.Encoder) {
-	r.Balance.EncodeTo(e)
+	types.V1Currency(r.Balance).EncodeTo(e)
 	r.Receipt.EncodeTo(e)
 	r.Signature.EncodeTo(e)
 }
 
 // DecodeFrom implements ProtocolObject.
 func (r *RPCFundAccountResponse) DecodeFrom(d *types.Decoder) {
-	r.Balance.DecodeFrom(d)
+	(*types.V1Currency)(&r.Balance).DecodeFrom(d)
 	r.Receipt.DecodeFrom(d)
 	r.Signature.DecodeFrom(d)
 }
@@ -244,12 +244,12 @@ func (r *RPCAccountBalanceRequest) DecodeFrom(d *types.Decoder) {
 
 // EncodeTo implements ProtocolObject.
 func (r *RPCAccountBalanceResponse) EncodeTo(e *types.Encoder) {
-	r.Balance.EncodeTo(e)
+	types.V1Currency(r.Balance).EncodeTo(e)
 }
 
 // DecodeFrom implements ProtocolObject.
 func (r *RPCAccountBalanceResponse) DecodeFrom(d *types.Decoder) {
-	r.Balance.DecodeFrom(d)
+	(*types.V1Currency)(&r.Balance).DecodeFrom(d)
 }
 
 // EncodeTo implements ProtocolObject.
@@ -290,7 +290,7 @@ func (r *RPCExecuteProgramRequest) DecodeFrom(d *types.Decoder) {
 
 // EncodeTo implements ProtocolObject.
 func (r *RPCExecuteProgramResponse) EncodeTo(e *types.Encoder) {
-	r.AdditionalCollateral.EncodeTo(e)
+	types.V1Currency(r.AdditionalCollateral).EncodeTo(e)
 	e.WriteUint64(r.OutputLength)
 	r.NewMerkleRoot.EncodeTo(e)
 	e.WriteUint64(r.NewSize)
@@ -303,14 +303,14 @@ func (r *RPCExecuteProgramResponse) EncodeTo(e *types.Encoder) {
 		errString = r.Error.Error()
 	}
 	e.WriteString(errString)
-	r.TotalCost.EncodeTo(e)
-	r.FailureRefund.EncodeTo(e)
+	types.V1Currency(r.TotalCost).EncodeTo(e)
+	types.V1Currency(r.FailureRefund).EncodeTo(e)
 	e.Write(r.Output)
 }
 
 // DecodeFrom implements ProtocolObject.
 func (r *RPCExecuteProgramResponse) DecodeFrom(d *types.Decoder) {
-	r.AdditionalCollateral.DecodeFrom(d)
+	(*types.V1Currency)(&r.AdditionalCollateral).DecodeFrom(d)
 	r.OutputLength = d.ReadUint64()
 	r.NewMerkleRoot.DecodeFrom(d)
 	r.NewSize = d.ReadUint64()
@@ -321,8 +321,8 @@ func (r *RPCExecuteProgramResponse) DecodeFrom(d *types.Decoder) {
 	if s := d.ReadString(); s != "" {
 		r.Error = errors.New(s)
 	}
-	r.TotalCost.DecodeFrom(d)
-	r.FailureRefund.DecodeFrom(d)
+	(*types.V1Currency)(&r.TotalCost).DecodeFrom(d)
+	(*types.V1Currency)(&r.FailureRefund).DecodeFrom(d)
 	r.Output = make([]byte, r.OutputLength)
 	d.Read(r.Output)
 }
@@ -333,11 +333,11 @@ func (r *RPCFinalizeProgramRequest) EncodeTo(e *types.Encoder) {
 	e.WriteUint64(r.RevisionNumber)
 	e.WritePrefix(len(r.ValidProofValues))
 	for _, v := range r.ValidProofValues {
-		v.EncodeTo(e)
+		types.V1Currency(v).EncodeTo(e)
 	}
 	e.WritePrefix(len(r.MissedProofValues))
 	for _, v := range r.MissedProofValues {
-		v.EncodeTo(e)
+		types.V1Currency(v).EncodeTo(e)
 	}
 }
 
@@ -347,11 +347,11 @@ func (r *RPCFinalizeProgramRequest) DecodeFrom(d *types.Decoder) {
 	r.RevisionNumber = d.ReadUint64()
 	r.ValidProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.ValidProofValues {
-		r.ValidProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.ValidProofValues[i]).DecodeFrom(d)
 	}
 	r.MissedProofValues = make([]types.Currency, d.ReadPrefix())
 	for i := range r.MissedProofValues {
-		r.MissedProofValues[i].DecodeFrom(d)
+		(*types.V1Currency)(&r.MissedProofValues[i]).DecodeFrom(d)
 	}
 }
 
@@ -417,7 +417,7 @@ func (r *RPCRenewContractHostAdditions) EncodeTo(e *types.Encoder) {
 	}
 	e.WritePrefix(len(r.SiacoinOutputs))
 	for i := range r.SiacoinOutputs {
-		r.SiacoinOutputs[i].EncodeTo(e)
+		types.V1SiacoinOutput(r.SiacoinOutputs[i]).EncodeTo(e)
 	}
 	r.FinalRevisionSignature.EncodeTo(e)
 }
@@ -434,7 +434,7 @@ func (r *RPCRenewContractHostAdditions) DecodeFrom(d *types.Decoder) {
 	}
 	r.SiacoinOutputs = make([]types.SiacoinOutput, d.ReadPrefix())
 	for i := range r.SiacoinOutputs {
-		r.SiacoinOutputs[i].DecodeFrom(d)
+		(*types.V1SiacoinOutput)(&r.SiacoinOutputs[i]).DecodeFrom(d)
 	}
 	r.FinalRevisionSignature.DecodeFrom(d)
 }

--- a/rhp/v3/rhp.go
+++ b/rhp/v3/rhp.go
@@ -35,7 +35,7 @@ func (p PayByEphemeralAccountRequest) SigHash() types.Hash256 {
 	h := types.NewHasher()
 	p.Account.EncodeTo(h.E)
 	h.E.WriteUint64(p.Expiry)
-	p.Amount.EncodeTo(h.E)
+	types.V1Currency(p.Amount).EncodeTo(h.E)
 	h.E.Write(p.Nonce[:])
 	return h.Sum()
 }

--- a/types/hash.go
+++ b/types/hash.go
@@ -158,7 +158,7 @@ func blockMerkleRoot(minerPayouts []SiacoinOutput, txns []Transaction) Hash256 {
 	for _, mp := range minerPayouts {
 		h.Reset()
 		h.E.WriteUint8(leafHashPrefix)
-		mp.EncodeTo(h.E)
+		V1SiacoinOutput(mp).EncodeTo(h.E)
 		acc.AddLeaf(h.Sum())
 	}
 	for _, txn := range txns {

--- a/types/multiproof.go
+++ b/types/multiproof.go
@@ -30,11 +30,11 @@ func chainIndexLeaf(e *ChainIndexElement) elementLeaf {
 }
 
 func siacoinLeaf(e *SiacoinElement) elementLeaf {
-	return elementLeaf{&e.StateElement, hashAll("leaf/siacoin", e.ID, e.SiacoinOutput, e.MaturityHeight)}
+	return elementLeaf{&e.StateElement, hashAll("leaf/siacoin", e.ID, V2SiacoinOutput(e.SiacoinOutput), e.MaturityHeight)}
 }
 
 func siafundLeaf(e *SiafundElement) elementLeaf {
-	return elementLeaf{&e.StateElement, hashAll("leaf/siafund", e.ID, e.SiafundOutput, e.ClaimStart)}
+	return elementLeaf{&e.StateElement, hashAll("leaf/siafund", e.ID, V2SiafundOutput(e.SiafundOutput), V2Currency(e.ClaimStart))}
 }
 
 func v2FileContractLeaf(e *V2FileContractElement) elementLeaf {


### PR DESCRIPTION
The current encoding of `Currency` uses an 8-byte length prefix followed by a variable-length big-endian encoding of the integer. This is inherently wasteful, as currency values never require more than a 1-byte prefix. Variable-length encodings can also hurt performance in certain use cases, and make it harder to predict the real-world size of various encoded payloads.

This PR adds an alternative fixed-width (16-byte) little-endian encoding for `Currency`. This matches the actual struct definition of `Currency` in `core`: two `uint64`s. Surprisingly, this is not quite as efficient as simply reducing the 8-byte prefix to a 1-byte prefix; the currency values currently present in the blockchain would encode to between 11-15 bytes on average. Still, the advantages of fixed width outweigh the slightly larger size imo.

As a side effect, I also ended up changing the encoding of `SiafundOutput` to be more compact in v2.