### PR TITLE
Update revision when revising a FileContractElement that's found in the ephemeral cache

### DIFF
--- a/consensus/update.go
+++ b/consensus/update.go
@@ -370,6 +370,7 @@ func (ms *MidState) reviseFileContractElement(fce types.FileContractElement, rev
 	rev.Payout = fce.FileContract.Payout
 	if i, ok := ms.ephemeral[fce.ID]; ok {
 		ms.fces[i].FileContract = rev
+		ms.revs[ms.fces[i].ID] = &ms.fces[i]
 	} else {
 		if r, ok := ms.revs[fce.ID]; ok {
 			r.FileContract = rev
@@ -377,8 +378,8 @@ func (ms *MidState) reviseFileContractElement(fce types.FileContractElement, rev
 			// store the original
 			fce.MerkleProof = append([]types.Hash256(nil), fce.MerkleProof...)
 			ms.fces = append(ms.fces, fce)
+
 			// store the revision
-			fce.MerkleProof = append([]types.Hash256(nil), fce.MerkleProof...)
 			fce.FileContract = rev
 			ms.revs[fce.ID] = &fce
 		}


### PR DESCRIPTION
When mining a block with transactions:
- contract formation
- contract revision (broadcast)
- contract revision (broadcast)
- contract revision (broadcast)

I noticed my subscriber receives only 3 file contract elements in the ApplyUpdate, more importantly though one of those did not have a revision. I think there's a bug in reviseFileContractElement that doesn't properly update the `rev` map when encountering an `fce` we find in `ephemeral`, which I assume is a sort of cache.

