### PR TITLE
Increase sector root performance

### DIFF
--- a/internal/blake2b/blake2b_amd64.s
+++ b/internal/blake2b/blake2b_amd64.s
@@ -1643,4 +1643,6 @@ TEXT ·hashBlocksAVX2(SB), NOSPLIT, $320-24
 	VMOVDQU     Y1, 32(CX)
 	VMOVDQU     Y2, 64(CX)
 	VMOVDQU     Y3, 96(CX)
+	// Clear the upper YMM registers to avoid performance penalties
+	VZEROUPPER
 	RET

--- a/internal/blake2b/gen.go
+++ b/internal/blake2b/gen.go
@@ -230,6 +230,8 @@ func genHashBlocksAVX2() {
 		}
 	}
 
+	Comment("Clear the upper YMM registers to avoid performance penalties")
+	VZEROUPPER()
 	RET()
 }
 


### PR DESCRIPTION
Before
```
goos: linux
goarch: amd64
pkg: go.sia.tech/core/internal/blake2b
cpu: AMD EPYC 7B13 64-Core Processor                
BenchmarkBLAKE2b/SumLeaves-128           4167430               290.8 ns/op       880.38 MB/s           0 B/op          0 allocs/op
BenchmarkBLAKE2b/SumNodes-128            3793945               285.3 ns/op       897.44 MB/s           0 B/op          0 allocs/op
PASS
ok      go.sia.tech/core/internal/blake2b       4.610s
```

After
```
goos: linux
goarch: amd64
pkg: go.sia.tech/core/internal/blake2b
cpu: AMD EPYC 7B13 64-Core Processor                
BenchmarkBLAKE2b/SumLeaves-128           6697410               176.7 ns/op      1448.80 MB/s           0 B/op          0 allocs/op
BenchmarkBLAKE2b/SumNodes-128            5853004               181.6 ns/op      1409.40 MB/s           0 B/op          0 allocs/op
PASS
ok      go.sia.tech/core/internal/blake2b       4.376s
```