### PR TITLE
consensus: Mark attestation elements as created

### DIFF
--- a/consensus/merkle.go
+++ b/consensus/merkle.go
@@ -282,7 +282,10 @@ func updateLeaves(leaves []elementLeaf) [64][]elementLeaf {
 	var recompute func(i, j uint64, leaves []elementLeaf) types.Hash256
 	recompute = func(i, j uint64, leaves []elementLeaf) types.Hash256 {
 		height := bits.TrailingZeros64(j - i) // equivalent to log2(j-i), as j-i is always a power of two
-		if len(leaves) == 1 && height == 0 {
+		if height == 0 {
+			if len(leaves) > 1 {
+				panic("consensus: multiple leaves with same accumulator index")
+			}
 			return leaves[0].hash()
 		}
 		mid := (i + j) / 2

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -448,6 +448,7 @@ func (ms *MidState) resolveV2FileContractElement(fce types.V2FileContractElement
 
 func (ms *MidState) addAttestationElement(ae types.AttestationElement) {
 	ms.aes = append(ms.aes, ae)
+	ms.created[ms.aes[len(ms.aes)-1].ID] = len(ms.aes) - 1
 }
 
 // ApplyTransaction applies a transaction to the MidState.


### PR DESCRIPTION
Attestations were being treated as "updated" instead of "created," causing various accumulator-related panics.

Fixes https://github.com/SiaFoundation/coreutils/pull/86