### PR TITLE
types: Escape non-alphanumeric Specifiers

### DIFF
--- a/gateway/encoding.go
+++ b/gateway/encoding.go
@@ -430,14 +430,14 @@ var (
 	idSendBlocks          = types.NewSpecifier("SendBlocks")
 	idSendBlk             = types.NewSpecifier("SendBlk")
 	idRelayHeader         = types.NewSpecifier("RelayHeader")
-	idRelayTransactionSet = types.NewSpecifier("RelayTransactionSet")
+	idRelayTransactionSet = types.NewSpecifier("RelayTransaction")
 	// v2
 	idSendV2Blocks          = types.NewSpecifier("SendV2Blocks")
 	idSendTransactions      = types.NewSpecifier("SendTransactions")
 	idSendCheckpoint        = types.NewSpecifier("SendCheckpoint")
 	idRelayV2Header         = types.NewSpecifier("RelayV2Header")
-	idRelayV2BlockOutline   = types.NewSpecifier("RelayV2BlockOutline")
-	idRelayV2TransactionSet = types.NewSpecifier("RelayV2TransactionSet")
+	idRelayV2BlockOutline   = types.NewSpecifier("RelayV2Outline")
+	idRelayV2TransactionSet = types.NewSpecifier("RelayV2Txns")
 )
 
 func idForObject(o Object) types.Specifier {

--- a/rhp/v2/encoding.go
+++ b/rhp/v2/encoding.go
@@ -12,6 +12,12 @@ type ProtocolObject interface {
 }
 
 // EncodeTo implements ProtocolObject.
+func (c *Challenge) EncodeTo(e *types.Encoder) { e.Write(c[:]) }
+
+// DecodeFrom implements ProtocolObject.
+func (c *Challenge) DecodeFrom(d *types.Decoder) { d.Read(c[:]) }
+
+// EncodeTo implements ProtocolObject.
 func (r *RPCError) EncodeTo(e *types.Encoder) {
 	r.Type.EncodeTo(e)
 	e.WriteBytes(r.Data)
@@ -164,7 +170,7 @@ func (r *RPCLockRequest) DecodeFrom(d *types.Decoder) {
 // EncodeTo implements ProtocolObject.
 func (r *RPCLockResponse) EncodeTo(e *types.Encoder) {
 	e.WriteBool(r.Acquired)
-	e.Write(r.NewChallenge[:])
+	r.NewChallenge.EncodeTo(e)
 	r.Revision.EncodeTo(e)
 	types.EncodeSlice(e, r.Signatures)
 }
@@ -172,7 +178,7 @@ func (r *RPCLockResponse) EncodeTo(e *types.Encoder) {
 // DecodeFrom implements ProtocolObject.
 func (r *RPCLockResponse) DecodeFrom(d *types.Decoder) {
 	r.Acquired = d.ReadBool()
-	d.Read(r.NewChallenge[:])
+	r.NewChallenge.DecodeFrom(d)
 	r.Revision.DecodeFrom(d)
 	types.DecodeSlice(d, &r.Signatures)
 }

--- a/rhp/v2/rhp.go
+++ b/rhp/v2/rhp.go
@@ -220,7 +220,7 @@ type (
 	// RPCLockResponse contains the response data for the Lock RPC.
 	RPCLockResponse struct {
 		Acquired     bool
-		NewChallenge [16]byte
+		NewChallenge Challenge
 		Revision     types.FileContractRevision
 		Signatures   []types.TransactionSignature
 	}

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -920,10 +920,7 @@ func (pk *PublicKey) DecodeFrom(d *Decoder) { d.Read(pk[:]) }
 func (s *Signature) DecodeFrom(d *Decoder) { d.Read(s[:]) }
 
 // DecodeFrom implements types.DecoderFrom.
-func (s *Specifier) DecodeFrom(d *Decoder) {
-	d.Read(s[:])
-	d.SetErr(s.validate())
-}
+func (s *Specifier) DecodeFrom(d *Decoder) { d.Read(s[:]) }
 
 // DecodeFrom implements types.DecoderFrom.
 func (uk *UnlockKey) DecodeFrom(d *Decoder) {

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -920,7 +920,10 @@ func (pk *PublicKey) DecodeFrom(d *Decoder) { d.Read(pk[:]) }
 func (s *Signature) DecodeFrom(d *Decoder) { d.Read(s[:]) }
 
 // DecodeFrom implements types.DecoderFrom.
-func (s *Specifier) DecodeFrom(d *Decoder) { d.Read(s[:]) }
+func (s *Specifier) DecodeFrom(d *Decoder) {
+	d.Read(s[:])
+	d.SetErr(s.validate())
+}
 
 // DecodeFrom implements types.DecoderFrom.
 func (uk *UnlockKey) DecodeFrom(d *Decoder) {


### PR DESCRIPTION
Specifiers were always intended to be human-readable IDs. This codifies that by escaping non-alphanumeric specifiers during marshaling. Alphanumeric specifiers are marshaled exactly the same as before.

Non-alphanumeric specifiers are fairly rare. The most common offending character is `" "`, which shows up in v1 specifiers like `"siacoin output"`. Also, an early version of the RHP used raw integers in some of its RPC IDs (e.g. `"RPCDownload\x02"`), but those RPCs have been obsolete for many years at this point.

Specifiers are primarily seen in two places: `UnlockKey` algorithms in transaction inputs, and RPC IDs in logs. The latter are developer chosen, so nothing will change there. As for the former, users can technically set the algorithm to whatever they want, but doing so exposes their SC to possible theft, so there is basically no reason to do it. Probably >99% of algorithms are `"ed25519"`, so again, no change.

I also decided to add length validation in `NewSpecifier`. While this is a little annoying, there's no question that silently truncating to 16 bytes has the potential to cause bugs. For example, because of this change, I discovered that `"RelayTransactionSet"` is actually sent over the wire as `"RelayTransaction"`! If we had added an RPC for sending a single transaction and called it `"RelayTransaction"`, those IDs would have collided.