### PR TITLE
Add missed proofs to update structs

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -18,6 +18,13 @@ import (
 )
 
 const (
+	v2ResolutionRenewal      = "renewal"
+	v2ResolutionStorageProof = "storageProof"
+	v2ResolutionFinalization = "finalization"
+	v2ResolutionExpiration   = "expiration"
+)
+
+const (
 	// MaxRevisionNumber is used to finalize a FileContract. When a contract's
 	// RevisionNumber is set to this value, no further revisions are possible.
 	MaxRevisionNumber = math.MaxUint64
@@ -1131,13 +1138,13 @@ func (res V2FileContractResolution) MarshalJSON() ([]byte, error) {
 	var typ string
 	switch res.Resolution.(type) {
 	case *V2FileContractRenewal:
-		typ = "renewal"
+		typ = v2ResolutionRenewal
 	case *V2StorageProof:
-		typ = "storageProof"
+		typ = v2ResolutionStorageProof
 	case *V2FileContractFinalization:
-		typ = "finalization"
+		typ = v2ResolutionFinalization
 	case *V2FileContractExpiration:
-		typ = "expiration"
+		typ = v2ResolutionExpiration
 	default:
 		panic(fmt.Sprintf("unhandled file contract resolution type %T", res.Resolution))
 	}
@@ -1159,13 +1166,13 @@ func (res *V2FileContractResolution) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	switch p.Type {
-	case "renewal":
+	case v2ResolutionRenewal:
 		res.Resolution = new(V2FileContractRenewal)
-	case "storageProof":
+	case v2ResolutionStorageProof:
 		res.Resolution = new(V2StorageProof)
-	case "finalization":
+	case v2ResolutionFinalization:
 		res.Resolution = new(V2FileContractFinalization)
-	case "expiration":
+	case v2ResolutionExpiration:
 		res.Resolution = new(V2FileContractExpiration)
 	default:
 		return fmt.Errorf("unknown file contract resolution type %q", p.Type)


### PR DESCRIPTION
All v1 contracts are considered `valid` in the JSON representation regardless of their resolution. Adds an additional `missed` slice.