### PR TITLE
Refactor BlockHeader

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -609,7 +609,7 @@ type MidState struct {
 }
 
 func (ms *MidState) siacoinElement(ts V1TransactionSupplement, id types.SiacoinOutputID) (types.SiacoinElement, bool) {
-	if i, ok := ms.created[types.Hash256(id)]; ok {
+	if i, ok := ms.created[id]; ok {
 		return ms.sces[i], true
 	}
 	return ts.siacoinElement(id)
@@ -714,7 +714,7 @@ func (ts *V1TransactionSupplement) DecodeFrom(d *types.Decoder) {
 
 func (ts V1TransactionSupplement) siacoinElement(id types.SiacoinOutputID) (sce types.SiacoinElement, ok bool) {
 	for _, sce := range ts.SiacoinInputs {
-		if types.SiacoinOutputID(sce.ID) == id {
+		if sce.ID == id {
 			return sce, true
 		}
 	}
@@ -723,7 +723,7 @@ func (ts V1TransactionSupplement) siacoinElement(id types.SiacoinOutputID) (sce 
 
 func (ts V1TransactionSupplement) siafundElement(id types.SiafundOutputID) (sfe types.SiafundElement, ok bool) {
 	for _, sfe := range ts.SiafundInputs {
-		if types.SiafundOutputID(sfe.ID) == id {
+		if sfe.ID == id {
 			return sfe, true
 		}
 	}
@@ -732,7 +732,7 @@ func (ts V1TransactionSupplement) siafundElement(id types.SiafundOutputID) (sfe 
 
 func (ts V1TransactionSupplement) revision(id types.FileContractID) (fce types.FileContractElement, ok bool) {
 	for _, fce := range ts.RevisedFileContracts {
-		if types.FileContractID(fce.ID) == id {
+		if fce.ID == id {
 			return fce, true
 		}
 	}
@@ -741,7 +741,7 @@ func (ts V1TransactionSupplement) revision(id types.FileContractID) (fce types.F
 
 func (ts V1TransactionSupplement) storageProof(id types.FileContractID) (sps V1StorageProofSupplement, ok bool) {
 	for _, sps := range ts.StorageProofs {
-		if types.FileContractID(sps.FileContract.ID) == id {
+		if sps.FileContract.ID == id {
 			return sps, true
 		}
 	}

--- a/gateway/encoding.go
+++ b/gateway/encoding.go
@@ -53,36 +53,6 @@ func (h *Header) decodeFrom(d *types.Decoder) {
 	h.NetAddress = d.ReadString()
 }
 
-func (h *BlockHeader) encodeTo(e *types.Encoder) {
-	h.ParentID.EncodeTo(e)
-	e.WriteUint64(h.Nonce)
-	e.WriteTime(h.Timestamp)
-	h.MerkleRoot.EncodeTo(e)
-}
-
-func (h *BlockHeader) decodeFrom(d *types.Decoder) {
-	h.ParentID.DecodeFrom(d)
-	h.Nonce = d.ReadUint64()
-	h.Timestamp = d.ReadTime()
-	h.MerkleRoot.DecodeFrom(d)
-}
-
-func (h *V2BlockHeader) encodeTo(e *types.Encoder) {
-	h.Parent.EncodeTo(e)
-	e.WriteUint64(h.Nonce)
-	e.WriteTime(h.Timestamp)
-	h.TransactionsRoot.EncodeTo(e)
-	h.MinerAddress.EncodeTo(e)
-}
-
-func (h *V2BlockHeader) decodeFrom(d *types.Decoder) {
-	h.Parent.DecodeFrom(d)
-	h.Nonce = d.ReadUint64()
-	h.Timestamp = d.ReadTime()
-	h.TransactionsRoot.DecodeFrom(d)
-	h.MinerAddress.DecodeFrom(d)
-}
-
 func (ob *V2BlockOutline) encodeTo(e *types.Encoder) {
 	e.WriteUint64(ob.Height)
 	ob.ParentID.EncodeTo(e)
@@ -261,12 +231,12 @@ func (r *RPCSendBlk) maxResponseLen() int             { return 5e6 }
 
 // RPCRelayHeader relays a header.
 type RPCRelayHeader struct {
-	Header BlockHeader
+	Header types.BlockHeader
 	emptyResponse
 }
 
-func (r *RPCRelayHeader) encodeRequest(e *types.Encoder) { r.Header.encodeTo(e) }
-func (r *RPCRelayHeader) decodeRequest(d *types.Decoder) { r.Header.decodeFrom(d) }
+func (r *RPCRelayHeader) encodeRequest(e *types.Encoder) { r.Header.EncodeTo(e) }
+func (r *RPCRelayHeader) decodeRequest(d *types.Decoder) { r.Header.DecodeFrom(d) }
 func (r *RPCRelayHeader) maxRequestLen() int             { return 32 + 8 + 8 + 32 }
 
 // RPCRelayTransactionSet relays a transaction set.
@@ -364,13 +334,13 @@ func (r *RPCSendCheckpoint) maxResponseLen() int { return 5e6 + 4e3 }
 
 // RPCRelayV2Header relays a v2 block header.
 type RPCRelayV2Header struct {
-	Header V2BlockHeader
+	Header types.BlockHeader
 	emptyResponse
 }
 
-func (r *RPCRelayV2Header) encodeRequest(e *types.Encoder) { r.Header.encodeTo(e) }
-func (r *RPCRelayV2Header) decodeRequest(d *types.Decoder) { r.Header.decodeFrom(d) }
-func (r *RPCRelayV2Header) maxRequestLen() int             { return 8 + 32 + 8 + 8 + 32 + 32 }
+func (r *RPCRelayV2Header) encodeRequest(e *types.Encoder) { r.Header.EncodeTo(e) }
+func (r *RPCRelayV2Header) decodeRequest(d *types.Decoder) { r.Header.DecodeFrom(d) }
+func (r *RPCRelayV2Header) maxRequestLen() int             { return 8 + 32 + 32 + 8 }
 
 // RPCRelayV2BlockOutline relays a v2 block outline.
 type RPCRelayV2BlockOutline struct {

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -880,6 +880,14 @@ func (b V2BlockData) EncodeTo(e *Encoder) {
 	V2TransactionsMultiproof(b.Transactions).EncodeTo(e)
 }
 
+// EncodeTo implements types.EncoderTo.
+func (h BlockHeader) EncodeTo(e *Encoder) {
+	h.ParentID.EncodeTo(e)
+	e.WriteUint64(h.Nonce)
+	e.WriteTime(h.Timestamp)
+	h.Commitment.EncodeTo(e)
+}
+
 // V1Block provides v1 encoding for Block.
 type V1Block Block
 
@@ -1355,6 +1363,14 @@ func (b *V2BlockData) DecodeFrom(d *Decoder) {
 	b.Height = d.ReadUint64()
 	b.Commitment.DecodeFrom(d)
 	(*V2TransactionsMultiproof)(&b.Transactions).DecodeFrom(d)
+}
+
+// DecodeFrom implements types.DecoderFrom.
+func (h *BlockHeader) DecodeFrom(d *Decoder) {
+	h.ParentID.DecodeFrom(d)
+	h.Nonce = d.ReadUint64()
+	h.Timestamp = d.ReadTime()
+	h.Commitment.DecodeFrom(d)
 }
 
 // DecodeFrom implements types.DecoderFrom.

--- a/types/encoding_test.go
+++ b/types/encoding_test.go
@@ -11,6 +11,26 @@ import (
 	"lukechampine.com/frand"
 )
 
+func TestEncodePtrCast(t *testing.T) {
+	var buf bytes.Buffer
+	e := types.NewEncoder(&buf)
+	c := types.Siacoins(1)
+	types.EncodePtrCast[types.V1Currency](e, &c)
+	types.EncodePtrCast[types.V2Currency](e, &c)
+	types.EncodePtrCast[types.V2Currency](e, nil)
+	e.Flush()
+	var c1, c2, c3 *types.Currency
+	d := types.NewBufDecoder(buf.Bytes())
+	types.DecodePtrCast[types.V1Currency](d, &c1)
+	types.DecodePtrCast[types.V2Currency](d, &c2)
+	types.DecodePtrCast[types.V2Currency](d, &c3)
+	if err := d.Err(); err != nil {
+		t.Fatal(err)
+	} else if *c1 != c || *c2 != c || c3 != nil {
+		t.Fatal("mismatch:", c1, c2, c3)
+	}
+}
+
 func TestEncodeSlice(t *testing.T) {
 	txns := multiproofTxns(10, 10)
 	var buf bytes.Buffer


### PR DESCRIPTION
This unifies v1 and v2 block headers and promotes `BlockHeader` from `gateway` to `types`. It also changes how V2 block IDs are computed.

I had previously omitted the `ParentID` from the v2 block "header," because it is incorporated into the `Commitment` field (via the hash of the parent `consensus.State`). This left the first 32 bytes of the 80-byte hash preimage unused, so I filled them with a distinguisher string.

However, after reflecting on how headers are actually used in the Syncer, I think it's better to include the `ParentID` after all, even if it's slightly redundant and not *strictly* necessary. Here's my reasoning, in the form of a dialogue:

- 🤔 Foo: Imagine a peer sends you a v2 header, claiming that they have found the next block. You hash the header and verify that, indeed, it meets the proof-of-work target. You therefore stop mining the current block and begin mining the next one. Unbeknownst to you, this header does not attach to the old block! Now you are wasting hashrate until you detect this deception. If the header contained the `ParentID`, you could check that it matched your current block before abandoning it.
- 🤨 Bar: Including the `ParentID` doesn't prevent this class of attack, because the purported block could be invalid for other reasons that aren't detectable from the header alone. For example, it could have missing signatures. Moreover, this attack requires the attacker to expend a lot of hashrate; why wouldn't they use that hashrate to mine a valid block instead?
- 🤔 Foo: Aha, but that's where the `ParentID` is different! You *don't* need to expend a lot of hashrate mining a purposefully-invalid block; instead, you can *reuse* the header of a recently-mined block. That header will (probably) still have sufficient proof-of-work to meet the current target, so it will pass the initial validation check.
- 🤨 Bar: Okay, but one of the first checks you perform when receiving a relayed header is "have I seen this block before?" So if you try to cheat by reusing a recent block, it will simply be ignored.
- 🤔 Foo: ...fine, granted. But there's basically no downside to include the `ParentID` anyway. We weren't using that space anyway (but we need to preserve it, for miner compatibility), it's occasionally useful, and you don't need to twist your brain into knots convincing yourself that the system is still secure without it.
- 🤨 Bar: ...sure, whatever.
