### PR TITLE
consensus: Add JSON methods for Updates

### DIFF
--- a/consensus/merkle.go
+++ b/consensus/merkle.go
@@ -52,17 +52,17 @@ func storageProofRoot(leafHash types.Hash256, leafIndex uint64, filesize uint64,
 // An elementLeaf represents a leaf in the ElementAccumulator Merkle tree.
 type elementLeaf struct {
 	*types.StateElement
-	ElementHash types.Hash256
-	Spent       bool
+	elementHash types.Hash256
+	spent       bool
 }
 
 // hash returns the leaf's hash, for direct use in the Merkle tree.
 func (l elementLeaf) hash() types.Hash256 {
 	buf := make([]byte, 1+32+8+1)
 	buf[0] = leafHashPrefix
-	copy(buf[1:], l.ElementHash[:])
+	copy(buf[1:], l.elementHash[:])
 	binary.LittleEndian.PutUint64(buf[33:], l.LeafIndex)
-	if l.Spent {
+	if l.spent {
 		buf[41] = 1
 	}
 	return types.HashBytes(buf)

--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -54,6 +54,15 @@ func TestApplyBlock(t *testing.T) {
 			return
 		}
 		cs, au = ApplyBlock(cs, *b, bs, db.ancestorTimestamp(b.ParentID))
+		// test update marshalling while we're at it
+		{
+			js, _ := au.MarshalJSON()
+			var au2 ApplyUpdate
+			if err = au2.UnmarshalJSON(js); err != nil {
+				panic(err)
+			}
+			au = au2
+		}
 		db.applyBlock(au)
 		return
 	}
@@ -195,6 +204,16 @@ func TestApplyBlock(t *testing.T) {
 	}
 
 	ru := RevertBlock(prev, b2, bs)
+	// test update marshalling while we're at it
+	{
+		js, _ := ru.MarshalJSON()
+		var ru2 RevertUpdate
+		if err := ru2.UnmarshalJSON(js); err != nil {
+			panic(err)
+		}
+		ru = ru2
+	}
+
 	checkRevertElements(ru, addedSCEs, spentSCEs, addedSFEs, spentSFEs)
 
 	// reverting a non-child block should trigger a panic


### PR DESCRIPTION
This enables consensus "subscription" over HTTP, which in turn allows nodes running on the same machine to share a consensus.db. See https://github.com/SiaFoundation/core/pull/180

This is an unfortunate amount of code. It could be shrunk a little by factoring out the `MidState` marshaling but... meh. It's not the end of the world.