### PR TITLE
types,consensus: Make contract finalization unilateral

### DIFF
--- a/consensus/update.go
+++ b/consensus/update.go
@@ -547,7 +547,7 @@ func (ms *MidState) ApplyV2Transaction(txn types.V2Transaction) {
 		case *types.V2StorageProof:
 			renter, host = fc.RenterOutput, fc.HostOutput
 		case *types.V2FileContractFinalization:
-			renter, host = r.RenterOutput, r.HostOutput
+			renter, host = fc.RenterOutput, fc.HostOutput
 		case *types.V2FileContractExpiration:
 			renter, host = fc.RenterOutput, fc.MissedHostOutput()
 		}

--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -905,8 +905,7 @@ func TestApplyRevertBlockV2(t *testing.T) {
 				r.RenterSignature = renterPrivateKey.SignHash(cs.RenewalSigHash(*r))
 				r.HostSignature = hostPrivateKey.SignHash(cs.RenewalSigHash(*r))
 			case *types.V2FileContractFinalization:
-				r.RenterSignature = renterPrivateKey.SignHash(cs.ContractSigHash(types.V2FileContract(*r)))
-				r.HostSignature = hostPrivateKey.SignHash(cs.ContractSigHash(types.V2FileContract(*r)))
+				*r = types.V2FileContractFinalization(renterPrivateKey.SignHash(cs.ContractSigHash(txn.FileContractResolutions[i].Parent.V2FileContract)))
 			}
 		}
 	}

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -852,8 +852,7 @@ func TestValidateV2Block(t *testing.T) {
 				r.RenterSignature = renterPrivateKey.SignHash(cs.RenewalSigHash(*r))
 				r.HostSignature = hostPrivateKey.SignHash(cs.RenewalSigHash(*r))
 			case *types.V2FileContractFinalization:
-				r.RenterSignature = renterPrivateKey.SignHash(cs.ContractSigHash(types.V2FileContract(*r)))
-				r.HostSignature = hostPrivateKey.SignHash(cs.ContractSigHash(types.V2FileContract(*r)))
+				*r = types.V2FileContractFinalization(renterPrivateKey.SignHash(cs.ContractSigHash(txn.FileContractResolutions[i].Parent.V2FileContract)))
 			}
 		}
 	}
@@ -1449,25 +1448,10 @@ func TestValidateV2Block(t *testing.T) {
 				},
 			},
 			{
-				"file contract finalization that does not set maximum revision number",
+				"file contract finalization with wrong revision number",
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
-
-					resolution := types.V2FileContractFinalization(testFces[0].V2FileContract)
-					txn.FileContractResolutions = []types.V2FileContractResolution{{
-						Parent:     testFces[0],
-						Resolution: &resolution,
-					}}
-				},
-			},
-			{
-				"file contract finalization with invalid revision",
-				func(b *types.Block) {
-					txn := &b.V2.Transactions[0]
-
-					resolution := types.V2FileContractFinalization(testFces[0].V2FileContract)
-					resolution.RevisionNumber = types.MaxRevisionNumber
-					resolution.TotalCollateral = types.ZeroCurrency
+					resolution := types.V2FileContractFinalization(renterPrivateKey.SignHash(cs.ContractSigHash((testFces[0].V2FileContract))))
 					txn.FileContractResolutions = []types.V2FileContractResolution{{
 						Parent:     testFces[0],
 						Resolution: &resolution,

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -696,7 +696,7 @@ func (ren V2FileContractRenewal) EncodeTo(e *Encoder) {
 
 // EncodeTo implements types.EncoderTo.
 func (fcf V2FileContractFinalization) EncodeTo(e *Encoder) {
-	V2FileContract(fcf).EncodeTo(e)
+	Signature(fcf).EncodeTo(e)
 }
 
 // EncodeTo implements types.EncoderTo.
@@ -840,9 +840,9 @@ func (txn V2TransactionSemantics) EncodeTo(e *Encoder) {
 		// normalize (being careful not to modify the original)
 		switch res := fcr.Resolution.(type) {
 		case *V2FileContractFinalization:
-			fc := *res
-			nilSigs(&fc.RenterSignature, &fc.HostSignature)
-			fcr.Resolution = &fc
+			fcf := *res
+			nilSigs((*Signature)(&fcf))
+			fcr.Resolution = &fcf
 		case *V2FileContractRenewal:
 			renewal := *res
 			nilSigs(
@@ -1291,7 +1291,7 @@ func (ren *V2FileContractRenewal) DecodeFrom(d *Decoder) {
 
 // DecodeFrom implements types.DecoderFrom.
 func (fcf *V2FileContractFinalization) DecodeFrom(d *Decoder) {
-	(*V2FileContract)(fcf).DecodeFrom(d)
+	(*Signature)(fcf).DecodeFrom(d)
 }
 
 // DecodeFrom implements types.DecoderFrom.

--- a/types/types.go
+++ b/types/types.go
@@ -502,8 +502,8 @@ type V2FileContractRevision struct {
 // A V2FileContractResolution closes a v2 file contract's payment channel. There
 // are four ways a contract can be resolved:
 //
-// 1) The renter and host can sign a final contract revision (a "finalization"),
-// after which the contract cannot be revised further.
+// 1) The renter can finalize the contract's current state, preventing further
+// revisions and immediately creating its outputs.
 //
 // 2) The renter and host can jointly renew the contract. The old contract is
 // finalized, and a portion of its funds are "rolled over" into a new contract.
@@ -547,7 +547,7 @@ func (*V2FileContractExpiration) isV2FileContractResolution()   {}
 
 // A V2FileContractFinalization finalizes a contract, preventing further
 // revisions and immediately creating its valid outputs.
-type V2FileContractFinalization V2FileContract
+type V2FileContractFinalization Signature
 
 // A V2FileContractRenewal renews a file contract.
 type V2FileContractRenewal struct {


### PR DESCRIPTION
Previously, a `V2FileContractFinalization` was a final revision of a contract, mutually agreed upon by the renter and host. However, there are scenarios in which a renter may want to unilaterally end a contract, such as when they want to leave the network entirely. This PR changes `V2FileContractFinalization` to be a signature: specifically, the renter's signature of the current revision, with its revision number set to `MaxRevisionNumber`. This addresses multiple concerns:

- Clearly the renter must not be allowed to finalize a contract revision that lacks a valid host signature. The approach in this PR forces the renter to finalize the *existing* state of the contract, so the host is not at risk.
- The host must not be allowed to finalize contracts at all, since they would be incentivized to do so as soon as they detect data loss (to avoid forfeiting their collateral). Requiring the signature to use `MaxRevisionNumber` prevents the host from replaying a previous renter signature.
- Mutual finalization remains possible: the renter and host simply agree to submit a revision, and then the renter submits the finalization. (Currently, it's possible to do both within the same block, though not the same transaction.)