### PR TITLE
Allow Foundation subsidy to be waived

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -257,22 +257,23 @@ func (s State) AncestorDepth() uint64 {
 }
 
 // FoundationSubsidy returns the Foundation subsidy output for the child block.
-// If no subsidy is due, the returned output has a value of zero.
 func (s State) FoundationSubsidy() (sco types.SiacoinOutput, exists bool) {
+	if s.FoundationPrimaryAddress == types.VoidAddress {
+		return types.SiacoinOutput{}, false
+	}
 	sco.Address = s.FoundationPrimaryAddress
-
 	subsidyPerBlock := types.Siacoins(30000)
 	blocksPerYear := uint64(365 * 24 * time.Hour / s.BlockInterval())
 	blocksPerMonth := blocksPerYear / 12
 	hardforkHeight := s.Network.HardforkFoundation.Height
 	if s.childHeight() < hardforkHeight || (s.childHeight()-hardforkHeight)%blocksPerMonth != 0 {
-		sco.Value = types.ZeroCurrency
+		return types.SiacoinOutput{}, false
 	} else if s.childHeight() == hardforkHeight {
 		sco.Value = subsidyPerBlock.Mul64(blocksPerYear)
 	} else {
 		sco.Value = subsidyPerBlock.Mul64(blocksPerMonth)
 	}
-	return sco, !sco.Value.IsZero()
+	return sco, true
 }
 
 // NonceFactor is the factor by which all block nonces must be divisible.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -343,6 +343,9 @@ func (s State) V2TransactionWeight(txn types.V2Transaction) uint64 {
 		a.EncodeTo(e)
 	}
 	e.Write(txn.ArbitraryData)
+	if txn.NewFoundationAddress != nil {
+		txn.NewFoundationAddress.EncodeTo(e)
+	}
 	e.Flush()
 	return uint64(wc.n)
 }

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -569,7 +569,9 @@ func (ms *MidState) ApplyV2Transaction(txn types.V2Transaction) {
 	}
 	if txn.NewFoundationAddress != nil {
 		ms.foundationPrimary = *txn.NewFoundationAddress
-		ms.foundationFailsafe = *txn.NewFoundationAddress
+		if *txn.NewFoundationAddress != types.VoidAddress {
+			ms.foundationFailsafe = *txn.NewFoundationAddress
+		}
 	}
 }
 

--- a/consensus/update_test.go
+++ b/consensus/update_test.go
@@ -1296,3 +1296,123 @@ func TestApplyRevertBlockV2(t *testing.T) {
 		checkUpdateElements(au, addedSCEs, spentSCEs, addedSFEs, spentSFEs)
 	}
 }
