### PR TITLE
types,consensus: Add Capacity field to V2FileContract

### DIFF
--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -1084,6 +1084,7 @@ func TestApplyRevertBlockV2(t *testing.T) {
 	v1FC.Filesize = 65
 	v1FC.FileMerkleRoot = blake2b.SumPair((State{}).StorageProofLeafHash([]byte{1}), (State{}).StorageProofLeafHash([]byte{2}))
 	v2FC := types.V2FileContract{
+		Capacity:         v1FC.Filesize,
 		Filesize:         v1FC.Filesize,
 		FileMerkleRoot:   v1FC.FileMerkleRoot,
 		ProofHeight:      20,

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -725,6 +725,8 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 
 	validateContract := func(fc types.V2FileContract, renewal bool) error {
 		switch {
+		case fc.Filesize > fc.Capacity:
+			return fmt.Errorf("has filesize (%v) exceeding capacity (%v)", fc.Filesize, fc.Capacity)
 		case fc.ProofHeight < ms.base.childHeight():
 			return fmt.Errorf("has proof height (%v) that has already passed", fc.ProofHeight)
 		case fc.ExpirationHeight <= fc.ProofHeight:
@@ -747,6 +749,10 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 		curOutputSum := cur.RenterOutput.Value.Add(cur.HostOutput.Value)
 		revOutputSum := rev.RenterOutput.Value.Add(rev.HostOutput.Value)
 		switch {
+		case rev.Capacity < cur.Capacity:
+			return fmt.Errorf("decreases capacity")
+		case rev.Filesize > rev.Capacity:
+			return fmt.Errorf("has filesize (%v) exceeding capacity (%v)", rev.Filesize, rev.Capacity)
 		case cur.ProofHeight < ms.base.childHeight():
 			return fmt.Errorf("revises contract after its proof window has opened")
 		case rev.RevisionNumber <= cur.RevisionNumber:

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -863,6 +863,7 @@ func TestValidateV2Block(t *testing.T) {
 	v1GiftFC.Filesize = 65
 	v1GiftFC.FileMerkleRoot = blake2b.SumPair((State{}).StorageProofLeafHash([]byte{1}), (State{}).StorageProofLeafHash([]byte{2}))
 	v2GiftFC := types.V2FileContract{
+		Capacity:         v1GiftFC.Filesize,
 		Filesize:         v1GiftFC.Filesize,
 		FileMerkleRoot:   v1GiftFC.FileMerkleRoot,
 		ProofHeight:      20,

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -651,6 +651,7 @@ func (sfe SiafundElement) EncodeTo(e *Encoder) {
 
 // EncodeTo implements types.EncoderTo.
 func (fc V2FileContract) EncodeTo(e *Encoder) {
+	e.WriteUint64(fc.Capacity)
 	e.WriteUint64(fc.Filesize)
 	fc.FileMerkleRoot.EncodeTo(e)
 	e.WriteUint64(fc.ProofHeight)
@@ -1246,6 +1247,7 @@ func (sfe *SiafundElement) DecodeFrom(d *Decoder) {
 
 // DecodeFrom implements types.DecoderFrom.
 func (fc *V2FileContract) DecodeFrom(d *Decoder) {
+	fc.Capacity = d.ReadUint64()
 	fc.Filesize = d.ReadUint64()
 	fc.FileMerkleRoot.DecodeFrom(d)
 	fc.ProofHeight = d.ReadUint64()

--- a/types/types.go
+++ b/types/types.go
@@ -455,6 +455,7 @@ func (txn *Transaction) TotalFees() Currency {
 // or "missed" depending on whether a valid StorageProof is submitted for the
 // contract.
 type V2FileContract struct {
+	Capacity         uint64        `json:"capacity"`
 	Filesize         uint64        `json:"filesize"`
 	FileMerkleRoot   Hash256       `json:"fileMerkleRoot"`
 	ProofHeight      uint64        `json:"proofHeight"`


### PR DESCRIPTION
This field clarifies some long-standing confusion around the economics of file contracts.

When you pay for storage in a file contract, you are buying that storage for the remainder of the contract duration. This means that, even if you delete some data, you do not get a refund. Why not? Well, mainly, how do you price the refund? If you use the host's current prices, the host can manipulate them in order to minimize the refund. On the other hand, if you use the original price, now you have to keep track of what the original price was -- and not just the price, but also *how long* each sector was originally stored for. That's a *lot* metadata, and both the renter *and* host need to track it accurately, or they'll disagree on the price and stop communicating entirely.

Okay, so we can't do refunds. But we also want a way for renters to get rid of data they don't care about. One way to do that is to *overwrite* the garbage data with data we *do* care about. For this to work, though, the renter has to keep track of the garbage sectors, which is annoying. In general, we want to minimize renter-side state (to facilitate light clients), so we shift responsibilities to the host and use cryptography to make sure the host doesn't cheat. So in RHPv4, that's the plan: have the *host* keep track of the garbage sectors, so that when you upload new data, the host can reuse existing capacity instead of increasing the contract size. This is why we need a capacity field: to ensure that the host doesn't lie about how much capacity is available.