### PR TITLE
Fix renewal payout validation

### DIFF
--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -1926,6 +1926,28 @@ func TestV2RenewalResolution(t *testing.T) {
 			errString: "invalid host signature",
 		},
 		{
+			desc: "invalid renewal - different host key",
+			renewFn: func(txn *types.V2Transaction) {
+				renewal := txn.FileContractResolutions[0].Resolution.(*types.V2FileContractRenewal)
+				sk := types.GeneratePrivateKey()
+				renewal.NewContract.HostPublicKey = sk.PublicKey()
+				contractSigHash := cs.ContractSigHash(renewal.NewContract)
+				renewal.NewContract.HostSignature = sk.SignHash(contractSigHash)
+			},
+			errString: "changes host public key",
+		},
+		{
+			desc: "invalid renewal - different renter key",
+			renewFn: func(txn *types.V2Transaction) {
+				renewal := txn.FileContractResolutions[0].Resolution.(*types.V2FileContractRenewal)
+				sk := types.GeneratePrivateKey()
+				renewal.NewContract.RenterPublicKey = sk.PublicKey()
+				contractSigHash := cs.ContractSigHash(renewal.NewContract)
+				renewal.NewContract.RenterSignature = sk.SignHash(contractSigHash)
+			},
+			errString: "changes renter public key",
+		},
+		{
 			desc: "invalid renewal - not enough host funds",
 			renewFn: func(txn *types.V2Transaction) {
 				renewal := txn.FileContractResolutions[0].Resolution.(*types.V2FileContractRenewal)

--- a/rhp/v4/encoding.go
+++ b/rhp/v4/encoding.go
@@ -263,10 +263,12 @@ func (r *RPCRenewContractResponse) maxLen() int {
 
 func (r *RPCRenewContractSecondResponse) encodeTo(e *types.Encoder) {
 	r.RenterRenewalSignature.EncodeTo(e)
+	r.RenterContractSignature.EncodeTo(e)
 	types.EncodeSlice(e, r.RenterSatisfiedPolicies)
 }
 func (r *RPCRenewContractSecondResponse) decodeFrom(d *types.Decoder) {
 	r.RenterRenewalSignature.DecodeFrom(d)
+	r.RenterContractSignature.DecodeFrom(d)
 	types.DecodeSlice(d, &r.RenterSatisfiedPolicies)
 }
 func (r *RPCRenewContractSecondResponse) maxLen() int {
@@ -331,10 +333,12 @@ func (r *RPCRefreshContractResponse) maxLen() int {
 
 func (r *RPCRefreshContractSecondResponse) encodeTo(e *types.Encoder) {
 	r.RenterRenewalSignature.EncodeTo(e)
+	r.RenterContractSignature.EncodeTo(e)
 	types.EncodeSlice(e, r.RenterSatisfiedPolicies)
 }
 func (r *RPCRefreshContractSecondResponse) decodeFrom(d *types.Decoder) {
 	r.RenterRenewalSignature.DecodeFrom(d)
+	r.RenterContractSignature.DecodeFrom(d)
 	types.DecodeSlice(d, &r.RenterSatisfiedPolicies)
 }
 func (r *RPCRefreshContractSecondResponse) maxLen() int {

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -310,6 +310,7 @@ type (
 	// RPCRefreshContractSecondResponse implements Object.
 	RPCRefreshContractSecondResponse struct {
 		RenterRenewalSignature  types.Signature         `json:"renterRenewalSignature"`
+		RenterContractSignature types.Signature         `json:"renterContractSignature"`
 		RenterSatisfiedPolicies []types.SatisfiedPolicy `json:"renterSatisfiedPolicies"`
 	}
 	// RPCRefreshContractThirdResponse implements Object.
@@ -344,6 +345,7 @@ type (
 	// RPCRenewContractSecondResponse implements Object.
 	RPCRenewContractSecondResponse struct {
 		RenterRenewalSignature  types.Signature         `json:"renterRenewalSignature"`
+		RenterContractSignature types.Signature         `json:"renterContractSignature"`
 		RenterSatisfiedPolicies []types.SatisfiedPolicy `json:"renterSatisfiedPolicies"`
 	}
 	// RPCRenewContractThirdResponse implements Object.


### PR DESCRIPTION
Did not notice this until after trying to update coreutils with #238.  The new renewal validation logic was checking the individual payout values against the parent file contract element. This does not account for the payouts changing in an unbroadcast revision. This changes the logic to check that the sum of the outputs is equal to the sum of the parent outputs. Also adds some additional validation tests.