### PR TITLE
consensus: Add validateSupplement

### DIFF
--- a/consensus/merkle.go
+++ b/consensus/merkle.go
@@ -199,6 +199,10 @@ func (acc *ElementAccumulator) containsSpentSiafundElement(sfe types.SiafundElem
 	return acc.containsLeaf(siafundLeaf(&sfe, true))
 }
 
+func (acc *ElementAccumulator) containsUnresolvedFileContractElement(fce types.FileContractElement) bool {
+	return acc.containsLeaf(fileContractLeaf(&fce, false))
+}
+
 func (acc *ElementAccumulator) containsUnresolvedV2FileContractElement(fce types.V2FileContractElement) bool {
 	return acc.containsLeaf(v2FileContractLeaf(&fce, false))
 }

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -46,6 +46,18 @@ type consensusDB struct {
 }
 
 func (db *consensusDB) applyBlock(au ApplyUpdate) {
+	for id, sce := range db.sces {
+		au.UpdateElementProof(&sce.StateElement)
+		db.sces[id] = sce
+	}
+	for id, sfe := range db.sfes {
+		au.UpdateElementProof(&sfe.StateElement)
+		db.sfes[id] = sfe
+	}
+	for id, fce := range db.fces {
+		au.UpdateElementProof(&fce.StateElement)
+		db.fces[id] = fce
+	}
 	au.ForEachSiacoinElement(func(sce types.SiacoinElement, created, spent bool) {
 		if spent {
 			delete(db.sces, types.SiacoinOutputID(sce.ID))


### PR DESCRIPTION
Previously, `ValidateBlock` (and by extension, `ApplyBlock`) assumed that the supplied `V1BlockSupplement` was valid. This is not entirely unreasonable, since the supplement is computed locally -- unlike the `Block` itself, it is not directly manipulable by an attacker. However, even if a local computation isn't malicious, it can still be buggy! And indeed, we recently discovered that the `consensusDB` helper in `validation_test.go` was not updating the Merkle proofs of its elements, which ultimately lead to a panic in `ApplyBlock`.

This PR adds a `validateSupplement` step to `ApplyBlock`, which ensures that all of the state elements in the supplement exist in the accumulator (and have not been spent or resolved). Note that this is different from how we handle accumulator checks in v2 transactions: in v2, we check the Merkle proofs individually (e.g. in `validateV2Siacoins`), whereas with v1 we validate all of the proofs in one place. Each strategy has its pros and cons; personally, doing accumulator checks in v1 validation functions just felt a bit out-of-place to me. Besides, there are other checks that need to be performed for the supplement, so centralizing them seemed sensible.