### PR TITLE
Fix consensus revisions

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -620,6 +620,10 @@ func (ms *MidState) siafundElement(ts V1TransactionSupplement, id types.SiafundO
 }
 
 func (ms *MidState) fileContractElement(ts V1TransactionSupplement, id types.FileContractID) (types.FileContractElement, bool) {
+	if rev, ok := ms.revs[types.Hash256(id)]; ok {
+		// TODO: Luke, double check this is valid
+		return *rev, true
+	}
 	if i, ok := ms.created[types.Hash256(id)]; ok {
 		return ms.fces[i], true
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -621,7 +621,6 @@ func (ms *MidState) siafundElement(ts V1TransactionSupplement, id types.SiafundO
 
 func (ms *MidState) fileContractElement(ts V1TransactionSupplement, id types.FileContractID) (types.FileContractElement, bool) {
 	if rev, ok := ms.revs[types.Hash256(id)]; ok {
-		// TODO: Luke, double check this is valid
 		return *rev, true
 	}
 	if i, ok := ms.created[types.Hash256(id)]; ok {

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -300,6 +300,9 @@ func TestValidateBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// clear signatures to avoid false positives
+	validBlock.Transactions[0].Signatures = nil
+
 	// tests with correct signatures
 	{
 		tests := []struct {
@@ -594,6 +597,17 @@ func TestValidateBlock(t *testing.T) {
 				},
 			},
 			{
+				"duplicate revisions in same block",
+				func(b *types.Block) {
+					txn := &b.Transactions[0]
+					newRevision := txn.FileContractRevisions[0]
+
+					b.Transactions = append(b.Transactions, types.Transaction{
+						FileContractRevisions: []types.FileContractRevision{newRevision},
+					})
+				},
+			},
+			{
 				"double-spent siacoin input",
 				func(b *types.Block) {
 					txn := &b.Transactions[0]
@@ -620,11 +634,15 @@ func TestValidateBlock(t *testing.T) {
 		for _, test := range tests {
 			corruptBlock := deepCopyBlock(validBlock)
 			test.corrupt(&corruptBlock)
-			signTxn(&corruptBlock.Transactions[0])
+			for i := range corruptBlock.Transactions {
+				signTxn(&corruptBlock.Transactions[i])
+			}
 			findBlockNonce(cs, &corruptBlock)
 
 			if err := ValidateBlock(cs, corruptBlock, db.supplementTipBlock(corruptBlock)); err == nil {
 				t.Fatalf("accepted block with %v", test.desc)
+			} else {
+				t.Log(test.desc, err)
 			}
 		}
 	}
@@ -693,6 +711,9 @@ func TestValidateBlock(t *testing.T) {
 		}
 		for _, test := range tests {
 			corruptBlock := deepCopyBlock(validBlock)
+			for i := range corruptBlock.Transactions {
+				signTxn(&corruptBlock.Transactions[i])
+			}
 			test.corrupt(&corruptBlock)
 			findBlockNonce(cs, &corruptBlock)
 

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -597,6 +597,21 @@ func TestValidateBlock(t *testing.T) {
 				},
 			},
 			{
+				"misordered revisions",
+				func(b *types.Block) {
+					newRevision := b.Transactions[0].FileContractRevisions[0]
+					newRevision.RevisionNumber = 99
+
+					b.Transactions = append(b.Transactions, types.Transaction{
+						FileContractRevisions: []types.FileContractRevision{newRevision},
+					})
+
+					// set the initial revision number to be higher than the new
+					// revision
+					b.Transactions[0].FileContractRevisions[0].RevisionNumber = 100
+				},
+			},
+			{
 				"duplicate revisions in same block",
 				func(b *types.Block) {
 					txn := &b.Transactions[0]


### PR DESCRIPTION
Fixes a validation regression in the `core` consensus allowing revisions with lower revision numbers in the same block. 