### PR TITLE
Change unlock conditions policy encoding to be unambiguous

### DIFF
--- a/types/policy_test.go
+++ b/types/policy_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"lukechampine.com/frand"
 )
 
 func roundtrip(from EncoderTo, to DecoderFrom) {
@@ -470,5 +472,25 @@ func TestSatisfiedPolicyUnmarshaling(t *testing.T) {
 		if len(tt.preimages) != 0 && !reflect.DeepEqual(tt.preimages, sp.Preimages) {
 			t.Error("preimage mismatch")
 		}
+	}
+}
+
+func TestPolicyTypeUnlockConditionsRoundtrip(t *testing.T) {
+	sp := SpendPolicy{PolicyTypeUnlockConditions(UnlockConditions{
+		Timelock: 0,
+		PublicKeys: []UnlockKey{
+			{
+				Algorithm: NewSpecifier("blank"),
+				Key:       frand.Bytes(40),
+			},
+		},
+		SignaturesRequired: 1,
+	})}
+	t.Log(sp.String())
+	parsed, err := ParseSpendPolicy(sp.String())
+	if err != nil {
+		t.Fatal(err)
+	} else if sp.String() != parsed.String() {
+		t.Fatalf("expected %q = %q", sp.String(), parsed.String())
 	}
 }


### PR DESCRIPTION
This changes the policy to stringify and parse the unlock key in the v1 format `specifier:hex key`. You can currently create a valid `PolicyTypeUnlockCondition` using an `UnlockKey` without an ed25519 algorithm, but can't reverse it. This doesn't cause any issues since the v2 validation checks will reject it, but it's slightly annoying that a valid serialization can't be reversed. 

also: I could be wrong, but I believe v1 treated unlock conditions with unknown key algorithms as, effectively, anyone-can-spend. I'm not sure if it was ever actually seen on-chain, but after the require height any unlock condition that used a different algorithm will no longer be spendable.

Current:
```go
sp := SpendPolicy{PolicyTypeUnlockConditions(UnlockConditions{
	Timelock: 0,
	PublicKeys: []UnlockKey{
		{
			Algorithm: NewSpecifier("blank"),
			Key:       frand.Bytes(40),
		},
	},
	SignaturesRequired: 1,
})}
sp.String() // uc(0,[0x97ef92d4c07713b7a3a0e17000e59a9ef6e27402eaef0b5c9ae5cb0da50a78dd0a04e63d0e78e60d],1)
``` 

New:
```go
sp := SpendPolicy{PolicyTypeUnlockConditions(UnlockConditions{
	Timelock: 0,
	PublicKeys: []UnlockKey{
		{
			Algorithm: NewSpecifier("blank"),
			Key:       frand.Bytes(40),
		},
	},
	SignaturesRequired: 1,
})}
sp.String() // uc(0,[blank:97ef92d4c07713b7a3a0e17000e59a9ef6e27402eaef0b5c9ae5cb0da50a78dd0a04e63d0e78e60d],1)
``` 