### PR TITLE
Fix account json

### DIFF
--- a/.changeset/fix_account_json_encoding.md
+++ b/.changeset/fix_account_json_encoding.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix account JSON encoding

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -178,10 +178,10 @@ type HostSettings struct {
 type Account types.PublicKey
 
 // String implements fmt.Stringer.
-func (a Account) String() string { return fmt.Sprintf("acct:%x", a[:]) }
+func (a Account) String() string { return hex.EncodeToString(a[:]) }
 
 // MarshalText implements encoding.TextMarshaler.
-func (a Account) MarshalText() []byte { return []byte(a.String()) }
+func (a Account) MarshalText() ([]byte, error) { return []byte(a.String()), nil }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
 func (a *Account) UnmarshalText(b []byte) error {


### PR DESCRIPTION
Fixes the implementation of `encoding.TextMarshaler` on the rhp4.Account type. Will change the JSON encoding of an account from an array to a string.

Fixes an issue raised in https://github.com/SiaFoundation/web/pull/895