### PR TITLE
Add Test Coverage for SatisfiedPolicy and enhance SpendPolicy tests

### DIFF
--- a/types/policy_test.go
+++ b/types/policy_test.go
@@ -2,7 +2,11 @@ package types
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -327,5 +331,125 @@ func TestPolicyRoundtrip(t *testing.T) {
 	roundtrip(sp, &sp2)
 	if fmt.Sprint(sp) != fmt.Sprint(sp2) {
 		t.Fatal("satisfied policy did not survive roundtrip:", sp, sp2)
+	}
+}
+
+func TestPolicyMarshaling(t *testing.T) {
+	privateKey := GeneratePrivateKey()
+	publicKey := privateKey.PublicKey()
+	publicKeyHex := hex.EncodeToString(publicKey[:])
+
+	// Generate a unique SHA256 hash from the current Unix time in nanoseconds for PolicyTypeHash test.
+	currentTime := time.Now().UnixNano()
+	currentTimeBytes := []byte(strconv.FormatInt(currentTime, 10))
+	hash := sha256.Sum256(currentTimeBytes)
+	hashHex := hex.EncodeToString(hash[:])
+
+	tests := []struct {
+		name        string
+		input       interface{}
+		output      string
+		marshalFunc func(interface{}) ([]byte, error)
+	}{
+		{
+			name:   "MarshalText",
+			input:  SpendPolicy{Type: PolicyTypeAbove(100)},
+			output: "above(100)",
+			marshalFunc: func(v interface{}) ([]byte, error) {
+				return v.(SpendPolicy).MarshalText()
+			},
+		},
+		{
+			name:   "MarshalText with PolicyTypeAfter",
+			input:  SpendPolicy{Type: PolicyTypeAfter(time.Unix(1234567890, 0))},
+			output: "after(1234567890)",
+			marshalFunc: func(v interface{}) ([]byte, error) {
+				return v.(SpendPolicy).MarshalText()
+			},
+		},
+		{
+			name:   "MarshalText with PolicyTypePublicKey",
+			input:  SpendPolicy{Type: PolicyTypePublicKey(publicKey)},
+			output: "pk(0x" + publicKeyHex + ")",
+			marshalFunc: func(v interface{}) ([]byte, error) {
+				return v.(SpendPolicy).MarshalText()
+			},
+		},
+		{
+			name:   "MarshalText with PolicyTypeHash",
+			input:  SpendPolicy{Type: PolicyTypeHash(hash)},
+			output: "h(0x" + hashHex + ")",
+			marshalFunc: func(v interface{}) ([]byte, error) {
+				return v.(SpendPolicy).MarshalText()
+			},
+		},
+		{
+			name: "MarshalJSON",
+			input: SatisfiedPolicy{
+				Preimages: [][]byte{{0xde, 0xad, 0xbe, 0xef}, {0xba, 0xad, 0xf0, 0x0d}},
+			},
+			output:      "preimages",
+			marshalFunc: json.Marshal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := tt.marshalFunc(tt.input)
+			if err != nil {
+				t.Fatalf("Expected no error, but got %v", err)
+			}
+
+			if !bytes.Contains(data, []byte(tt.output)) {
+				t.Fatalf("Expected %v in the output, but it was not found. Got: %s", tt.output, string(data))
+			}
+		})
+	}
+}
+
+func TestPolicyUnmarshaling(t *testing.T) {
+	tests := []struct {
+		name          string
+		jsonData      string
+		expectErr     bool
+		preimage      string
+		checkPreimage bool
+	}{
+		{
+			name:      "InvalidHex",
+			jsonData:  `{"Policy": null, "Signatures": null, "Preimages": ["InvalidHex"]}`,
+			expectErr: true,
+		},
+		{
+			name:      "InvalidPolicy",
+			jsonData:  `{"Policy": "ShouldBeAnObjectOrValidType", "Signatures": null, "Preimages": []}`,
+			expectErr: true,
+		},
+		{
+			name:          "ValidPreimage",
+			jsonData:      `{"Policy": null, "Signatures": null, "Preimages": ["68656c6c6f776f726c64"]}`,
+			expectErr:     false,
+			preimage:      "helloworld",
+			checkPreimage: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sp SatisfiedPolicy
+			if err := sp.UnmarshalJSON([]byte(tt.jsonData)); (err != nil) != tt.expectErr {
+				t.Fatalf("UnmarshalJSON() error = %v, expectErr %v", err, tt.expectErr)
+			}
+
+			if tt.checkPreimage {
+				expectedPreimage, err := hex.DecodeString("68656c6c6f776f726c64")
+				if err != nil {
+					t.Fatalf("hex.DecodeString error: %v", err)
+				}
+				if !bytes.Equal(sp.Preimages[0], expectedPreimage) {
+					t.Errorf("Preimage mismatch")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
I started writing this code during the last hackathon for fun, practicing writing test cases. But I didn't finish it because I had to switch to the main task regarding consensus coverage. I felt bad for wipe out a work that had been done, so I ended up finishing the code and also making some changes to it. Initially, I was only aiming to cover the `SatisfiedPolicy` but got carried away and started covering the `PolicyTypeAbove` and `PolicyTypePublicKey`, completely overlooking the fact that you had already done this 😅 Anyway, here it is. I hope that this alternative approach and the additional scenarios will prove valuable to you 🙏