### PR TITLE
types: Fix (*V2Transaction).DeepCopy mutating V2StorageProof

### DIFF
--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -834,7 +834,7 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 			} else if sp.ProofIndex.ChainIndex.Height != fc.ProofHeight {
 				// see note on this field in types.StorageProof
 				return fmt.Errorf("file contract storage proof %v has ProofIndex height (%v) that does not match contract ProofHeight (%v)", i, sp.ProofIndex.ChainIndex.Height, fc.ProofHeight)
-			} else if ms.base.Elements.containsChainIndex(sp.ProofIndex) {
+			} else if !ms.base.Elements.containsChainIndex(sp.ProofIndex) {
 				return fmt.Errorf("file contract storage proof %v has invalid history proof", i)
 			}
 			leafIndex := ms.base.StorageProofLeafIndex(fc.Filesize, sp.ProofIndex.ChainIndex.ID, types.FileContractID(fcr.Parent.ID))

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -688,7 +688,7 @@ func TestValidateBlock(t *testing.T) {
 	}
 }
 
-func updateProofs(au ApplyUpdate, sces []types.SiacoinElement, sfes []types.SiafundElement, fces []types.V2FileContractElement) {
+func updateProofs(au ApplyUpdate, sces []types.SiacoinElement, sfes []types.SiafundElement, fces []types.V2FileContractElement, cies []types.ChainIndexElement) {
 	for i := range sces {
 		au.UpdateElementProof(&sces[i].StateElement)
 	}
@@ -697,6 +697,9 @@ func updateProofs(au ApplyUpdate, sces []types.SiacoinElement, sfes []types.Siaf
 	}
 	for i := range fces {
 		au.UpdateElementProof(&fces[i].StateElement)
+	}
+	for i := range cies {
+		au.UpdateElementProof(&cies[i].StateElement)
 	}
 }
 
@@ -1171,7 +1174,7 @@ func TestValidateV2Block(t *testing.T) {
 
 	cs, testAU := ApplyBlock(cs, validBlock, db.supplementTipBlock(validBlock), time.Now())
 	db.applyBlock(testAU)
-	updateProofs(testAU, sces, sfes, fces)
+	updateProofs(testAU, sces, sfes, fces, cies)
 
 	var testSces []types.SiacoinElement
 	testAU.ForEachSiacoinElement(func(sce types.SiacoinElement, spent bool) {
@@ -1209,8 +1212,8 @@ func TestValidateV2Block(t *testing.T) {
 		}
 		cs, au = ApplyBlock(cs, b, db.supplementTipBlock(validBlock), time.Now())
 		db.applyBlock(au)
-		updateProofs(au, sces, sfes, fces)
-		updateProofs(au, testSces, testSfes, testFces)
+		updateProofs(au, sces, sfes, fces, cies)
+		updateProofs(au, testSces, testSfes, testFces, nil)
 		cies = append(cies, au.ChainIndexElement())
 
 		blockID = b.ID()
@@ -1246,6 +1249,7 @@ func TestValidateV2Block(t *testing.T) {
 			Proof:      []types.Hash256{cs.StorageProofLeafHash([]byte{1})},
 		}
 	}
+
 	signTxn(cs, &b.V2.Transactions[0])
 	b.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(b.Transactions, b.V2Transactions()), b.MinerPayouts[0].Address)
 	findBlockNonce(cs, &validBlock)

--- a/types/types.go
+++ b/types/types.go
@@ -736,9 +736,11 @@ func (txn *V2Transaction) DeepCopy() V2Transaction {
 	c.FileContractResolutions = append([]V2FileContractResolution(nil), c.FileContractResolutions...)
 	for i := range c.FileContractResolutions {
 		c.FileContractResolutions[i].Parent.MerkleProof = append([]Hash256(nil), c.FileContractResolutions[i].Parent.MerkleProof...)
-		if sp, ok := c.FileContractResolutions[i].Resolution.(*V2StorageProof); ok {
+		if res, ok := c.FileContractResolutions[i].Resolution.(*V2StorageProof); ok {
+			sp := *res
 			sp.ProofIndex.MerkleProof = append([]Hash256(nil), sp.ProofIndex.MerkleProof...)
 			sp.Proof = append([]Hash256(nil), sp.Proof...)
+			c.FileContractResolutions[i].Resolution = &sp
 		}
 	}
 	c.Attestations = append([]Attestation(nil), c.Attestations...)


### PR DESCRIPTION
@n8maninger noticed a flipped conditional in `validateV2FileContracts`; after fixing it, I updated `TestValidateV2Block` to update the ChainIndexElement proofs, but the test still failed -- with `commitment hash mismatch`, which is a weird error. Further investigation revealed that `V2Block.EncodeTo` was mutating the block. Specifically, it was `nil`-ing out the `V2StorageProof` history proof, which is why this wasn't caught earlier: since the test wasn't updating the proofs in the first place, they were always `nil`, so `EncodeTo` didn't affect them. Anyway, this cascade of failures has all been fixed now :P