### PR TITLE
types: Simplify SatisfiedPolicy encoding

### DIFF
--- a/types/multiproof_test.go
+++ b/types/multiproof_test.go
@@ -160,7 +160,7 @@ func TestBlockCompression(t *testing.T) {
 		{"4 elements", multiproofTxns(2, 2), 0.90},
 		{"10 elements", multiproofTxns(2, 5), 0.85},
 		{"25 elements", multiproofTxns(5, 5), 0.75},
-		{"100 elements", multiproofTxns(10, 10), 0.70},
+		{"100 elements", multiproofTxns(10, 10), 0.71},
 	}
 	for _, test := range tests {
 		if r := ratio(test.txns); r >= test.exp {


### PR DESCRIPTION
Previously, we used the policy itself to figure out how many signatures and preimages to expect. This saved two length prefixes (16 bytes), but it was annoying to implement, and also led to a vulnerability: `EncodeTo` panicked when called with the wrong number of signatures or preimages, but `UnmarshalJSON` did not validate these, so you could trigger a panic by causing a node to decode an invalid `SpendPolicy` as JSON and then encode it as binary.

The modal satisfied policy is 1 pubkey + 1 signature, so ~100 bytes, making this a ~16% size increase. Not insignificant, but tolerable.

Note that we don't need any additional validation: `(SpendPolicy).Verify` already checks for superfluous signatures and preimages.