### PR TITLE
Fix panic when validating v2 transactions

### DIFF
--- a/.changeset/fixed_a_panic_when_unmarshalling_unknown_spend_policy_types.md
+++ b/.changeset/fixed_a_panic_when_unmarshalling_unknown_spend_policy_types.md
@@ -1,5 +1,7 @@
 ---
-default: patch
+default: major
 ---
 
 # Fixed a panic when unmarshalling unknown spend policy types
+
+An error will now be returned when trying to encode a transaction with an unset `SpendPolicy`

--- a/.changeset/fixed_a_panic_when_unmarshalling_unknown_spend_policy_types.md
+++ b/.changeset/fixed_a_panic_when_unmarshalling_unknown_spend_policy_types.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed a panic when unmarshalling unknown spend policy types

--- a/types/policy.go
+++ b/types/policy.go
@@ -496,6 +496,8 @@ func (p *SpendPolicy) UnmarshalJSON(b []byte) (err error) {
 		var pt PolicyTypeUnlockConditions
 		err = json.Unmarshal(v.Policy, (*UnlockConditions)(&pt))
 		p.Type = pt
+	default:
+		err = fmt.Errorf("unknown policy type %q", v.Type)
 	}
 	return
 }

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"strings"
 	"testing"
-	"time"
 
 	"lukechampine.com/frand"
 )
@@ -810,7 +809,7 @@ func TestV2TransactionJSONMarshalling(t *testing.T) {
 					},
 				},
 				SatisfiedPolicy: SatisfiedPolicy{
-					Policy: PolicyAfter(time.Now()),
+					Policy: AnyoneCanSpend(),
 				},
 			},
 		},

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"lukechampine.com/frand"
 )
@@ -807,6 +808,9 @@ func TestV2TransactionJSONMarshalling(t *testing.T) {
 					StateElement: StateElement{
 						LeafIndex: frand.Uint64n(math.MaxUint64),
 					},
+				},
+				SatisfiedPolicy: SatisfiedPolicy{
+					Policy: PolicyAfter(time.Now()),
 				},
 			},
 		},


### PR DESCRIPTION
Fixes a panic in `AddV2PoolTransactions` when validating v2 transactions with nil spend policies. Uses the same strategy as currency overflows to validate once and assumes it is valid afterward. `AddV2PoolTransactions` should be able to handle unvalidated input without panicking.

```
NFO    http: panic serving [::1]:60723: unhandled policy type <nil>
goroutine 713398 [running]:
net/http.(*conn).serve.func1()
        /opt/homebrew/opt/go/libexec/src/net/http/server.go:1947 +0xb0
panic({0x103d2e900?, 0x140004bfd00?})
        /opt/homebrew/opt/go/libexec/src/runtime/panic.go:785 +0x124
go.sia.tech/core/types.SpendPolicy.encodePolicy({{0x0?, 0x0?}}, 0x1?)
        /Users/alexfreska/go/pkg/mod/go.sia.tech/core@v0.9.1/types/encoding.go:604 +0x3a0
go.sia.tech/core/types.SpendPolicy.EncodeTo({{0x0?, 0x0?}}, 0x140005f8488)
        /Users/alexfreska/go/pkg/mod/go.sia.tech/core@v0.9.1/types/encoding.go:612 +0x5c
go.sia.tech/core/types.SatisfiedPolicy.EncodeTo({{{0x0, 0x0}}, {0x0, 0x0, 0x0}, {0x0, 0x0, 0x0}}, 0x140005f8488)
        /Users/alexfreska/go/pkg/mod/go.sia.tech/core@v0.9.1/types/encoding.go:617 +0x4c
go.sia.tech/core/types.V2SiacoinInput.EncodeTo({{{0x5a, 0xe0, 0xf7, 0xba, 0xe3, 0xb, 0xea, 0xff, 0x82, 0x9a, ...}, ...}, ...}, ...)
        /Users/alexfreska/go/pkg/mod/go.sia.tech/core@v0.9.1/types/encoding.go:633 +0x70
go.sia.tech/core/consensus.State.V2TransactionWeight({0x1400050c000, {0x262, {0xac, 0xf5, 0x34, 0xc8, 0xbd, 0x6d, 0x7a, 0x8e, ...}}, ...}, ...)
        /Users/alexfreska/go/pkg/mod/go.sia.tech/core@v0.9.1/consensus/state.go:314 +0xe0
go.sia.tech/core/consensus.ValidateV2Transaction(_, {{0x140001f6840, 0x1, 0x1}, {0x1400021e660, 0x2, 0x2}, {0x0, 0x0, 0x0}, ...})
        /Users/alexfreska/go/pkg/mod/go.sia.tech/core@v0.9.1/consensus/validation.go:866 +0xf4
go.sia.tech/coreutils/chain.(*Manager).checkTxnSet(0x14000134c08, {0x0, 0x0, 0x41e675be1ab4638c?}, {0x140005c9680, 0x1, 0x8e7a6dbdc834f5ac?})
        /Users/alexfreska/go/pkg/mod/go.sia.tech/coreutils@v0.10.2-0.20250124134251-3a96ba4fb39c/chain/manager.go:1068 +0x8f8
go.sia.tech/coreutils/chain.(*Manager).AddV2PoolTransactions(0x14000134c08, {0x262, {0xac, 0xf5, 0x34, 0xc8, 0xbd, 0x6d, 0x7a, 0x8e, ...}}, ...)
        /Users/alexfreska/go/pkg/mod/go.sia.tech/coreutils@v0.10.2-0.20250124134251-3a96ba4fb39c/chain/manager.go:1250 +0x2fc
go.sia.tech/walletd/api.(*server).txpoolBroadcastHandler(0x140005c8000, {{0x103e90fe0, 0x14000484ee0}, 0x140005ca640, {0x0, 0x0, 0x0}})
        /Users/alexfreska/go/pkg/mod/go.sia.tech/walletd@v0.9.0-beta.1.0.20250116183850-24b3faed5183/api/server.go:302 +0x194
go.sia.tech/walletd/api.NewServer.NewServer.func3.func16({{0x103e90fe0, 0x14000484ee0}, 0x140005ca640, {0x0, 0x0, 0x0}})
```