### PR TITLE
types: Fix PolicyTypeUnlockConditions validation

### DIFF
--- a/types/policy_test.go
+++ b/types/policy_test.go
@@ -138,6 +138,16 @@ func TestPolicyVerify(t *testing.T) {
 			false,
 		},
 		{
+			"exceed threshold with keys",
+			PolicyThreshold(1, []SpendPolicy{
+				PolicyPublicKey(pk),
+				PolicyPublicKey(pk),
+			}),
+			11,
+			[]Signature{key.SignHash(sigHash), key.SignHash(sigHash)},
+			false,
+		},
+		{
 			"lower threshold, neither valid",
 			PolicyThreshold(1, []SpendPolicy{
 				PolicyOpaque(PolicyAbove(10)),
@@ -175,6 +185,15 @@ func TestPolicyVerify(t *testing.T) {
 			}},
 			1,
 			nil,
+			false,
+		},
+		{
+			"unlock conditions, superfluous signatures",
+			SpendPolicy{PolicyTypeUnlockConditions{
+				SignaturesRequired: 0,
+			}},
+			1,
+			[]Signature{key.SignHash(sigHash)},
 			false,
 		},
 		{
@@ -221,6 +240,16 @@ func TestPolicyVerify(t *testing.T) {
 			}},
 			1,
 			[]Signature{key.SignHash(sigHash)},
+			true,
+		},
+		{
+			"unlock conditions, valid with extra pubkeys",
+			SpendPolicy{PolicyTypeUnlockConditions{
+				PublicKeys:         []UnlockKey{pk.UnlockKey(), PublicKey{1, 2, 3}.UnlockKey(), pk.UnlockKey()},
+				SignaturesRequired: 2,
+			}},
+			1,
+			[]Signature{key.SignHash(sigHash), key.SignHash(sigHash)},
 			true,
 		},
 	} {


### PR DESCRIPTION
The old implementation was broken, as evidenced by the test cases I added. Specifically, we were implementing this policy in terms of `PolicyThreshold`, but `PolicyThreshold` requires you to mask any unused public keys with `PolicyOpaque`, which `PolicyTypeUnlockConditions` can't do. We also now handle algorithms other than `SpecifierEd25519` correctly. Overall, this brings validation into agreement with `consensus.validateSignatures`. We can't match its behavior exactly (because v1 transactions contain a list signatures that target specific inputs, while v2 transaction inputs carry their signatures with them), but that's fine; we just need to ensure that any `UnlockConditions` that were satisfiable in v1 are also satisfiable in v2.