### PR TITLE
Add SpendPolicy fuzzer

### DIFF
--- a/types/encoding.go
+++ b/types/encoding.go
@@ -1186,6 +1186,10 @@ func (sp *SatisfiedPolicy) DecodeFrom(d *Decoder) {
 			}
 		case PolicyTypeUnlockConditions:
 			for i := range p.PublicKeys {
+				if len(p.PublicKeys[i].Key) != 32 {
+					d.SetErr(fmt.Errorf("invalid public key length: %d", len(p.PublicKeys[i].Key)))
+					return
+				}
 				rec(PolicyPublicKey(*(*PublicKey)(p.PublicKeys[i].Key)))
 			}
 		default:

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -1185,12 +1185,15 @@ func (sp *SatisfiedPolicy) DecodeFrom(d *Decoder) {
 				rec(p.Of[i])
 			}
 		case PolicyTypeUnlockConditions:
-			for i := range p.PublicKeys {
-				if len(p.PublicKeys[i].Key) != 32 {
-					d.SetErr(fmt.Errorf("invalid public key length: %d", len(p.PublicKeys[i].Key)))
+			for _, uk := range p.PublicKeys {
+				if len(uk.Key) != 32 {
+					d.SetErr(fmt.Errorf("invalid public key length: %d", len(uk.Key)))
+					return
+				} else if uk.Algorithm != SpecifierEd25519 {
+					d.SetErr(fmt.Errorf("invalid specifier: %v", uk.Algorithm))
 					return
 				}
-				rec(PolicyPublicKey(*(*PublicKey)(p.PublicKeys[i].Key)))
+				rec(PolicyPublicKey(*(*PublicKey)(uk.Key)))
 			}
 		default:
 			// nothing to do

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -78,10 +78,10 @@ func FuzzSpendPolicy(f *testing.F) {
 		types.PolicyHash(types.Hash256{}),
 		types.PolicyHash(hash),
 		types.AnyoneCanSpend(),
+		types.PolicyOpaque(types.PolicyAbove(0)),
 	}
 	for _, seed := range seeds {
 		f.Add(encode(seed))
-		f.Add(encode(types.PolicyOpaque(seed)))
 	}
 
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
Fuzz decoding of SpendPolicy which is probably has the most complicated decoding logic of all the types.  I have been running for ~30 minutes and coverage has not flatlined yet.

Run with:
```
$ go test -fuzz FuzzSpendPolicy ./types
```