### PR TITLE
consensus: Add (*MidState).forEachRevertedElementLeaf

### DIFF
--- a/consensus/merkle.go
+++ b/consensus/merkle.go
@@ -360,8 +360,7 @@ func (acc *ElementAccumulator) applyBlock(updated, added []elementLeaf) (eau ele
 
 // revertBlock modifies the proofs of supplied elements such that they validate
 // under acc, which must be the accumulator prior to the application of those
-// elements. All of the elements will be marked unspent. The accumulator itself
-// is not modified.
+// elements. The accumulator itself is not modified.
 func (acc *ElementAccumulator) revertBlock(updated, added []elementLeaf) (eru elementRevertUpdate) {
 	eru.updated = updateLeaves(updated)
 	eru.numLeaves = acc.NumLeaves

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -721,7 +721,7 @@ func (ts V1TransactionSupplement) siacoinElement(id types.SiacoinOutputID) (sce 
 	return
 }
 
-func (ts V1TransactionSupplement) siafundElement(id types.SiafundOutputID) (sce types.SiafundElement, ok bool) {
+func (ts V1TransactionSupplement) siafundElement(id types.SiafundOutputID) (sfe types.SiafundElement, ok bool) {
 	for _, sfe := range ts.SiafundInputs {
 		if types.SiafundOutputID(sfe.ID) == id {
 			return sfe, true
@@ -730,7 +730,7 @@ func (ts V1TransactionSupplement) siafundElement(id types.SiafundOutputID) (sce 
 	return
 }
 
-func (ts V1TransactionSupplement) fileContractElement(id types.FileContractID) (sce types.FileContractElement, ok bool) {
+func (ts V1TransactionSupplement) fileContractElement(id types.FileContractID) (fce types.FileContractElement, ok bool) {
 	for _, fce := range ts.RevisedFileContracts {
 		if types.FileContractID(fce.ID) == id {
 			return fce, true

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -680,6 +680,7 @@ func (au ApplyUpdate) ForEachTreeNode(fn func(row, col uint64, h types.Hash256))
 		row, col := uint64(0), el.LeafIndex
 		h := el.hash()
 		fn(row, col, h)
+		seen[[2]uint64{row, col}] = true
 		for i, sibling := range el.MerkleProof {
 			if el.LeafIndex&(1<<i) == 0 {
 				h = blake2b.SumPair(h, sibling)
@@ -688,10 +689,10 @@ func (au ApplyUpdate) ForEachTreeNode(fn func(row, col uint64, h types.Hash256))
 			}
 			row++
 			col >>= 1
-			fn(row, col, h)
 			if seen[[2]uint64{row, col}] {
 				return // already seen everything above this
 			}
+			fn(row, col, h)
 			seen[[2]uint64{row, col}] = true
 		}
 	})
@@ -789,6 +790,7 @@ func (ru RevertUpdate) ForEachTreeNode(fn func(row, col uint64, h types.Hash256)
 		row, col := uint64(0), el.LeafIndex
 		h := el.hash()
 		fn(row, col, h)
+		seen[[2]uint64{row, col}] = true
 		for i, sibling := range el.MerkleProof {
 			if el.LeafIndex&(1<<i) == 0 {
 				h = blake2b.SumPair(h, sibling)
@@ -797,10 +799,10 @@ func (ru RevertUpdate) ForEachTreeNode(fn func(row, col uint64, h types.Hash256)
 			}
 			row++
 			col >>= 1
-			fn(row, col, h)
 			if seen[[2]uint64{row, col}] {
 				return // already seen everything above this
 			}
+			fn(row, col, h)
 			seen[[2]uint64{row, col}] = true
 		}
 	})


### PR DESCRIPTION
When iterating over the elements in a `MidState`, we need to be careful with regard to contract revisions. When *applying* a block, we want to report the latest revision; but when *reverting*, we want to report the *earliest*. Unfortunately, this asymmetry was overlooked, leading to a rather pernicious bug: when a block containing a revision is reverted, the Merkle tree is still contains the revision, not the original contract.

It's pernicious because A) reorgs are fairly uncommon, and B) the reorg has to contain a revision, and also C) redundancy in the DB code means that the invalid hashes may be overwritten by valid ones, masking the problem. That's likely why we only discovered this bug after adding a sanity check that validates every block supplement. Sure, our consensus tests *are* a bit lacking when it comes to file contracts -- I don't think there are *any* involving both a revision and a reorg! -- but the nature of this bug makes me wonder if it would have eluded detection anyway.

If you've been running a `core` node long enough to observe a reorg, there's a decent chance your Merkle tree is (very slightly) wrong. This can *probably* be fixed by updating and then manually reverting and re-applying a lot of blocks... but resyncing from genesis is the best way to be sure your state is ok. 🙃 