### PR TITLE
Add helpers to get revision as an element from v1/v2 file contract element diffs

### DIFF
--- a/.changeset/add_helpers_to_get_revision_as_an_element_from_v1v2_file_contract_element_diffs.md
+++ b/.changeset/add_helpers_to_get_revision_as_an_element_from_v1v2_file_contract_element_diffs.md
@@ -1,0 +1,9 @@
+---
+default: minor
+---
+
+# Add helpers to get revision as an element from v1/v2 file contract element diffs
+
+#274 by @chris124567
+
+See https://github.com/SiaFoundation/explored/pull/169#discussion_r1950507575

--- a/.changeset/add_helpers_to_get_revision_as_an_element_from_v1v2_file_contract_element_diffs.md
+++ b/.changeset/add_helpers_to_get_revision_as_an_element_from_v1v2_file_contract_element_diffs.md
@@ -6,4 +6,4 @@ default: minor
 
 #274 by @chris124567
 
-See https://github.com/SiaFoundation/explored/pull/169#discussion_r1950507575
+In the old ForEachFileContractElement interface, the revision was provided as a pointer to a (V2)FileContractElement.  In the new system of diffs, the revision is only provided as a (V2)FileContract. There are multiple [places](https://github.com/SiaFoundation/explored/pull/169#discussion_r1950507575) where it is useful to have the revision as an element, and in all of these places more or less the same code will be duplicated unless we create this helper.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -616,15 +616,16 @@ type FileContractElementDiff struct {
 }
 
 // RevisionElement returns the revision, if present, as a FileContractElement.
-func (diff FileContractElementDiff) RevisionElement() *types.FileContractElement {
+// It returns a boolean indicating whether the revision exists or not.
+func (diff FileContractElementDiff) RevisionElement() (types.FileContractElement, bool) {
 	if diff.Revision == nil {
-		return nil
+		return types.FileContractElement{}, false
 	}
-	return &types.FileContractElement{
+	return types.FileContractElement{
 		ID:           diff.FileContractElement.ID,
 		StateElement: diff.FileContractElement.StateElement,
 		FileContract: *diff.Revision,
-	}
+	}, true
 }
 
 // A V2FileContractElementDiff is a V2FileContractElement that was created,
@@ -642,16 +643,17 @@ type V2FileContractElementDiff struct {
 }
 
 // V2RevisionElement returns the revision, if present, as a
-// V2FileContractElement.
-func (diff V2FileContractElementDiff) V2RevisionElement() *types.V2FileContractElement {
+// V2FileContractElement.  It returns a boolean indicating whether the revision
+// exists or not.
+func (diff V2FileContractElementDiff) V2RevisionElement() (types.V2FileContractElement, bool) {
 	if diff.Revision == nil {
-		return nil
+		return types.V2FileContractElement{}, false
 	}
-	return &types.V2FileContractElement{
+	return types.V2FileContractElement{
 		ID:             diff.V2FileContractElement.ID,
 		StateElement:   diff.V2FileContractElement.StateElement,
 		V2FileContract: *diff.Revision,
-	}
+	}, true
 }
 
 // A MidState represents the state of the chain within a block.

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -615,6 +615,18 @@ type FileContractElementDiff struct {
 	Valid    bool                `json:"valid"`
 }
 
+// RevisionElement returns the revision, if present, as a FileContractElement.
+func (diff FileContractElementDiff) RevisionElement() *types.FileContractElement {
+	if diff.Revision == nil {
+		return nil
+	}
+	return &types.FileContractElement{
+		ID:           diff.FileContractElement.ID,
+		StateElement: diff.FileContractElement.StateElement,
+		FileContract: *diff.Revision,
+	}
+}
+
 // A V2FileContractElementDiff is a V2FileContractElement that was created,
 // revised, and/or resolved within a block. Note that, within a block, a v2
 // contract may be both created and revised, or revised and resolved, but not
@@ -627,6 +639,19 @@ type V2FileContractElementDiff struct {
 	Revision *types.V2FileContract `json:"revision"`
 	// Non-nil if the contract was resolved.
 	Resolution types.V2FileContractResolutionType `json:"resolution"`
+}
+
+// V2RevisionElement returns the revision, if present, as a
+// V2FileContractElement.
+func (diff V2FileContractElementDiff) V2RevisionElement() *types.V2FileContractElement {
+	if diff.Revision == nil {
+		return nil
+	}
+	return &types.V2FileContractElement{
+		ID:             diff.V2FileContractElement.ID,
+		StateElement:   diff.V2FileContractElement.StateElement,
+		V2FileContract: *diff.Revision,
+	}
 }
 
 // A MidState represents the state of the chain within a block.


### PR DESCRIPTION
See https://github.com/SiaFoundation/explored/pull/169#discussion_r1950507575