+
+func TestFoundationSubsidy(t *testing.T) {
+	key := types.GeneratePrivateKey()
+	addr := types.StandardAddress(key.PublicKey())
+	n, genesisBlock := testnet()
+	n.HardforkFoundation.Height = 1
+	n.HardforkFoundation.PrimaryAddress = addr
+	n.HardforkFoundation.FailsafeAddress = addr
+	n.HardforkV2.AllowHeight = 1
+	n.HardforkV2.RequireHeight = 1
+	n.BlockInterval = 10 * time.Hour // subsidies every 10 blocks
+	subsidyInterval := uint64(365 * 24 * time.Hour / n.BlockInterval / 12)
+	genesisBlock.Transactions = []types.Transaction{{
+		SiacoinOutputs: []types.SiacoinOutput{{
+			Address: addr,
+			Value:   types.Siacoins(1), // funds for changing address later
+		}},
+	}}
+	scoid := genesisBlock.Transactions[0].SiacoinOutputID(0)
+
+	db, cs := newConsensusDB(n, genesisBlock)
+	mineBlock := func(txns []types.V2Transaction) (subsidy types.SiacoinElement, exists bool) {
+		b := types.Block{
+			ParentID:     cs.Index.ID,
+			Timestamp:    types.CurrentTimestamp(),
+			MinerPayouts: []types.SiacoinOutput{{Address: types.VoidAddress, Value: cs.BlockReward()}},
+			V2: &types.V2BlockData{
+				Height:       cs.Index.Height + 1,
+				Commitment:   cs.Commitment(cs.TransactionsCommitment(nil, txns), types.VoidAddress),
+				Transactions: txns,
+			},
+		}
+		bs := db.supplementTipBlock(b)
+		findBlockNonce(cs, &b)
+		if err := ValidateBlock(cs, b, bs); err != nil {
+			t.Fatal(err)
+			return
+		}
+		var au ApplyUpdate
+		cs, au = ApplyBlock(cs, b, bs, db.ancestorTimestamp(b.ParentID))
+		db.applyBlock(au)
+		au.ForEachSiacoinElement(func(sce types.SiacoinElement, created, _ bool) {
+			if created && sce.SiacoinOutput.Address == addr {
+				subsidy = sce
+				exists = true
+			}
+		})
+		return
+	}
+
+	// receive initial subsidy
+	initialSubsidy, ok := mineBlock(nil)
+	if !ok {
+		t.Fatal("expected subsidy")
+	}
+
+	// mine until we receive a normal subsidy
+	for range subsidyInterval - 1 {
+		if _, ok := mineBlock(nil); ok {
+			t.Fatal("unexpected subsidy")
+		}
+	}
+	subsidy, ok := mineBlock(nil)
+	if !ok {
+		t.Fatal("expected subsidy")
+	} else if subsidy.SiacoinOutput.Value != initialSubsidy.SiacoinOutput.Value.Div64(12) {
+		t.Fatal("expected subsidy to be 1/12 of initial subsidy")
+	}
+	// disable subsidy
+	txn := types.V2Transaction{
+		SiacoinInputs: []types.V2SiacoinInput{{
+			Parent: db.sces[scoid],
+			SatisfiedPolicy: types.SatisfiedPolicy{
+				Policy: types.PolicyPublicKey(key.PublicKey()),
+			},
+		}},
+		SiacoinOutputs: []types.SiacoinOutput{{
+			Address: addr,
+			Value:   db.sces[scoid].SiacoinOutput.Value,
+		}},
+		NewFoundationAddress: &types.VoidAddress,
+	}
+	txn.SiacoinInputs[0].SatisfiedPolicy.Signatures = []types.Signature{key.SignHash(cs.InputSigHash(txn))}
+	scoid = txn.SiacoinOutputID(txn.ID(), 0)
+	mineBlock([]types.V2Transaction{txn})
+
+	// mine until we would receive another subsidy
+	for range subsidyInterval {
+		if _, ok := mineBlock(nil); ok {
+			t.Fatal("unexpected subsidy")
+		}
+	}
+
+	// re-enable subsidy
+	txn = types.V2Transaction{
+		SiacoinInputs: []types.V2SiacoinInput{{
+			Parent: db.sces[scoid],
+			SatisfiedPolicy: types.SatisfiedPolicy{
+				Policy: types.PolicyPublicKey(key.PublicKey()),
+			},
+		}},
+		SiacoinOutputs: []types.SiacoinOutput{{
+			Address: addr,
+			Value:   db.sces[scoid].SiacoinOutput.Value,
+		}},
+		NewFoundationAddress: &addr,
+	}
+	txn.SiacoinInputs[0].SatisfiedPolicy.Signatures = []types.Signature{key.SignHash(cs.InputSigHash(txn))}
+	mineBlock([]types.V2Transaction{txn})
+
+	// mine until we would receive another subsidy
+	for range subsidyInterval - 3 {
+		if _, ok := mineBlock(nil); ok {
+			t.Fatal("unexpected subsidy")
+		}
+	}
+	if _, ok := mineBlock(nil); !ok {
+		t.Fatal("expected subsidy")
+	}
+}

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -387,7 +387,7 @@ func validateArbitraryData(ms *MidState, txn types.Transaction) error {
 			// check that the transaction is signed by a current key
 			var signed bool
 			for _, sci := range txn.SiacoinInputs {
-				if uh := sci.UnlockConditions.UnlockHash(); uh != ms.base.FoundationPrimaryAddress && uh != ms.base.FoundationFailsafeAddress {
+				if uh := sci.UnlockConditions.UnlockHash(); uh != ms.base.FoundationSubsidyAddress && uh != ms.base.FoundationManagementAddress {
 					continue
 				}
 				for _, sig := range txn.Signatures {
@@ -861,7 +861,7 @@ func validateFoundationUpdate(ms *MidState, txn types.V2Transaction) error {
 		return nil
 	}
 	for _, in := range txn.SiacoinInputs {
-		if in.Parent.SiacoinOutput.Address == ms.base.FoundationFailsafeAddress {
+		if in.Parent.SiacoinOutput.Address == ms.base.FoundationManagementAddress {
 			return nil
 		}
 	}

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -861,7 +861,7 @@ func validateFoundationUpdate(ms *MidState, txn types.V2Transaction) error {
 		return nil
 	}
 	for _, in := range txn.SiacoinInputs {
-		if in.Parent.SiacoinOutput.Address == ms.base.FoundationPrimaryAddress {
+		if in.Parent.SiacoinOutput.Address == ms.base.FoundationFailsafeAddress {
 			return nil
 		}
 	}


### PR DESCRIPTION
v2 transactions have a `NewFoundationAddress` field, which, if present, updates both the primary and failsafe addresses. This PR tweaks the update logic slightly: if the new address is `types.VoidAddress`, only the primary address is updated. `(State).FoundationSubsidy` also now returns `false` if the primary address is `types.VoidAddress`. Together, these changes allow the Foundation to effectively waive the subsidy until a new, non-void primary address is set. This is preferable to receiving and then later burning the subsidy; instead, the subsidy is simply not created in the first place.

I also renamed "primary" and "failsafe" to "subsidy" and "management" to reflect the function of these addresses in v2. The "subsidy" address receives the subsidies, while the "management" address is used to update addresses. (Note that, thanks to spend policies, the old "primary" and "failsafe" can be combined into one address using a threshold policy.)

Checking for `types.VoidAddress` might seem like a bit of a hack. Alternatively, we could expand the definition of `NewFoundationAddress`. Technically, this would change the encoding of `V2Transaction`; however, AFAICT, it would not actually cause any breakage, as the field is a pointer and has never been used in the v2 testnet (hence always encoded as `false`).