### PR TITLE
Drain channel when stopping timers

### DIFF
--- a/internal/smux/stream.go
+++ b/internal/smux/stream.go
@@ -45,7 +45,14 @@ func (s *Stream) Read(b []byte) (n int, err error) {
 	var deadline <-chan time.Time
 	if d, ok := s.readDeadline.Load().(time.Time); ok && !d.IsZero() {
 		timer := time.NewTimer(time.Until(d))
-		defer timer.Stop()
+		defer func() {
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		}()
 		deadline = timer.C
 	}
 


### PR DESCRIPTION
I'm not entirely sure that we need to do it per se in these three instances but in the context of the memory leaks we're seeing I think it's good practice to drain the timer channel when stopping them.