### PR TITLE
Consensus diffs

### DIFF
--- a/.changeset/consensus_diffs.md
+++ b/.changeset/consensus_diffs.md
@@ -1,0 +1,11 @@
+---
+default: major
+---
+
+# Consensus diffs
+
+#270 by @lukechampine
+
+This replaces the `ForEach` update API with slices of "diffs" -- new types wrapping the various element types. This was originally intended as an ergonomics improvement (since it's annoying to e.g. break out of a `ForEach` callback), but it ended up significantly simplifying most `MidState`-related code: it consolidated the interrelated maps within `MidState`, and enabled a much saner rewrite of the update JSON types.
+
+I originally left the `ForEach` methods in place (with a `// Deprecated` warning), but later removed them entirely; we're going to update all the callsites in `coreutils` anyway, so there's little reason to keep them around. (`ForEachTreeNode` remains, though, since it's used by `explored`.)

--- a/consensus/application.go
+++ b/consensus/application.go
@@ -735,46 +735,6 @@ func (au ApplyUpdate) UpdateElementProof(e *types.StateElement) {
 	au.eau.updateElementProof(e)
 }
 
-// ForEachSiacoinElement calls fn on each siacoin element related to the applied
-// block.
-//
-// Deprecated: Use SiacoinElements instead.
-func (au ApplyUpdate) ForEachSiacoinElement(fn func(sce types.SiacoinElement, created, spent bool)) {
-	for _, sce := range au.sces {
-		fn(sce.SiacoinElement, sce.Created, sce.Spent)
-	}
-}
-
-// ForEachSiafundElement calls fn on each siafund element related to the applied
-// block.
-//
-// Deprecated: Use SiafundElements instead.
-func (au ApplyUpdate) ForEachSiafundElement(fn func(sfe types.SiafundElement, created, spent bool)) {
-	for _, sfe := range au.sfes {
-		fn(sfe.SiafundElement, sfe.Created, sfe.Spent)
-	}
-}
-
-// ForEachFileContractElement calls fn on each file contract element related to
-// the applied block.
-//
-// Deprecated: Use FileContractElements instead.
-func (au ApplyUpdate) ForEachFileContractElement(fn func(fce types.FileContractElement, created bool, rev *types.FileContractElement, resolved, valid bool)) {
-	for _, fce := range au.fces {
-		fn(fce.FileContractElement, fce.Created, fce.Revision, fce.Resolved, fce.Valid)
-	}
-}
-
-// ForEachV2FileContractElement calls fn on each v2 file contract element
-// related to the applied block.
-//
-// Deprecated: Use V2FileContractElements instead.
-func (au ApplyUpdate) ForEachV2FileContractElement(fn func(fce types.V2FileContractElement, created bool, rev *types.V2FileContractElement, res types.V2FileContractResolutionType)) {
-	for _, fce := range au.v2fces {
-		fn(fce.V2FileContractElement, fce.Created, fce.Revision, fce.Resolution)
-	}
-}
-
 // ForEachTreeNode calls fn on each node in the accumulator affected by au.
 func (au ApplyUpdate) ForEachTreeNode(fn func(row, col uint64, h types.Hash256)) {
 	seen := make(map[[2]uint64]bool)
@@ -869,46 +829,6 @@ func (ru RevertUpdate) V2FileContractElements() []UpdatedV2FileContractElement {
 // up-to-date; if it is not, UpdateElementProof may panic.
 func (ru RevertUpdate) UpdateElementProof(e *types.StateElement) {
 	ru.eru.updateElementProof(e)
-}
-
-// ForEachSiacoinElement calls fn on each siacoin element related to the reverted
-// block.
-//
-// Deprecated: Use SiacoinElements instead.
-func (ru RevertUpdate) ForEachSiacoinElement(fn func(sce types.SiacoinElement, created, spent bool)) {
-	for _, sce := range ru.sces {
-		fn(sce.SiacoinElement, sce.Created, sce.Spent)
-	}
-}
-
-// ForEachSiafundElement calls fn on each siafund element related to the
-// reverted block.
-//
-// Deprecated: Use SiafundElements instead.
-func (ru RevertUpdate) ForEachSiafundElement(fn func(sfe types.SiafundElement, created, spent bool)) {
-	for _, sfe := range ru.sfes {
-		fn(sfe.SiafundElement, sfe.Created, sfe.Spent)
-	}
-}
-
-// ForEachFileContractElement calls fn on each file contract element related to
-// the reverted block.
-//
-// Deprecated: Use FileContractElements instead.
-func (ru RevertUpdate) ForEachFileContractElement(fn func(fce types.FileContractElement, created bool, rev *types.FileContractElement, resolved, valid bool)) {
-	for _, fce := range ru.fces {
-		fn(fce.FileContractElement, fce.Created, fce.Revision, fce.Resolved, fce.Valid)
-	}
-}
-
-// ForEachV2FileContractElement calls fn on each v2 file contract element
-// related to the reverted block.
-//
-// Deprecated: Use V2FileContractElements instead.
-func (ru RevertUpdate) ForEachV2FileContractElement(fn func(fce types.V2FileContractElement, created bool, rev *types.V2FileContractElement, res types.V2FileContractResolutionType)) {
-	for _, fce := range ru.v2fces {
-		fn(fce.V2FileContractElement, fce.Created, fce.Revision, fce.Resolution)
-	}
 }
 
 // ForEachTreeNode calls fn on each node in the accumulator affected by ru.

--- a/consensus/application.go
+++ b/consensus/application.go
@@ -481,11 +481,10 @@ func (ms *MidState) resolveV2FileContractElement(fce types.V2FileContractElement
 	fced := ms.recordV2FileContractElement(fce.ID)
 	if fced.Created {
 		panic("consensus: resolved a newly-created v2 contract")
-	} else {
-		fced.Resolution = res
-		dupProof(&fce.StateElement)
-		fced.V2FileContractElement = fce
 	}
+	fced.Resolution = res
+	dupProof(&fce.StateElement)
+	fced.V2FileContractElement = fce
 	ms.spends[fce.ID] = txid
 }
 
@@ -784,9 +783,13 @@ func ApplyBlock(s State, b types.Block, bs V1BlockSupplement, targetTimestamp ti
 
 // A RevertUpdate represents the effects of reverting to a prior state. These
 // are the same effects seen as when applying the block, but should be processed
-// inversely. For example, if ForEachSiacoinElement reports an element with the
-// created flag set, it means the block created that element when it was
+// inversely. For example, if SiacoinElementDiffs reports an element with the
+// Created flag set, it means the block created that element when it was
 // applied; thus, when the block is reverted, the element no longer exists.
+//
+// Furthermore, the order of all diffs is reversed: if the block first created a
+// siacoin element, then later spent it, SiacoinElementDiffs will show the
+// element being spent, then later created. This simplifies diff processing.
 type RevertUpdate struct {
 	sces   []SiacoinElementDiff
 	sfes   []SiafundElementDiff

--- a/consensus/application.go
+++ b/consensus/application.go
@@ -341,150 +341,150 @@ func dupProof(se *types.StateElement) {
 	se.MerkleProof = append([]types.Hash256(nil), se.MerkleProof...)
 }
 
-func (ms *MidState) recordSiacoinElement(id types.SiacoinOutputID) *UpdatedSiacoinElement {
+func (ms *MidState) recordSiacoinElement(id types.SiacoinOutputID) *SiacoinElementDiff {
 	if i, ok := ms.elements[id]; ok {
 		return &ms.sces[i]
 	}
-	ms.sces = append(ms.sces, UpdatedSiacoinElement{})
+	ms.sces = append(ms.sces, SiacoinElementDiff{})
 	ms.elements[id] = len(ms.sces) - 1
 	return &ms.sces[len(ms.sces)-1]
 }
 
-func (ms *MidState) createSiacoinElement(id types.SiacoinOutputID, sco types.SiacoinOutput) *UpdatedSiacoinElement {
-	usce := ms.recordSiacoinElement(id)
-	usce.SiacoinElement = types.SiacoinElement{
+func (ms *MidState) createSiacoinElement(id types.SiacoinOutputID, sco types.SiacoinOutput) *SiacoinElementDiff {
+	sced := ms.recordSiacoinElement(id)
+	sced.SiacoinElement = types.SiacoinElement{
 		StateElement:  types.StateElement{LeafIndex: types.UnassignedLeafIndex},
 		ID:            id,
 		SiacoinOutput: sco,
 	}
-	usce.Created = true
-	return usce
+	sced.Created = true
+	return sced
 }
 
-func (ms *MidState) createImmatureSiacoinElement(id types.SiacoinOutputID, sco types.SiacoinOutput) *UpdatedSiacoinElement {
-	usce := ms.createSiacoinElement(id, sco)
-	usce.SiacoinElement.MaturityHeight = ms.base.MaturityHeight()
-	return usce
+func (ms *MidState) createImmatureSiacoinElement(id types.SiacoinOutputID, sco types.SiacoinOutput) *SiacoinElementDiff {
+	sced := ms.createSiacoinElement(id, sco)
+	sced.SiacoinElement.MaturityHeight = ms.base.MaturityHeight()
+	return sced
 }
 
 func (ms *MidState) spendSiacoinElement(sce types.SiacoinElement, txid types.TransactionID) {
-	usce := ms.recordSiacoinElement(sce.ID)
-	usce.SiacoinElement = sce
-	usce.Spent = true
-	dupProof(&usce.SiacoinElement.StateElement)
+	sced := ms.recordSiacoinElement(sce.ID)
+	sced.SiacoinElement = sce
+	sced.Spent = true
+	dupProof(&sced.SiacoinElement.StateElement)
 	ms.spends[sce.ID] = txid
 }
 
-func (ms *MidState) recordSiafundElement(id types.SiafundOutputID) *UpdatedSiafundElement {
+func (ms *MidState) recordSiafundElement(id types.SiafundOutputID) *SiafundElementDiff {
 	if i, ok := ms.elements[id]; ok {
 		return &ms.sfes[i]
 	}
-	ms.sfes = append(ms.sfes, UpdatedSiafundElement{})
+	ms.sfes = append(ms.sfes, SiafundElementDiff{})
 	ms.elements[id] = len(ms.sfes) - 1
 	return &ms.sfes[len(ms.sfes)-1]
 }
 
-func (ms *MidState) createSiafundElement(id types.SiafundOutputID, sfo types.SiafundOutput) *UpdatedSiafundElement {
-	usce := ms.recordSiafundElement(id)
-	usce.SiafundElement = types.SiafundElement{
+func (ms *MidState) createSiafundElement(id types.SiafundOutputID, sfo types.SiafundOutput) *SiafundElementDiff {
+	sfed := ms.recordSiafundElement(id)
+	sfed.SiafundElement = types.SiafundElement{
 		StateElement:  types.StateElement{LeafIndex: types.UnassignedLeafIndex},
 		ID:            id,
 		SiafundOutput: sfo,
 	}
-	usce.Created = true
-	return usce
+	sfed.Created = true
+	return sfed
 }
 
 func (ms *MidState) spendSiafundElement(sfe types.SiafundElement, txid types.TransactionID) {
-	usfe := ms.recordSiafundElement(sfe.ID)
-	usfe.SiafundElement = sfe
-	usfe.Spent = true
-	dupProof(&usfe.SiafundElement.StateElement)
+	sfed := ms.recordSiafundElement(sfe.ID)
+	sfed.SiafundElement = sfe
+	sfed.Spent = true
+	dupProof(&sfed.SiafundElement.StateElement)
 	ms.spends[sfe.ID] = txid
 }
 
-func (ms *MidState) recordFileContractElement(id types.FileContractID) *UpdatedFileContractElement {
+func (ms *MidState) recordFileContractElement(id types.FileContractID) *FileContractElementDiff {
 	if i, ok := ms.elements[id]; ok {
 		return &ms.fces[i]
 	}
-	ms.fces = append(ms.fces, UpdatedFileContractElement{})
+	ms.fces = append(ms.fces, FileContractElementDiff{})
 	ms.elements[id] = len(ms.fces) - 1
 	return &ms.fces[len(ms.fces)-1]
 }
 
 func (ms *MidState) createFileContractElement(id types.FileContractID, fc types.FileContract) {
-	ufce := ms.recordFileContractElement(id)
-	ufce.FileContractElement = types.FileContractElement{
+	fced := ms.recordFileContractElement(id)
+	fced.FileContractElement = types.FileContractElement{
 		StateElement: types.StateElement{LeafIndex: types.UnassignedLeafIndex},
 		ID:           id,
 		FileContract: fc,
 	}
-	ufce.Created = true
+	fced.Created = true
 	ms.siafundTaxRevenue = ms.siafundTaxRevenue.Add(ms.base.FileContractTax(fc))
 }
 
 func (ms *MidState) reviseFileContractElement(fce types.FileContractElement, rev types.FileContract) {
 	rev.Payout = fce.FileContract.Payout
-	ufce := ms.recordFileContractElement(fce.ID)
-	if ufce.Created {
-		ufce.FileContractElement.FileContract = rev
-	} else if ufce.Revision != nil {
-		*ufce.Revision = rev
+	fced := ms.recordFileContractElement(fce.ID)
+	if fced.Created {
+		fced.FileContractElement.FileContract = rev
+	} else if fced.Revision != nil {
+		*fced.Revision = rev
 	} else {
-		ufce.FileContractElement = fce
-		ufce.Revision = &rev
+		fced.FileContractElement = fce
+		fced.Revision = &rev
 	}
 }
 
 func (ms *MidState) resolveFileContractElement(fce types.FileContractElement, valid bool, txid types.TransactionID) {
-	ufce := ms.recordFileContractElement(fce.ID)
-	ufce.Resolved = true
-	ufce.Valid = valid
+	fced := ms.recordFileContractElement(fce.ID)
+	fced.Resolved = true
+	fced.Valid = valid
 	dupProof(&fce.StateElement)
-	ufce.FileContractElement = fce
+	fced.FileContractElement = fce
 	ms.spends[fce.ID] = txid
 }
 
-func (ms *MidState) recordV2FileContractElement(id types.FileContractID) *UpdatedV2FileContractElement {
+func (ms *MidState) recordV2FileContractElement(id types.FileContractID) *V2FileContractElementDiff {
 	if i, ok := ms.elements[id]; ok {
 		return &ms.v2fces[i]
 	}
-	ms.v2fces = append(ms.v2fces, UpdatedV2FileContractElement{})
+	ms.v2fces = append(ms.v2fces, V2FileContractElementDiff{})
 	ms.elements[id] = len(ms.v2fces) - 1
 	return &ms.v2fces[len(ms.v2fces)-1]
 }
 
 func (ms *MidState) createV2FileContractElement(id types.FileContractID, fc types.V2FileContract) {
-	ufce := ms.recordV2FileContractElement(id)
-	ufce.V2FileContractElement = types.V2FileContractElement{
+	fced := ms.recordV2FileContractElement(id)
+	fced.V2FileContractElement = types.V2FileContractElement{
 		StateElement:   types.StateElement{LeafIndex: types.UnassignedLeafIndex},
 		ID:             id,
 		V2FileContract: fc,
 	}
-	ufce.Created = true
+	fced.Created = true
 	ms.siafundTaxRevenue = ms.siafundTaxRevenue.Add(ms.base.V2FileContractTax(fc))
 }
 
 func (ms *MidState) reviseV2FileContractElement(fce types.V2FileContractElement, rev types.V2FileContract) {
-	ufce := ms.recordV2FileContractElement(fce.ID)
-	if ufce.Created {
-		ufce.V2FileContractElement.V2FileContract = rev
-	} else if ufce.Revision != nil {
-		*ufce.Revision = rev
+	fced := ms.recordV2FileContractElement(fce.ID)
+	if fced.Created {
+		fced.V2FileContractElement.V2FileContract = rev
+	} else if fced.Revision != nil {
+		*fced.Revision = rev
 	} else {
-		ufce.V2FileContractElement = fce
-		ufce.Revision = &rev
+		fced.V2FileContractElement = fce
+		fced.Revision = &rev
 	}
 }
 
 func (ms *MidState) resolveV2FileContractElement(fce types.V2FileContractElement, res types.V2FileContractResolutionType, txid types.TransactionID) {
-	ufce := ms.recordV2FileContractElement(fce.ID)
-	if ufce.Created {
+	fced := ms.recordV2FileContractElement(fce.ID)
+	if fced.Created {
 		panic("consensus: resolved a newly-created v2 contract")
 	} else {
-		ufce.Resolution = res
+		fced.Resolution = res
 		dupProof(&fce.StateElement)
-		ufce.V2FileContractElement = fce
+		fced.V2FileContractElement = fce
 	}
 	ms.spends[fce.ID] = txid
 }
@@ -645,7 +645,7 @@ func (ms *MidState) ApplyBlock(b types.Block, bs V1BlockSupplement) {
 	}
 }
 
-func forEachAppliedElement(sces []UpdatedSiacoinElement, sfes []UpdatedSiafundElement, fces []UpdatedFileContractElement, v2fces []UpdatedV2FileContractElement, aes []types.AttestationElement, cie *types.ChainIndexElement, fn func(elementLeaf)) {
+func forEachAppliedElement(sces []SiacoinElementDiff, sfes []SiafundElementDiff, fces []FileContractElementDiff, v2fces []V2FileContractElementDiff, aes []types.AttestationElement, cie *types.ChainIndexElement, fn func(elementLeaf)) {
 	for i := range sces {
 		sce := &sces[i]
 		fn(siacoinLeaf(&sce.SiacoinElement, sce.Spent))
@@ -673,7 +673,7 @@ func forEachAppliedElement(sces []UpdatedSiacoinElement, sfes []UpdatedSiafundEl
 	fn(chainIndexLeaf(cie))
 }
 
-func forEachRevertedElement(sces []UpdatedSiacoinElement, sfes []UpdatedSiafundElement, fces []UpdatedFileContractElement, v2fces []UpdatedV2FileContractElement, fn func(elementLeaf)) {
+func forEachRevertedElement(sces []SiacoinElementDiff, sfes []SiafundElementDiff, fces []FileContractElementDiff, v2fces []V2FileContractElementDiff, fn func(elementLeaf)) {
 	for i := range sces {
 		fn(siacoinLeaf(&sces[i].SiacoinElement, false))
 	}
@@ -690,29 +690,31 @@ func forEachRevertedElement(sces []UpdatedSiacoinElement, sfes []UpdatedSiafundE
 
 // An ApplyUpdate represents the effects of applying a block to a state.
 type ApplyUpdate struct {
-	sces   []UpdatedSiacoinElement
-	sfes   []UpdatedSiafundElement
-	fces   []UpdatedFileContractElement
-	v2fces []UpdatedV2FileContractElement
+	sces   []SiacoinElementDiff
+	sfes   []SiafundElementDiff
+	fces   []FileContractElementDiff
+	v2fces []V2FileContractElementDiff
 	aes    []types.AttestationElement
 	cie    types.ChainIndexElement
 
 	eau elementApplyUpdate
 }
 
-// SiacoinElements returns the siacoin elements related to the applied block.
-func (au ApplyUpdate) SiacoinElements() []UpdatedSiacoinElement { return au.sces }
+// SiacoinElementDiffs returns the siacoin element diffs related to the applied
+// block.
+func (au ApplyUpdate) SiacoinElementDiffs() []SiacoinElementDiff { return au.sces }
 
-// SiafundElements returns the siafund elements related to the applied block.
-func (au ApplyUpdate) SiafundElements() []UpdatedSiafundElement { return au.sfes }
+// SiafundElementDiffs returns the siafund element diffs related to the applied
+// block.
+func (au ApplyUpdate) SiafundElementDiffs() []SiafundElementDiff { return au.sfes }
 
-// FileContractElements returns the file contract elements related to the
-// applied block.
-func (au ApplyUpdate) FileContractElements() []UpdatedFileContractElement { return au.fces }
+// FileContractElementDiffs returns the file contract element diffs related to
+// the applied block.
+func (au ApplyUpdate) FileContractElementDiffs() []FileContractElementDiff { return au.fces }
 
-// V2FileContractElements returns the v2 file contract elements related to the
-// applied block.
-func (au ApplyUpdate) V2FileContractElements() []UpdatedV2FileContractElement { return au.v2fces }
+// V2FileContractElementDiffs returns the v2 file contract element diffs related
+// to the applied block.
+func (au ApplyUpdate) V2FileContractElementDiffs() []V2FileContractElementDiff { return au.v2fces }
 
 // UpdateElementProof updates the Merkle proof of the supplied element to
 // incorporate the changes made to the accumulator. The element's proof must be
@@ -786,29 +788,31 @@ func ApplyBlock(s State, b types.Block, bs V1BlockSupplement, targetTimestamp ti
 // created flag set, it means the block created that element when it was
 // applied; thus, when the block is reverted, the element no longer exists.
 type RevertUpdate struct {
-	sces   []UpdatedSiacoinElement
-	sfes   []UpdatedSiafundElement
-	fces   []UpdatedFileContractElement
-	v2fces []UpdatedV2FileContractElement
+	sces   []SiacoinElementDiff
+	sfes   []SiafundElementDiff
+	fces   []FileContractElementDiff
+	v2fces []V2FileContractElementDiff
 	aes    []types.AttestationElement
 	cie    types.ChainIndexElement
 
 	eru elementRevertUpdate
 }
 
-// SiacoinElements returns the siacoin elements related to the applied block.
-func (ru RevertUpdate) SiacoinElements() []UpdatedSiacoinElement { return ru.sces }
+// SiacoinElementDiffs returns the siacoin element diffs related to the applied
+// block.
+func (ru RevertUpdate) SiacoinElementDiffs() []SiacoinElementDiff { return ru.sces }
 
-// SiafundElements returns the siafund elements related to the applied block.
-func (ru RevertUpdate) SiafundElements() []UpdatedSiafundElement { return ru.sfes }
+// SiafundElementDiffs returns the siafund element diffs related to the applied
+// block.
+func (ru RevertUpdate) SiafundElementDiffs() []SiafundElementDiff { return ru.sfes }
 
-// FileContractElements returns the file contract elements related to the
-// applied block.
-func (ru RevertUpdate) FileContractElements() []UpdatedFileContractElement { return ru.fces }
+// FileContractElementDiffs returns the file contract element diffs related to
+// the applied block.
+func (ru RevertUpdate) FileContractElementDiffs() []FileContractElementDiff { return ru.fces }
 
-// V2FileContractElements returns the v2 file contract elements related to the
-// applied block.
-func (ru RevertUpdate) V2FileContractElements() []UpdatedV2FileContractElement { return ru.v2fces }
+// V2FileContractElementDiffs returns the v2 file contract element diffs related
+// to the applied block.
+func (ru RevertUpdate) V2FileContractElementDiffs() []V2FileContractElementDiff { return ru.v2fces }
 
 // UpdateElementProof updates the Merkle proof of the supplied element to
 // incorporate the changes made to the accumulator. The element's proof must be
@@ -881,12 +885,12 @@ func RevertBlock(s State, b types.Block, bs V1BlockSupplement) RevertUpdate {
 // condensed representation of the update types for JSON marshaling
 type (
 	applyUpdateJSON struct {
-		SiacoinElements        []UpdatedSiacoinElement        `json:"siacoinElements"`
-		SiafundElements        []UpdatedSiafundElement        `json:"siafundElements"`
-		FileContractElements   []UpdatedFileContractElement   `json:"fileContractElements"`
-		V2FileContractElements []UpdatedV2FileContractElement `json:"v2FileContractElements"`
-		AttestationElements    []types.AttestationElement     `json:"attestationElements"`
-		ChainIndexElement      types.ChainIndexElement        `json:"chainIndexElement"`
+		SiacoinElements            []SiacoinElementDiff        `json:"siacoinElements"`
+		SiafundElementDiffs        []SiafundElementDiff        `json:"siafundElementDiffs"`
+		FileContractElementDiffs   []FileContractElementDiff   `json:"fileContractElementDiffs"`
+		V2FileContractElementDiffs []V2FileContractElementDiff `json:"v2FileContractElementDiffs"`
+		AttestationElements        []types.AttestationElement  `json:"attestationElements"`
+		ChainIndexElement          types.ChainIndexElement     `json:"chainIndexElement"`
 
 		UpdatedLeaves map[int][]elementLeaf   `json:"updatedLeaves"`
 		TreeGrowth    map[int][]types.Hash256 `json:"treeGrowth"`
@@ -895,12 +899,12 @@ type (
 	}
 
 	revertUpdateJSON struct {
-		SiacoinElements        []UpdatedSiacoinElement        `json:"siacoinElements"`
-		SiafundElements        []UpdatedSiafundElement        `json:"siafundElements"`
-		FileContractElements   []UpdatedFileContractElement   `json:"fileContractElements"`
-		V2FileContractElements []UpdatedV2FileContractElement `json:"v2FileContractElements"`
-		AttestationElements    []types.AttestationElement     `json:"attestationElements"`
-		ChainIndexElement      types.ChainIndexElement        `json:"chainIndexElement"`
+		SiacoinElements            []SiacoinElementDiff        `json:"siacoinElements"`
+		SiafundElementDiffs        []SiafundElementDiff        `json:"siafundElementDiffs"`
+		FileContractElementDiffs   []FileContractElementDiff   `json:"fileContractElementDiffs"`
+		V2FileContractElementDiffs []V2FileContractElementDiff `json:"v2FileContractElementDiffs"`
+		AttestationElements        []types.AttestationElement  `json:"attestationElements"`
+		ChainIndexElement          types.ChainIndexElement     `json:"chainIndexElement"`
 
 		UpdatedLeaves map[int][]elementLeaf `json:"updatedLeaves"`
 		NumLeaves     uint64                `json:"numLeaves"`
@@ -910,12 +914,12 @@ type (
 // MarshalJSON implements json.Marshaler.
 func (au ApplyUpdate) MarshalJSON() ([]byte, error) {
 	js := applyUpdateJSON{
-		SiacoinElements:        au.sces,
-		SiafundElements:        au.sfes,
-		FileContractElements:   au.fces,
-		V2FileContractElements: au.v2fces,
-		AttestationElements:    au.aes,
-		ChainIndexElement:      au.cie,
+		SiacoinElements:            au.sces,
+		SiafundElementDiffs:        au.sfes,
+		FileContractElementDiffs:   au.fces,
+		V2FileContractElementDiffs: au.v2fces,
+		AttestationElements:        au.aes,
+		ChainIndexElement:          au.cie,
 	}
 	js.UpdatedLeaves = make(map[int][]elementLeaf, len(au.eau.updated))
 	for i, els := range au.eau.updated {
@@ -941,9 +945,9 @@ func (au *ApplyUpdate) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	au.sces = js.SiacoinElements
-	au.sfes = js.SiafundElements
-	au.fces = js.FileContractElements
-	au.v2fces = js.V2FileContractElements
+	au.sfes = js.SiafundElementDiffs
+	au.fces = js.FileContractElementDiffs
+	au.v2fces = js.V2FileContractElementDiffs
 	au.aes = js.AttestationElements
 	au.cie = js.ChainIndexElement
 
@@ -963,12 +967,12 @@ func (au *ApplyUpdate) UnmarshalJSON(b []byte) error {
 // MarshalJSON implements json.Marshaler.
 func (ru RevertUpdate) MarshalJSON() ([]byte, error) {
 	js := revertUpdateJSON{
-		SiacoinElements:        ru.sces,
-		SiafundElements:        ru.sfes,
-		FileContractElements:   ru.fces,
-		V2FileContractElements: ru.v2fces,
-		AttestationElements:    ru.aes,
-		ChainIndexElement:      ru.cie,
+		SiacoinElements:            ru.sces,
+		SiafundElementDiffs:        ru.sfes,
+		FileContractElementDiffs:   ru.fces,
+		V2FileContractElementDiffs: ru.v2fces,
+		AttestationElements:        ru.aes,
+		ChainIndexElement:          ru.cie,
 	}
 	js.UpdatedLeaves = make(map[int][]elementLeaf, len(ru.eru.updated))
 	for i, els := range ru.eru.updated {
@@ -987,9 +991,9 @@ func (ru *RevertUpdate) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	ru.sces = js.SiacoinElements
-	ru.sfes = js.SiafundElements
-	ru.fces = js.FileContractElements
-	ru.v2fces = js.V2FileContractElements
+	ru.sfes = js.SiafundElementDiffs
+	ru.fces = js.FileContractElementDiffs
+	ru.v2fces = js.V2FileContractElementDiffs
 	ru.aes = js.AttestationElements
 	ru.cie = js.ChainIndexElement
 

--- a/consensus/application.go
+++ b/consensus/application.go
@@ -429,13 +429,10 @@ func (ms *MidState) reviseFileContractElement(fce types.FileContractElement, rev
 	if ufce.Created {
 		ufce.FileContractElement.FileContract = rev
 	} else if ufce.Revision != nil {
-		ufce.Revision.FileContract = rev
+		*ufce.Revision = rev
 	} else {
 		ufce.FileContractElement = fce
-		revElement := fce
-		dupProof(&revElement.StateElement)
-		revElement.FileContract = rev
-		ufce.Revision = &revElement
+		ufce.Revision = &rev
 	}
 }
 
@@ -473,13 +470,10 @@ func (ms *MidState) reviseV2FileContractElement(fce types.V2FileContractElement,
 	if ufce.Created {
 		ufce.V2FileContractElement.V2FileContract = rev
 	} else if ufce.Revision != nil {
-		ufce.Revision.V2FileContract = rev
+		*ufce.Revision = rev
 	} else {
 		ufce.V2FileContractElement = fce
-		revElement := fce
-		dupProof(&revElement.StateElement)
-		revElement.V2FileContract = rev
-		ufce.Revision = &revElement
+		ufce.Revision = &rev
 	}
 }
 
@@ -662,19 +656,11 @@ func forEachAppliedElement(sces []UpdatedSiacoinElement, sfes []UpdatedSiafundEl
 	}
 	for i := range fces {
 		fce := &fces[i]
-		if fce.Revision != nil {
-			fn(fileContractLeaf(fce.Revision, fce.Resolved))
-		} else {
-			fn(fileContractLeaf(&fce.FileContractElement, fce.Resolved))
-		}
+		fn(fileContractLeaf(&fce.FileContractElement, fce.Revision, fce.Resolved))
 	}
 	for i := range v2fces {
 		v2fce := &v2fces[i]
-		if v2fce.Revision != nil {
-			fn(v2FileContractLeaf(v2fce.Revision, v2fce.Resolution != nil))
-		} else {
-			fn(v2FileContractLeaf(&v2fce.V2FileContractElement, v2fce.Resolution != nil))
-		}
+		fn(v2FileContractLeaf(&v2fce.V2FileContractElement, v2fce.Revision, v2fce.Resolution != nil))
 		// NOTE: Although it is an element, we do not process the ProofIndex
 		// field of V2StorageProofs. These are a special case, as they are not
 		// being updated (like e.g. siacoin inputs), nor are they being created
@@ -695,10 +681,10 @@ func forEachRevertedElement(sces []UpdatedSiacoinElement, sfes []UpdatedSiafundE
 		fn(siafundLeaf(&sfes[i].SiafundElement, false))
 	}
 	for i := range fces {
-		fn(fileContractLeaf(&fces[i].FileContractElement, false))
+		fn(fileContractLeaf(&fces[i].FileContractElement, nil, false))
 	}
 	for i := range v2fces {
-		fn(v2FileContractLeaf(&v2fces[i].V2FileContractElement, false))
+		fn(v2FileContractLeaf(&v2fces[i].V2FileContractElement, nil, false))
 	}
 }
 

--- a/consensus/application_test.go
+++ b/consensus/application_test.go
@@ -15,18 +15,17 @@ import (
 func checkApplyUpdate(t *testing.T, cs State, au ApplyUpdate) {
 	t.Helper()
 
-	ms := au.ms
-	for _, sce := range ms.sces {
+	for _, sce := range au.sces {
 		if !cs.Elements.containsLeaf(siacoinLeaf(&sce.SiacoinElement, sce.Spent)) {
 			t.Fatalf("consensus: siacoin element %v %v not found in accumulator after apply", sce.Spent, sce.SiacoinElement.ID)
 		}
 	}
-	for _, sfe := range ms.sfes {
+	for _, sfe := range au.sfes {
 		if !cs.Elements.containsLeaf(siafundLeaf(&sfe.SiafundElement, sfe.Spent)) {
 			t.Fatalf("consensus: siafund element %v not found in accumulator after apply", sfe.SiafundElement.ID)
 		}
 	}
-	for _, fce := range ms.fces {
+	for _, fce := range au.fces {
 		leaf := fileContractLeaf(&fce.FileContractElement, fce.Resolved)
 		if fce.Revision != nil {
 			leaf = fileContractLeaf(fce.Revision, fce.Resolved)
@@ -36,7 +35,7 @@ func checkApplyUpdate(t *testing.T, cs State, au ApplyUpdate) {
 			t.Fatal("consensus: file contract element leaf not found in accumulator after apply")
 		}
 	}
-	for _, fce := range ms.v2fces {
+	for _, fce := range au.v2fces {
 		leaf := v2FileContractLeaf(&fce.V2FileContractElement, fce.Resolution != nil)
 		if fce.Revision != nil {
 			leaf = v2FileContractLeaf(fce.Revision, fce.Resolution != nil)
@@ -46,7 +45,7 @@ func checkApplyUpdate(t *testing.T, cs State, au ApplyUpdate) {
 			t.Fatal("consensus: v2 file contract element leaf not found in accumulator after apply")
 		}
 	}
-	for _, ae := range ms.aes {
+	for _, ae := range au.aes {
 		if !cs.Elements.containsLeaf(attestationLeaf(&ae)) {
 			t.Fatal("consensus: attestation element leaf not found in accumulator after apply")
 		}
@@ -56,18 +55,17 @@ func checkApplyUpdate(t *testing.T, cs State, au ApplyUpdate) {
 func checkRevertUpdate(t *testing.T, cs State, ru RevertUpdate) {
 	t.Helper()
 
-	ms := ru.ms
-	for _, sce := range ms.sces {
+	for _, sce := range ru.sces {
 		if cs.Elements.containsLeaf(siacoinLeaf(&sce.SiacoinElement, sce.Spent)) {
 			t.Fatal("consensus: siacoin element found in accumulator after revert")
 		}
 	}
-	for _, sfe := range ms.sfes {
+	for _, sfe := range ru.sfes {
 		if cs.Elements.containsLeaf(siafundLeaf(&sfe.SiafundElement, sfe.Spent)) {
 			t.Fatal("consensus: siafund element found in accumulator after revert")
 		}
 	}
-	for _, fce := range ms.fces {
+	for _, fce := range ru.fces {
 		leaf := fileContractLeaf(&fce.FileContractElement, fce.Resolved)
 		if fce.Revision != nil {
 			leaf = fileContractLeaf(fce.Revision, fce.Resolved)
@@ -77,7 +75,7 @@ func checkRevertUpdate(t *testing.T, cs State, ru RevertUpdate) {
 			t.Fatal("consensus: file contract element leaf found in accumulator after revert")
 		}
 	}
-	for _, fce := range ms.v2fces {
+	for _, fce := range ru.v2fces {
 		leaf := v2FileContractLeaf(&fce.V2FileContractElement, fce.Resolution != nil)
 		if fce.Revision != nil {
 			leaf = v2FileContractLeaf(fce.Revision, fce.Resolution != nil)
@@ -87,7 +85,7 @@ func checkRevertUpdate(t *testing.T, cs State, ru RevertUpdate) {
 			t.Fatal("consensus: v2 file contract element leaf found in accumulator after revert")
 		}
 	}
-	for _, ae := range ms.aes {
+	for _, ae := range ru.aes {
 		if cs.Elements.containsLeaf(attestationLeaf(&ae)) {
 			t.Fatal("consensus: attestation element leaf found in accumulator after revert")
 		}

--- a/consensus/merkle.go
+++ b/consensus/merkle.go
@@ -92,14 +92,22 @@ func siafundLeaf(e *types.SiafundElement, spent bool) elementLeaf {
 }
 
 // fileContractLeaf returns the elementLeaf for a FileContractElement.
-func fileContractLeaf(e *types.FileContractElement, spent bool) elementLeaf {
-	elemHash := hashAll("leaf/filecontract", e.ID, e.FileContract)
+func fileContractLeaf(e *types.FileContractElement, rev *types.FileContract, spent bool) elementLeaf {
+	fc := e.FileContract
+	if rev != nil {
+		fc = *rev
+	}
+	elemHash := hashAll("leaf/filecontract", e.ID, fc)
 	return elementLeaf{&e.StateElement, elemHash, spent}
 }
 
 // v2FileContractLeaf returns the elementLeaf for a V2FileContractElement.
-func v2FileContractLeaf(e *types.V2FileContractElement, spent bool) elementLeaf {
-	elemHash := hashAll("leaf/v2filecontract", e.ID, e.V2FileContract)
+func v2FileContractLeaf(e *types.V2FileContractElement, rev *types.V2FileContract, spent bool) elementLeaf {
+	fc := e.V2FileContract
+	if rev != nil {
+		fc = *rev
+	}
+	elemHash := hashAll("leaf/v2filecontract", e.ID, fc)
 	return elementLeaf{&e.StateElement, elemHash, spent}
 }
 
@@ -200,15 +208,15 @@ func (acc *ElementAccumulator) containsSpentSiafundElement(sfe types.SiafundElem
 }
 
 func (acc *ElementAccumulator) containsUnresolvedFileContractElement(fce types.FileContractElement) bool {
-	return acc.containsLeaf(fileContractLeaf(&fce, false))
+	return acc.containsLeaf(fileContractLeaf(&fce, nil, false))
 }
 
 func (acc *ElementAccumulator) containsUnresolvedV2FileContractElement(fce types.V2FileContractElement) bool {
-	return acc.containsLeaf(v2FileContractLeaf(&fce, false))
+	return acc.containsLeaf(v2FileContractLeaf(&fce, nil, false))
 }
 
 func (acc *ElementAccumulator) containsResolvedV2FileContractElement(fce types.V2FileContractElement) bool {
-	return acc.containsLeaf(v2FileContractLeaf(&fce, true))
+	return acc.containsLeaf(v2FileContractLeaf(&fce, nil, true))
 }
 
 // addLeaves adds the supplied leaves to the accumulator, filling in their

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -584,31 +584,72 @@ func (s State) AttestationSigHash(a types.Attestation) types.Hash256 {
 	return hashAll("sig/attestation", s.v2ReplayPrefix(), a)
 }
 
+// An UpdatedSiacoinElement is a SiacoinElement that was created and/or spent
+// within a block. Note that an element may be both created and spent in the the
+// same block.
+type UpdatedSiacoinElement struct {
+	SiacoinElement types.SiacoinElement
+	Created        bool
+	Spent          bool
+}
+
+// An UpdatedSiafundElement is a SiafundElement that was created and/or spent
+// within a block. Note that an element may be both created and spent in the the
+// same block.
+type UpdatedSiafundElement struct {
+	SiafundElement types.SiafundElement
+	Created        bool
+	Spent          bool
+}
+
+// An UpdatedFileContractElement is a FileContractElement that was created,
+// revised, and/or resolved within a block. Note that a contract may be created,
+// revised, and resolved all within the same block.
+type UpdatedFileContractElement struct {
+	FileContractElement types.FileContractElement
+	Created             bool
+	// Non-nil if the contract was revised. If the contract was revised multiple
+	// times, this is the revision with the highest revision number.
+	Revision *types.FileContractElement
+	Resolved bool
+	Valid    bool
+}
+
+// An UpdatedV2FileContractElement is a V2FileContractElement that was created,
+// revised, and/or resolved within a block. Note that, within a block, a v2
+// contract may be both created and revised, or revised and resolved, but not
+// created and resolved.
+type UpdatedV2FileContractElement struct {
+	V2FileContractElement types.V2FileContractElement
+	Created               bool
+	// Non-nil if the contract was revised. If the contract was revised multiple
+	// times, this is the revision with the highest revision number.
+	Revision *types.V2FileContractElement
+	// Non-nil if the contract was resolved.
+	Resolution types.V2FileContractResolutionType
+}
+
 // A MidState represents the state of the chain within a block.
 type MidState struct {
 	base                 State
-	created              map[types.ElementID]int // indices into element slices
+	elements             map[types.ElementID]int // indices into element slices
 	spends               map[types.ElementID]types.TransactionID
-	revs                 map[types.FileContractID]*types.FileContractElement
-	res                  map[types.FileContractID]bool
-	v2revs               map[types.FileContractID]*types.V2FileContractElement
-	v2res                map[types.FileContractID]types.V2FileContractResolutionType
 	siafundTaxRevenue    types.Currency
 	foundationSubsidy    types.Address
 	foundationManagement types.Address
 
 	// elements created/updated by block
-	sces   []types.SiacoinElement
-	sfes   []types.SiafundElement
-	fces   []types.FileContractElement
-	v2fces []types.V2FileContractElement
+	sces   []UpdatedSiacoinElement
+	sfes   []UpdatedSiafundElement
+	fces   []UpdatedFileContractElement
+	v2fces []UpdatedV2FileContractElement
 	aes    []types.AttestationElement
 	cie    types.ChainIndexElement
 }
 
 func (ms *MidState) siacoinElement(ts V1TransactionSupplement, id types.SiacoinOutputID) (types.SiacoinElement, bool) {
-	if i, ok := ms.created[id]; ok {
-		return ms.sces[i], true
+	if i, ok := ms.elements[id]; ok {
+		return ms.sces[i].SiacoinElement, true
 	}
 	for _, sce := range ts.SiacoinInputs {
 		if sce.ID == id {
@@ -619,8 +660,8 @@ func (ms *MidState) siacoinElement(ts V1TransactionSupplement, id types.SiacoinO
 }
 
 func (ms *MidState) siafundElement(ts V1TransactionSupplement, id types.SiafundOutputID) (types.SiafundElement, bool) {
-	if i, ok := ms.created[id]; ok {
-		return ms.sfes[i], true
+	if i, ok := ms.elements[id]; ok {
+		return ms.sfes[i].SiafundElement, true
 	}
 	for _, sfe := range ts.SiafundInputs {
 		if sfe.ID == id {
@@ -631,10 +672,11 @@ func (ms *MidState) siafundElement(ts V1TransactionSupplement, id types.SiafundO
 }
 
 func (ms *MidState) fileContractElement(ts V1TransactionSupplement, id types.FileContractID) (types.FileContractElement, bool) {
-	if rev, ok := ms.revs[id]; ok {
-		return *rev, true
-	} else if i, ok := ms.created[id]; ok {
-		return ms.fces[i], true
+	if i, ok := ms.elements[id]; ok {
+		if ms.fces[i].Revision != nil {
+			return *ms.fces[i].Revision, true
+		}
+		return ms.fces[i].FileContractElement, true
 	}
 	for _, fce := range ts.RevisedFileContracts {
 		if fce.ID == id {
@@ -650,7 +692,7 @@ func (ms *MidState) fileContractElement(ts V1TransactionSupplement, id types.Fil
 }
 
 func (ms *MidState) storageProofWindowID(ts V1TransactionSupplement, id types.FileContractID) (types.BlockID, bool) {
-	if i, ok := ms.created[id]; ok && ms.fces[i].FileContract.WindowStart == ms.base.childHeight() {
+	if i, ok := ms.elements[id]; ok && ms.fces[i].FileContractElement.FileContract.WindowStart == ms.base.childHeight() {
 		return ms.base.Index.ID, true
 	}
 	for _, sps := range ts.StorageProofs {
@@ -671,21 +713,12 @@ func (ms *MidState) isSpent(id types.ElementID) bool {
 	return ok
 }
 
-func (ms *MidState) isCreated(id types.ElementID) bool {
-	_, ok := ms.created[id]
-	return ok || id == ms.cie.ID
-}
-
 // NewMidState constructs a MidState initialized to the provided base state.
 func NewMidState(s State) *MidState {
 	return &MidState{
 		base:                 s,
-		created:              make(map[types.ElementID]int),
+		elements:             make(map[types.ElementID]int),
 		spends:               make(map[types.ElementID]types.TransactionID),
-		revs:                 make(map[types.FileContractID]*types.FileContractElement),
-		res:                  make(map[types.FileContractID]bool),
-		v2revs:               make(map[types.FileContractID]*types.V2FileContractElement),
-		v2res:                make(map[types.FileContractID]types.V2FileContractResolutionType),
 		siafundTaxRevenue:    s.SiafundTaxRevenue,
 		foundationSubsidy:    s.FoundationSubsidyAddress,
 		foundationManagement: s.FoundationManagementAddress,

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -588,31 +588,31 @@ func (s State) AttestationSigHash(a types.Attestation) types.Hash256 {
 // within a block. Note that an element may be both created and spent in the the
 // same block.
 type UpdatedSiacoinElement struct {
-	SiacoinElement types.SiacoinElement
-	Created        bool
-	Spent          bool
+	SiacoinElement types.SiacoinElement `json:"siacoinElement"`
+	Created        bool                 `json:"created"`
+	Spent          bool                 `json:"spent"`
 }
 
 // An UpdatedSiafundElement is a SiafundElement that was created and/or spent
 // within a block. Note that an element may be both created and spent in the the
 // same block.
 type UpdatedSiafundElement struct {
-	SiafundElement types.SiafundElement
-	Created        bool
-	Spent          bool
+	SiafundElement types.SiafundElement `json:"siafundElement"`
+	Created        bool                 `json:"created"`
+	Spent          bool                 `json:"spent"`
 }
 
 // An UpdatedFileContractElement is a FileContractElement that was created,
 // revised, and/or resolved within a block. Note that a contract may be created,
 // revised, and resolved all within the same block.
 type UpdatedFileContractElement struct {
-	FileContractElement types.FileContractElement
-	Created             bool
+	FileContractElement types.FileContractElement `json:"fileContractElement"`
+	Created             bool                      `json:"created"`
 	// Non-nil if the contract was revised. If the contract was revised multiple
 	// times, this is the revision with the highest revision number.
-	Revision *types.FileContractElement
-	Resolved bool
-	Valid    bool
+	Revision *types.FileContractElement `json:"revision"`
+	Resolved bool                       `json:"resolved"`
+	Valid    bool                       `json:"valid"`
 }
 
 // An UpdatedV2FileContractElement is a V2FileContractElement that was created,
@@ -620,13 +620,13 @@ type UpdatedFileContractElement struct {
 // contract may be both created and revised, or revised and resolved, but not
 // created and resolved.
 type UpdatedV2FileContractElement struct {
-	V2FileContractElement types.V2FileContractElement
-	Created               bool
+	V2FileContractElement types.V2FileContractElement `json:"v2FileContractElement"`
+	Created               bool                        `json:"created"`
 	// Non-nil if the contract was revised. If the contract was revised multiple
 	// times, this is the revision with the highest revision number.
-	Revision *types.V2FileContractElement
+	Revision *types.V2FileContractElement `json:"revision"`
 	// Non-nil if the contract was resolved.
-	Resolution types.V2FileContractResolutionType
+	Resolution types.V2FileContractResolutionType `json:"resolution"`
 }
 
 // A MidState represents the state of the chain within a block.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -584,28 +584,28 @@ func (s State) AttestationSigHash(a types.Attestation) types.Hash256 {
 	return hashAll("sig/attestation", s.v2ReplayPrefix(), a)
 }
 
-// An UpdatedSiacoinElement is a SiacoinElement that was created and/or spent
-// within a block. Note that an element may be both created and spent in the the
-// same block.
-type UpdatedSiacoinElement struct {
+// A SiacoinElementDiff is a SiacoinElement that was created and/or spent within
+// a block. Note that an element may be both created and spent in the the same
+// block.
+type SiacoinElementDiff struct {
 	SiacoinElement types.SiacoinElement `json:"siacoinElement"`
 	Created        bool                 `json:"created"`
 	Spent          bool                 `json:"spent"`
 }
 
-// An UpdatedSiafundElement is a SiafundElement that was created and/or spent
-// within a block. Note that an element may be both created and spent in the the
-// same block.
-type UpdatedSiafundElement struct {
+// A SiafundElementDiff is a SiafundElement that was created and/or spent within
+// a block. Note that an element may be both created and spent in the the same
+// block.
+type SiafundElementDiff struct {
 	SiafundElement types.SiafundElement `json:"siafundElement"`
 	Created        bool                 `json:"created"`
 	Spent          bool                 `json:"spent"`
 }
 
-// An UpdatedFileContractElement is a FileContractElement that was created,
-// revised, and/or resolved within a block. Note that a contract may be created,
-// revised, and resolved all within the same block.
-type UpdatedFileContractElement struct {
+// A FileContractElementDiff is a FileContractElement that was created, revised,
+// and/or resolved within a block. Note that a contract may be created, revised,
+// and resolved all within the same block.
+type FileContractElementDiff struct {
 	FileContractElement types.FileContractElement `json:"fileContractElement"`
 	Created             bool                      `json:"created"`
 	// Non-nil if the contract was revised. If the contract was revised multiple
@@ -615,11 +615,11 @@ type UpdatedFileContractElement struct {
 	Valid    bool                `json:"valid"`
 }
 
-// An UpdatedV2FileContractElement is a V2FileContractElement that was created,
+// A V2FileContractElementDiff is a V2FileContractElement that was created,
 // revised, and/or resolved within a block. Note that, within a block, a v2
 // contract may be both created and revised, or revised and resolved, but not
 // created and resolved.
-type UpdatedV2FileContractElement struct {
+type V2FileContractElementDiff struct {
 	V2FileContractElement types.V2FileContractElement `json:"v2FileContractElement"`
 	Created               bool                        `json:"created"`
 	// Non-nil if the contract was revised. If the contract was revised multiple
@@ -639,10 +639,10 @@ type MidState struct {
 	foundationManagement types.Address
 
 	// elements created/updated by block
-	sces   []UpdatedSiacoinElement
-	sfes   []UpdatedSiafundElement
-	fces   []UpdatedFileContractElement
-	v2fces []UpdatedV2FileContractElement
+	sces   []SiacoinElementDiff
+	sfes   []SiafundElementDiff
+	fces   []FileContractElementDiff
+	v2fces []V2FileContractElementDiff
 	aes    []types.AttestationElement
 	cie    types.ChainIndexElement
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -610,9 +610,9 @@ type UpdatedFileContractElement struct {
 	Created             bool                      `json:"created"`
 	// Non-nil if the contract was revised. If the contract was revised multiple
 	// times, this is the revision with the highest revision number.
-	Revision *types.FileContractElement `json:"revision"`
-	Resolved bool                       `json:"resolved"`
-	Valid    bool                       `json:"valid"`
+	Revision *types.FileContract `json:"revision"`
+	Resolved bool                `json:"resolved"`
+	Valid    bool                `json:"valid"`
 }
 
 // An UpdatedV2FileContractElement is a V2FileContractElement that was created,
@@ -624,7 +624,7 @@ type UpdatedV2FileContractElement struct {
 	Created               bool                        `json:"created"`
 	// Non-nil if the contract was revised. If the contract was revised multiple
 	// times, this is the revision with the highest revision number.
-	Revision *types.V2FileContractElement `json:"revision"`
+	Revision *types.V2FileContract `json:"revision"`
 	// Non-nil if the contract was resolved.
 	Resolution types.V2FileContractResolutionType `json:"resolution"`
 }
@@ -674,7 +674,9 @@ func (ms *MidState) siafundElement(ts V1TransactionSupplement, id types.SiafundO
 func (ms *MidState) fileContractElement(ts V1TransactionSupplement, id types.FileContractID) (types.FileContractElement, bool) {
 	if i, ok := ms.elements[id]; ok {
 		if ms.fces[i].Revision != nil {
-			return *ms.fces[i].Revision, true
+			fce := ms.fces[i].FileContractElement
+			fce.FileContract = *ms.fces[i].Revision
+			return fce, true
 		}
 		return ms.fces[i].FileContractElement, true
 	}

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -726,7 +726,7 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 		cur := fce.V2FileContract
 		// check for prior revision within block
 		if i, ok := ms.elements[fce.ID]; ok && ms.v2fces[i].Revision != nil {
-			cur = ms.v2fces[i].Revision.V2FileContract
+			cur = *ms.v2fces[i].Revision
 		}
 		curOutputSum := cur.RenterOutput.Value.Add(cur.HostOutput.Value)
 		revOutputSum := rev.RenterOutput.Value.Add(rev.HostOutput.Value)

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -576,7 +576,7 @@ func validateV2Siacoins(ms *MidState, txn types.V2Transaction) error {
 
 		// check accumulator
 		if sci.Parent.StateElement.LeafIndex == types.UnassignedLeafIndex {
-			if !ms.isCreated(sci.Parent.ID) {
+			if i, ok := ms.elements[sci.Parent.ID]; !ok || !ms.sces[i].Created {
 				return fmt.Errorf("siacoin input %v spends nonexistent ephemeral output %v", i, sci.Parent.ID)
 			}
 		} else if !ms.base.Elements.containsUnspentSiacoinElement(sci.Parent) {
@@ -640,7 +640,7 @@ func validateV2Siafunds(ms *MidState, txn types.V2Transaction) error {
 
 		// check accumulator
 		if sfi.Parent.StateElement.LeafIndex == types.UnassignedLeafIndex {
-			if !ms.isCreated(sfi.Parent.ID) {
+			if i, ok := ms.elements[sfi.Parent.ID]; !ok || !ms.sfes[i].Created {
 				return fmt.Errorf("siafund input %v spends nonexistent ephemeral output %v", i, sfi.Parent.ID)
 			}
 		} else if !ms.base.Elements.containsUnspentSiafundElement(sfi.Parent) {
@@ -724,8 +724,9 @@ func validateV2FileContracts(ms *MidState, txn types.V2Transaction) error {
 
 	validateRevision := func(fce types.V2FileContractElement, rev types.V2FileContract) error {
 		cur := fce.V2FileContract
-		if priorRev, ok := ms.v2revs[fce.ID]; ok {
-			cur = priorRev.V2FileContract
+		// check for prior revision within block
+		if i, ok := ms.elements[fce.ID]; ok && ms.v2fces[i].Revision != nil {
+			cur = ms.v2fces[i].Revision.V2FileContract
 		}
 		curOutputSum := cur.RenterOutput.Value.Add(cur.HostOutput.Value)
 		revOutputSum := rev.RenterOutput.Value.Add(rev.HostOutput.Value)

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -105,7 +105,6 @@ func (db *consensusDB) applyBlock(au ApplyUpdate) {
 }
 
 func (db *consensusDB) revertBlock(ru RevertUpdate) {
-
 	for _, sce := range ru.sces {
 		if sce.Spent {
 			db.sces[sce.SiacoinElement.ID] = sce.SiacoinElement

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -99,7 +99,7 @@ func (db *consensusDB) applyBlock(au ApplyUpdate) {
 			delete(db.v2fces, fce.ID)
 		}
 	})
-	db.blockIDs = append(db.blockIDs, au.ms.cie.ID)
+	db.blockIDs = append(db.blockIDs, au.cie.ID)
 }
 
 func (db *consensusDB) revertBlock(ru RevertUpdate) {

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -85,7 +85,8 @@ func (db *consensusDB) applyBlock(au ApplyUpdate) {
 		if fce.Created {
 			db.fces[fce.FileContractElement.ID] = fce.FileContractElement
 		} else if fce.Revision != nil {
-			db.fces[fce.FileContractElement.ID] = *fce.Revision
+			fce.FileContractElement.FileContract = *fce.Revision
+			db.fces[fce.FileContractElement.ID] = fce.FileContractElement
 		} else if fce.Resolved {
 			delete(db.fces, fce.FileContractElement.ID)
 		}
@@ -94,7 +95,8 @@ func (db *consensusDB) applyBlock(au ApplyUpdate) {
 		if v2fce.Created {
 			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement
 		} else if v2fce.Revision != nil {
-			db.v2fces[v2fce.V2FileContractElement.ID] = *v2fce.Revision
+			v2fce.V2FileContractElement.V2FileContract = *v2fce.Revision
+			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement
 		} else if v2fce.Resolution != nil {
 			delete(db.v2fces, v2fce.V2FileContractElement.ID)
 		}
@@ -1762,7 +1764,8 @@ func TestV2RevisionApply(t *testing.T) {
 			case fce.Resolution != nil:
 				delete(fces, fce.V2FileContractElement.ID)
 			case fce.Revision != nil:
-				fces[fce.V2FileContractElement.ID] = *fce.Revision
+				fce.V2FileContractElement.V2FileContract = *fce.Revision
+				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
 			default:
 				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
 			}
@@ -1884,7 +1887,8 @@ func TestV2RenewalResolution(t *testing.T) {
 			case fce.Resolution != nil:
 				delete(fces, fce.V2FileContractElement.ID)
 			case fce.Revision != nil:
-				fces[fce.V2FileContractElement.ID] = *fce.Revision
+				fce.V2FileContractElement.V2FileContract = *fce.Revision
+				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
 			default:
 				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
 			}

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -954,17 +954,17 @@ func TestValidateV2Block(t *testing.T) {
 
 	cs, au := ApplyBlock(n.GenesisState(), genesisBlock, V1BlockSupplement{}, time.Time{})
 	checkApplyUpdate(t, cs, au)
-	sces := make([]types.SiacoinElement, len(au.SiacoinElements()))
+	sces := make([]types.SiacoinElement, len(au.SiacoinElementDiffs()))
 	for i := range sces {
-		sces[i] = au.SiacoinElements()[i].SiacoinElement
+		sces[i] = au.SiacoinElementDiffs()[i].SiacoinElement
 	}
-	sfes := make([]types.SiafundElement, len(au.SiafundElements()))
+	sfes := make([]types.SiafundElement, len(au.SiafundElementDiffs()))
 	for i := range sfes {
-		sfes[i] = au.SiafundElements()[i].SiafundElement
+		sfes[i] = au.SiafundElementDiffs()[i].SiafundElement
 	}
-	fces := make([]types.V2FileContractElement, len(au.V2FileContractElements()))
+	fces := make([]types.V2FileContractElement, len(au.V2FileContractElementDiffs()))
 	for i := range fces {
-		fces[i] = au.V2FileContractElements()[i].V2FileContractElement
+		fces[i] = au.V2FileContractElementDiffs()[i].V2FileContractElement
 	}
 	cies := []types.ChainIndexElement{au.ChainIndexElement()}
 
@@ -1000,7 +1000,7 @@ func TestValidateV2Block(t *testing.T) {
 				},
 				FileContracts: []types.V2FileContract{fc},
 				FileContractRevisions: []types.V2FileContractRevision{
-					{Parent: au.V2FileContractElements()[0].V2FileContractElement, Revision: rev1},
+					{Parent: au.V2FileContractElementDiffs()[0].V2FileContractElement, Revision: rev1},
 				},
 				MinerFee: minerFee,
 			}},
@@ -1234,7 +1234,7 @@ func TestValidateV2Block(t *testing.T) {
 				},
 			},
 			{
-				fmt.Sprintf("file contract revision 1 parent (%v) has already been revised", au.V2FileContractElements()[0].V2FileContractElement.ID),
+				fmt.Sprintf("file contract revision 1 parent (%v) has already been revised", au.V2FileContractElementDiffs()[0].V2FileContractElement.ID),
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
 					newRevision := txn.FileContractRevisions[0]
@@ -1361,17 +1361,17 @@ func TestValidateV2Block(t *testing.T) {
 	db.applyBlock(testAU)
 	updateProofs(testAU, sces, sfes, fces, cies)
 
-	testSces := make([]types.SiacoinElement, len(testAU.SiacoinElements()))
+	testSces := make([]types.SiacoinElement, len(testAU.SiacoinElementDiffs()))
 	for i := range testSces {
-		testSces[i] = testAU.SiacoinElements()[i].SiacoinElement
+		testSces[i] = testAU.SiacoinElementDiffs()[i].SiacoinElement
 	}
-	testSfes := make([]types.SiafundElement, len(testAU.SiafundElements()))
+	testSfes := make([]types.SiafundElement, len(testAU.SiafundElementDiffs()))
 	for i := range testSfes {
-		testSfes[i] = testAU.SiafundElements()[i].SiafundElement
+		testSfes[i] = testAU.SiafundElementDiffs()[i].SiafundElement
 	}
-	testFces := make([]types.V2FileContractElement, len(testAU.V2FileContractElements()))
+	testFces := make([]types.V2FileContractElement, len(testAU.V2FileContractElementDiffs()))
 	for i := range testFces {
-		testFces[i] = testAU.V2FileContractElements()[i].V2FileContractElement
+		testFces[i] = testAU.V2FileContractElementDiffs()[i].V2FileContractElement
 	}
 	cies = append(cies, testAU.ChainIndexElement())
 
@@ -1599,7 +1599,7 @@ func TestV2ImmatureSiacoinOutput(t *testing.T) {
 		var cau ApplyUpdate
 		cs, cau = ApplyBlock(cs, b, db.supplementTipBlock(b), db.ancestorTimestamp(b.ParentID))
 		checkApplyUpdate(t, cs, cau)
-		for _, sce := range cau.SiacoinElements() {
+		for _, sce := range cau.SiacoinElementDiffs() {
 			if sce.Spent {
 				delete(utxos, types.SiacoinOutputID(sce.SiacoinElement.ID))
 			} else if sce.SiacoinElement.SiacoinOutput.Address == addr {
@@ -1759,7 +1759,7 @@ func TestV2RevisionApply(t *testing.T) {
 	contractID := genesisTxn.V2FileContractID(genesisTxn.ID(), 0)
 	fces := make(map[types.FileContractID]types.V2FileContractElement)
 	applyContractChanges := func(au ApplyUpdate) {
-		for _, fce := range au.V2FileContractElements() {
+		for _, fce := range au.V2FileContractElementDiffs() {
 			switch {
 			case fce.Resolution != nil:
 				delete(fces, fce.V2FileContractElement.ID)
@@ -1882,7 +1882,7 @@ func TestV2RenewalResolution(t *testing.T) {
 	fces := make(map[types.FileContractID]types.V2FileContractElement)
 	genesisOutput := genesisTxn.EphemeralSiacoinOutput(0)
 	applyChanges := func(au ApplyUpdate) {
-		for _, fce := range au.V2FileContractElements() {
+		for _, fce := range au.V2FileContractElementDiffs() {
 			switch {
 			case fce.Resolution != nil:
 				delete(fces, fce.V2FileContractElement.ID)
@@ -1893,7 +1893,7 @@ func TestV2RenewalResolution(t *testing.T) {
 				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
 			}
 		}
-		for _, sce := range au.SiacoinElements() {
+		for _, sce := range au.SiacoinElementDiffs() {
 			if sce.SiacoinElement.ID == genesisOutput.ID {
 				genesisOutput = sce.SiacoinElement
 				break

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -69,34 +69,34 @@ func (db *consensusDB) applyBlock(au ApplyUpdate) {
 	}
 	au.ForEachSiacoinElement(func(sce types.SiacoinElement, created, spent bool) {
 		if spent {
-			delete(db.sces, types.SiacoinOutputID(sce.ID))
+			delete(db.sces, sce.ID)
 		} else {
-			db.sces[types.SiacoinOutputID(sce.ID)] = sce
+			db.sces[sce.ID] = sce
 		}
 	})
 	au.ForEachSiafundElement(func(sfe types.SiafundElement, created, spent bool) {
 		if spent {
-			delete(db.sfes, types.SiafundOutputID(sfe.ID))
+			delete(db.sfes, sfe.ID)
 		} else {
-			db.sfes[types.SiafundOutputID(sfe.ID)] = sfe
+			db.sfes[sfe.ID] = sfe
 		}
 	})
 	au.ForEachFileContractElement(func(fce types.FileContractElement, created bool, rev *types.FileContractElement, resolved, valid bool) {
 		if created {
-			db.fces[types.FileContractID(fce.ID)] = fce
+			db.fces[fce.ID] = fce
 		} else if rev != nil {
-			db.fces[types.FileContractID(fce.ID)] = *rev
+			db.fces[fce.ID] = *rev
 		} else if resolved {
-			delete(db.fces, types.FileContractID(fce.ID))
+			delete(db.fces, fce.ID)
 		}
 	})
 	au.ForEachV2FileContractElement(func(fce types.V2FileContractElement, created bool, rev *types.V2FileContractElement, res types.V2FileContractResolutionType) {
 		if created {
-			db.v2fces[types.FileContractID(fce.ID)] = fce
+			db.v2fces[fce.ID] = fce
 		} else if rev != nil {
-			db.v2fces[types.FileContractID(fce.ID)] = *rev
+			db.v2fces[fce.ID] = *rev
 		} else if res != nil {
-			delete(db.v2fces, types.FileContractID(fce.ID))
+			delete(db.v2fces, fce.ID)
 		}
 	})
 	db.blockIDs = append(db.blockIDs, au.ms.cie.ID)
@@ -105,34 +105,34 @@ func (db *consensusDB) applyBlock(au ApplyUpdate) {
 func (db *consensusDB) revertBlock(ru RevertUpdate) {
 	ru.ForEachSiacoinElement(func(sce types.SiacoinElement, created, spent bool) {
 		if spent {
-			db.sces[types.SiacoinOutputID(sce.ID)] = sce
+			db.sces[sce.ID] = sce
 		} else {
-			delete(db.sces, types.SiacoinOutputID(sce.ID))
+			delete(db.sces, sce.ID)
 		}
 	})
 	ru.ForEachSiafundElement(func(sfe types.SiafundElement, created, spent bool) {
 		if spent {
-			db.sfes[types.SiafundOutputID(sfe.ID)] = sfe
+			db.sfes[sfe.ID] = sfe
 		} else {
-			delete(db.sfes, types.SiafundOutputID(sfe.ID))
+			delete(db.sfes, sfe.ID)
 		}
 	})
 	ru.ForEachFileContractElement(func(fce types.FileContractElement, created bool, rev *types.FileContractElement, resolved, valid bool) {
 		if created {
-			delete(db.fces, types.FileContractID(fce.ID))
+			delete(db.fces, fce.ID)
 		} else if rev != nil {
-			db.fces[types.FileContractID(fce.ID)] = fce
+			db.fces[fce.ID] = fce
 		} else if resolved {
-			db.fces[types.FileContractID(fce.ID)] = fce
+			db.fces[fce.ID] = fce
 		}
 	})
 	ru.ForEachV2FileContractElement(func(fce types.V2FileContractElement, created bool, rev *types.V2FileContractElement, res types.V2FileContractResolutionType) {
 		if created {
-			delete(db.v2fces, types.FileContractID(fce.ID))
+			delete(db.v2fces, fce.ID)
 		} else if rev != nil {
-			db.v2fces[types.FileContractID(fce.ID)] = fce
+			db.v2fces[fce.ID] = fce
 		} else if res != nil {
-			db.v2fces[types.FileContractID(fce.ID)] = fce
+			db.v2fces[fce.ID] = fce
 		}
 	})
 	for id, sce := range db.sces {

--- a/types/multiproof_test.go
+++ b/types/multiproof_test.go
@@ -36,17 +36,17 @@ func multiproofTxns(numTxns int, numElems int) []types.V2Transaction {
 	}
 	// apply the block and extract the created elements
 	cs, cau := consensus.ApplyBlock(cs, b, consensus.V1BlockSupplement{}, time.Time{})
-	sces := make([]types.SiacoinElement, len(cau.SiacoinElements()))
+	sces := make([]types.SiacoinElement, len(cau.SiacoinElementDiffs()))
 	for i := range sces {
-		sces[i] = cau.SiacoinElements()[i].SiacoinElement
+		sces[i] = cau.SiacoinElementDiffs()[i].SiacoinElement
 	}
-	sfes := make([]types.SiafundElement, len(cau.SiafundElements()))
+	sfes := make([]types.SiafundElement, len(cau.SiafundElementDiffs()))
 	for i := range sfes {
-		sfes[i] = cau.SiafundElements()[i].SiafundElement
+		sfes[i] = cau.SiafundElementDiffs()[i].SiafundElement
 	}
-	fces := make([]types.V2FileContractElement, len(cau.V2FileContractElements()))
+	fces := make([]types.V2FileContractElement, len(cau.V2FileContractElementDiffs()))
 	for i := range fces {
-		fces[i] = cau.V2FileContractElements()[i].V2FileContractElement
+		fces[i] = cau.V2FileContractElementDiffs()[i].V2FileContractElement
 	}
 
 	// select randomly

--- a/types/multiproof_test.go
+++ b/types/multiproof_test.go
@@ -36,18 +36,19 @@ func multiproofTxns(numTxns int, numElems int) []types.V2Transaction {
 	}
 	// apply the block and extract the created elements
 	cs, cau := consensus.ApplyBlock(cs, b, consensus.V1BlockSupplement{}, time.Time{})
-	var sces []types.SiacoinElement
-	cau.ForEachSiacoinElement(func(sce types.SiacoinElement, created, spent bool) {
-		sces = append(sces, sce)
-	})
-	var sfes []types.SiafundElement
-	cau.ForEachSiafundElement(func(sfe types.SiafundElement, created, spent bool) {
-		sfes = append(sfes, sfe)
-	})
-	var fces []types.V2FileContractElement
-	cau.ForEachV2FileContractElement(func(fce types.V2FileContractElement, created bool, rev *types.V2FileContractElement, res types.V2FileContractResolutionType) {
-		fces = append(fces, fce)
-	})
+	sces := make([]types.SiacoinElement, len(cau.SiacoinElements()))
+	for i := range sces {
+		sces[i] = cau.SiacoinElements()[i].SiacoinElement
+	}
+	sfes := make([]types.SiafundElement, len(cau.SiafundElements()))
+	for i := range sfes {
+		sfes[i] = cau.SiafundElements()[i].SiafundElement
+	}
+	fces := make([]types.V2FileContractElement, len(cau.V2FileContractElements()))
+	for i := range fces {
+		fces[i] = cau.V2FileContractElements()[i].V2FileContractElement
+	}
+
 	// select randomly
 	rng := frand.NewCustom(make([]byte, 32), 1024, 12)
 	rng.Shuffle(len(sces), reflect.Swapper(sces))


### PR DESCRIPTION
This replaces the `ForEach` update API with slices of "diffs" -- new types wrapping the various element types. This was originally intended as an ergonomics improvement (since it's annoying to e.g. break out of a `ForEach` callback), but it ended up significantly simplifying most `MidState`-related code: it consolidated the interrelated maps within `MidState`, and enabled a much saner rewrite of the update JSON types.

I originally left the `ForEach` methods in place (with a `// Deprecated` warning), but later removed them entirely; we're going to update all the callsites in `coreutils` anyway, so there's little reason to keep them around. (`ForEachTreeNode` remains, though, since it's used by `explored`.)