### PR TITLE
Avoid reallocating memory for blocks in RPCSendBlocks

### DIFF
--- a/gateway/encoding.go
+++ b/gateway/encoding.go
@@ -247,7 +247,11 @@ func (r *RPCSendBlocks) encodeResponse(e *types.Encoder) {
 	}
 }
 func (r *RPCSendBlocks) decodeResponse(d *types.Decoder) {
-	r.Blocks = make([]types.Block, d.ReadPrefix())
+	if n := d.ReadPrefix(); n <= cap(r.Blocks) {
+		r.Blocks = r.Blocks[:n]
+	} else {
+		r.Blocks = make([]types.Block, n)
+	}
 	for i := range r.Blocks {
 		(*types.V1Block)(&r.Blocks[i]).DecodeFrom(d)
 	}


### PR DESCRIPTION
(note: confirmed this fixes memory leak on my node)