### PR TITLE
Simplify V2FileContractRenewal

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -574,7 +574,6 @@ func (s State) ContractSigHash(fc types.V2FileContract) types.Hash256 {
 func (s State) RenewalSigHash(fcr types.V2FileContractRenewal) types.Hash256 {
 	nilSigs(
 		&fcr.NewContract.RenterSignature, &fcr.NewContract.HostSignature,
-		&fcr.FinalRevision.RenterSignature, &fcr.FinalRevision.HostSignature,
 		&fcr.RenterSignature, &fcr.HostSignature,
 	)
 	return hashAll("sig/filecontractrenewal", s.v2ReplayPrefix(), fcr)

--- a/consensus/update.go
+++ b/consensus/update.go
@@ -548,9 +548,7 @@ func (ms *MidState) ApplyV2Transaction(txn types.V2Transaction) {
 		var renter, host types.SiacoinOutput
 		switch r := fcr.Resolution.(type) {
 		case *types.V2FileContractRenewal:
-			renter, host = r.FinalRevision.RenterOutput, r.FinalRevision.HostOutput
-			renter.Value = renter.Value.Sub(r.RenterRollover)
-			host.Value = host.Value.Sub(r.HostRollover)
+			renter, host = r.FinalRenterOutput, r.FinalHostOutput
 			ms.addV2FileContractElement(fce.ID.V2RenewalID(), r.NewContract)
 		case *types.V2StorageProof:
 			renter, host = fc.RenterOutput, fc.HostOutput

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -799,7 +799,7 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 				return fmt.Errorf("file contract renewal %v does not finalize old contract", i)
 			} else if err := validateRevision(fcr.Parent, old, true); err != nil {
 				return fmt.Errorf("file contract renewal %v final revision %s", i, err)
-			} else if err := validateContract(renewed, true); err != nil {
+			} else if err := validateContract(renewed, false); err != nil {
 				return fmt.Errorf("file contract renewal %v initial revision %s", i, err)
 			}
 

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -690,32 +690,17 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 		return nil
 	}
 
-	validateSignatures := func(fc types.V2FileContract, renter, host types.PublicKey, renewal bool) error {
-		if renewal {
-			// The sub-contracts of a renewal must have empty signatures;
-			// otherwise they would be independently valid, i.e. the atomicity
-			// of the renewal could be violated. Consider a host who has lost or
-			// deleted their contract data; all they have to do is wait for a
-			// renter to initiate a renewal, then broadcast just the
-			// finalization of the old contract, allowing them to successfully
-			// resolve the contract without a storage proof.
-			if fc.RenterSignature != (types.Signature{}) {
-				return errors.New("has non-empty renter signature")
-			} else if fc.HostSignature != (types.Signature{}) {
-				return errors.New("has non-empty host signature")
-			}
-		} else {
-			contractHash := ms.base.ContractSigHash(fc)
-			if !renter.VerifyHash(contractHash, fc.RenterSignature) {
-				return errors.New("has invalid renter signature")
-			} else if !host.VerifyHash(contractHash, fc.HostSignature) {
-				return errors.New("has invalid host signature")
-			}
+	validateSignatures := func(fc types.V2FileContract, renter, host types.PublicKey) error {
+		contractHash := ms.base.ContractSigHash(fc)
+		if !renter.VerifyHash(contractHash, fc.RenterSignature) {
+			return errors.New("has invalid renter signature")
+		} else if !host.VerifyHash(contractHash, fc.HostSignature) {
+			return errors.New("has invalid host signature")
 		}
 		return nil
 	}
 
-	validateContract := func(fc types.V2FileContract, renewal bool) error {
+	validateContract := func(fc types.V2FileContract) error {
 		switch {
 		case fc.Filesize > fc.Capacity:
 			return fmt.Errorf("has filesize (%v) exceeding capacity (%v)", fc.Filesize, fc.Capacity)
@@ -730,10 +715,10 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 		case fc.TotalCollateral.Cmp(fc.HostOutput.Value) > 0:
 			return fmt.Errorf("has total collateral (%d H) exceeding valid host value (%d H)", fc.TotalCollateral, fc.HostOutput.Value)
 		}
-		return validateSignatures(fc, fc.RenterPublicKey, fc.HostPublicKey, renewal)
+		return validateSignatures(fc, fc.RenterPublicKey, fc.HostPublicKey)
 	}
 
-	validateRevision := func(fce types.V2FileContractElement, rev types.V2FileContract, renewal bool) error {
+	validateRevision := func(fce types.V2FileContractElement, rev types.V2FileContract) error {
 		cur := fce.V2FileContract
 		if priorRev, ok := ms.v2revs[fce.ID]; ok {
 			cur = priorRev.V2FileContract
@@ -761,11 +746,11 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 			return fmt.Errorf("leaves no time between proof height (%v) and expiration height (%v)", rev.ProofHeight, rev.ExpirationHeight)
 		}
 		// NOTE: very important that we verify with the *current* keys!
-		return validateSignatures(rev, cur.RenterPublicKey, cur.HostPublicKey, renewal)
+		return validateSignatures(rev, cur.RenterPublicKey, cur.HostPublicKey)
 	}
 
 	for i, fc := range txn.FileContracts {
-		if err := validateContract(fc, false); err != nil {
+		if err := validateContract(fc); err != nil {
 			return fmt.Errorf("file contract %v %s", i, err)
 		}
 	}
@@ -780,7 +765,7 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 			// NOTE: disallowing this means that resolutions always take
 			// precedence over revisions
 			return fmt.Errorf("file contract revision %v resolves contract", i)
-		} else if err := validateRevision(fcr.Parent, rev, false); err != nil {
+		} else if err := validateRevision(fcr.Parent, rev); err != nil {
 			return fmt.Errorf("file contract revision %v %s", i, err)
 		}
 		revised[fcr.Parent.ID] = i
@@ -794,25 +779,17 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 		switch r := fcr.Resolution.(type) {
 		case *types.V2FileContractRenewal:
 			renewal := *r
-			old, renewed := renewal.FinalRevision, renewal.NewContract
-			if old.RevisionNumber != types.MaxRevisionNumber {
-				return fmt.Errorf("file contract renewal %v does not finalize old contract", i)
-			} else if err := validateRevision(fcr.Parent, old, true); err != nil {
-				return fmt.Errorf("file contract renewal %v final revision %s", i, err)
-			} else if err := validateContract(renewed, false); err != nil {
+
+			newContractCost := renewal.NewContract.RenterOutput.Value.Add(renewal.NewContract.HostOutput.Value).Add(ms.base.V2FileContractTax(renewal.NewContract))
+			if totalRenter := renewal.FinalRenterOutput.Value.Add(renewal.RenterRollover); totalRenter != fc.RenterOutput.Value {
+				return fmt.Errorf("file contract renewal %v renter payout plus rollover (%d H) does not match old contract payout (%d H)", i, totalRenter, fc.RenterOutput.Value)
+			} else if totalHost := renewal.FinalHostOutput.Value.Add(renewal.HostRollover); totalHost != fc.HostOutput.Value {
+				return fmt.Errorf("file contract renewal %v host payout plus rollover (%d H) does not match old contract payout (%d H)", i, totalHost, fc.HostOutput.Value)
+			} else if rollover := renewal.RenterRollover.Add(renewal.HostRollover); rollover.Cmp(newContractCost) > 0 {
+				return fmt.Errorf("file contract renewal %v has rollover (%d H) exceeding new contract cost (%d H)", i, rollover, newContractCost)
+			} else if err := validateContract(renewal.NewContract); err != nil {
 				return fmt.Errorf("file contract renewal %v initial revision %s", i, err)
 			}
-
-			rollover := renewal.RenterRollover.Add(renewal.HostRollover)
-			newContractCost := renewed.RenterOutput.Value.Add(renewed.HostOutput.Value).Add(ms.base.V2FileContractTax(renewed))
-			if renewal.RenterRollover.Cmp(old.RenterOutput.Value) > 0 {
-				return fmt.Errorf("file contract renewal %v has renter rollover (%d H) exceeding old output (%d H)", i, renewal.RenterRollover, old.RenterOutput.Value)
-			} else if renewal.HostRollover.Cmp(old.HostOutput.Value) > 0 {
-				return fmt.Errorf("file contract renewal %v has host rollover (%d H) exceeding old output (%d H)", i, renewal.HostRollover, old.HostOutput.Value)
-			} else if rollover.Cmp(newContractCost) > 0 {
-				return fmt.Errorf("file contract renewal %v has rollover (%d H) exceeding new contract cost (%d H)", i, rollover, newContractCost)
-			}
-
 			renewalHash := ms.base.RenewalSigHash(renewal)
 			if !fc.RenterPublicKey.VerifyHash(renewalHash, renewal.RenterSignature) {
 				return fmt.Errorf("file contract renewal %v has invalid renter signature", i)

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -2038,6 +2038,9 @@ func TestV2RenewalResolution(t *testing.T) {
 			test.renewFn(&renewTxn)
 
 			// sign the renewal
+			newContract := &renewTxn.FileContractResolutions[0].Resolution.(*types.V2FileContractRenewal).NewContract
+			newContract.RenterSignature = pk.SignHash(cs.ContractSigHash(*newContract))
+			newContract.HostSignature = pk.SignHash(cs.ContractSigHash(*newContract))
 			sigHash := cs.RenewalSigHash(*resolution)
 			resolution.RenterSignature = pk.SignHash(sigHash)
 			resolution.HostSignature = pk.SignHash(sigHash)

--- a/types/encoding.go
+++ b/types/encoding.go
@@ -703,10 +703,11 @@ func (rev V2FileContractRevision) EncodeTo(e *Encoder) {
 
 // EncodeTo implements types.EncoderTo.
 func (ren V2FileContractRenewal) EncodeTo(e *Encoder) {
-	ren.FinalRevision.EncodeTo(e)
-	ren.NewContract.EncodeTo(e)
+	V2SiacoinOutput(ren.FinalRenterOutput).EncodeTo(e)
+	V2SiacoinOutput(ren.FinalHostOutput).EncodeTo(e)
 	V2Currency(ren.RenterRollover).EncodeTo(e)
 	V2Currency(ren.HostRollover).EncodeTo(e)
+	ren.NewContract.EncodeTo(e)
 	ren.RenterSignature.EncodeTo(e)
 	ren.HostSignature.EncodeTo(e)
 }
@@ -853,7 +854,6 @@ func (txn V2TransactionSemantics) EncodeTo(e *Encoder) {
 			renewal := *res
 			nilSigs(
 				&renewal.NewContract.RenterSignature, &renewal.NewContract.HostSignature,
-				&renewal.FinalRevision.RenterSignature, &renewal.FinalRevision.HostSignature,
 				&renewal.RenterSignature, &renewal.HostSignature,
 			)
 			fcr.Resolution = &renewal
@@ -1264,10 +1264,11 @@ func (rev *V2FileContractRevision) DecodeFrom(d *Decoder) {
 
 // DecodeFrom implements types.DecoderFrom.
 func (ren *V2FileContractRenewal) DecodeFrom(d *Decoder) {
-	ren.FinalRevision.DecodeFrom(d)
-	ren.NewContract.DecodeFrom(d)
+	(*V2SiacoinOutput)(&ren.FinalRenterOutput).DecodeFrom(d)
+	(*V2SiacoinOutput)(&ren.FinalHostOutput).DecodeFrom(d)
 	(*V2Currency)(&ren.RenterRollover).DecodeFrom(d)
 	(*V2Currency)(&ren.HostRollover).DecodeFrom(d)
+	ren.NewContract.DecodeFrom(d)
 	ren.RenterSignature.DecodeFrom(d)
 	ren.HostSignature.DecodeFrom(d)
 }

--- a/types/types.go
+++ b/types/types.go
@@ -555,10 +555,11 @@ func (*V2FileContractExpiration) isV2FileContractResolution() {}
 
 // A V2FileContractRenewal renews a file contract.
 type V2FileContractRenewal struct {
-	FinalRevision  V2FileContract `json:"finalRevision"`
-	NewContract    V2FileContract `json:"newContract"`
-	RenterRollover Currency       `json:"renterRollover"`
-	HostRollover   Currency       `json:"hostRollover"`
+	FinalRenterOutput SiacoinOutput  `json:"finalRenterOutput"`
+	FinalHostOutput   SiacoinOutput  `json:"finalHostOutput"`
+	RenterRollover    Currency       `json:"renterRollover"`
+	HostRollover      Currency       `json:"hostRollover"`
+	NewContract       V2FileContract `json:"newContract"`
 
 	// signatures cover above fields
 	RenterSignature Signature `json:"renterSignature"`

--- a/types/types.go
+++ b/types/types.go
@@ -516,25 +516,19 @@ type V2FileContractRevision struct {
 }
 
 // A V2FileContractResolution closes a v2 file contract's payment channel. There
-// are four ways a contract can be resolved:
+// are three ways a contract can be resolved:
 //
-// 1) The renter can finalize the contract's current state, preventing further
-// revisions and immediately creating its outputs.
-//
-// 2) The renter and host can jointly renew the contract. The old contract is
+// 1) The renter and host can jointly renew the contract. The old contract is
 // finalized, and a portion of its funds are "rolled over" into a new contract.
+// Renewals must be submitted prior to the contract's ProofHeight.
 //
-// 3) The host can submit a storage proof, asserting that it has faithfully
-// stored the contract data for the agreed-upon duration. Typically, a storage
-// proof is only required if the renter is unable or unwilling to sign a
-// renewal. A storage proof can only be submitted after the contract's
-// ProofHeight; this allows the renter (or host) to broadcast the
-// latest contract revision prior to the proof.
+// 2) If the renter is unwilling or unable to sign a renewal, the host can
+// submit a storage proof, asserting that it has faithfully stored the contract
+// data for the agreed-upon duration. Storage proofs must be submitted after the
+// contract's ProofHeight and prior to its ExpirationHeight.
 //
-// 4) Lastly, anyone can submit a contract expiration. An expiration can only
-// be submitted after the contract's ExpirationHeight; this gives the host a
-// reasonable window of time after the ProofHeight in which to submit a storage
-// proof.
+// 3) Lastly, anyone can submit a contract expiration. An expiration can only be
+// submitted after the contract's ExpirationHeight.
 //
 // Once a contract has been resolved, it cannot be altered or resolved again.
 // When a contract is resolved, its RenterOutput and HostOutput are created


### PR DESCRIPTION
The tradeoff is that resolution transactions can't contain other outputs. That doesn't seem too restrictive to me, but maybe I'm forgetting a use case that requires it?

I also noticed that a renewal's `FinalRevision` wasn't being applied to the accumulator that way; instead, the accumulator would contain the most recent revision of the contract. Not a huge deal, just felt inconsistent.