### PR TITLE
Add RHP4 RPC replenish types

### DIFF
--- a/.changeset/add_rpcreplenish_to_rhp4.md
+++ b/.changeset/add_rpcreplenish_to_rhp4.md
@@ -1,0 +1,7 @@
+---
+default: minor
+---
+
+# Add RPCReplenish to RHP4
+
+Adds an RPC to RHP4 that enables renters to set a target balance instead of first fetching the current balance and then funding the account with the difference. This is primarily to speed up account funding and reduce round trips when managing a large number of accounts.

--- a/rhp/v2/contracts.go
+++ b/rhp/v2/contracts.go
@@ -135,7 +135,7 @@ func PrepareContractRenewal(currentRevision types.FileContractRevision, renterAd
 }
 
 // CalculateHostPayouts calculates the contract payouts for the host.
-func CalculateHostPayouts(fc types.FileContract, newCollateral types.Currency, settings HostSettings, endHeight uint64) (types.Currency, types.Currency, types.Currency, types.Currency) {
+func CalculateHostPayouts(fc types.FileContract, newCollateral types.Currency, settings HostSettings, endHeight uint64) (hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice types.Currency) {
 	// The host gets their contract fee, plus the cost of the data already in the
 	// contract, plus their collateral. In the event of a missed payout, the cost
 	// and collateral of the data already in the contract is subtracted from the
@@ -151,7 +151,7 @@ func CalculateHostPayouts(fc types.FileContract, newCollateral types.Currency, s
 	// impossible until they change their settings.
 
 	// calculate base price and collateral
-	var basePrice, baseCollateral types.Currency
+	var baseCollateral types.Currency
 
 	// if the contract height did not increase both prices are zero
 	if contractEnd := uint64(endHeight + settings.WindowSize); contractEnd > fc.WindowEnd {
@@ -161,13 +161,13 @@ func CalculateHostPayouts(fc types.FileContract, newCollateral types.Currency, s
 	}
 
 	// calculate payouts
-	hostValidPayout := settings.ContractPrice.Add(basePrice).Add(baseCollateral).Add(newCollateral)
-	voidMissedPayout := basePrice.Add(baseCollateral)
+	hostValidPayout = settings.ContractPrice.Add(basePrice).Add(baseCollateral).Add(newCollateral)
+	voidMissedPayout = basePrice.Add(baseCollateral)
 	if hostValidPayout.Cmp(voidMissedPayout) < 0 {
 		// TODO: detect this elsewhere
 		panic("host's settings are unsatisfiable")
 	}
-	hostMissedPayout := hostValidPayout.Sub(voidMissedPayout)
+	hostMissedPayout = hostValidPayout.Sub(voidMissedPayout)
 	return hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice
 }
 

--- a/rhp/v3/contracts.go
+++ b/rhp/v3/contracts.go
@@ -43,7 +43,7 @@ func PrepareContractRenewal(currentRevision types.FileContractRevision, hostAddr
 }
 
 // CalculateHostPayouts calculates the contract payouts for the host.
-func CalculateHostPayouts(fc types.FileContract, minNewCollateral types.Currency, pt HostPriceTable, expectedNewStorage, endHeight uint64) (types.Currency, types.Currency, types.Currency, types.Currency, error) {
+func CalculateHostPayouts(fc types.FileContract, minNewCollateral types.Currency, pt HostPriceTable, expectedNewStorage, endHeight uint64) (hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice types.Currency, _ error) {
 	// sanity check the inputs
 	if endHeight < fc.EndHeight() {
 		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, errors.New("endHeight should be at least the current end height of the contract")
@@ -60,12 +60,12 @@ func CalculateHostPayouts(fc types.FileContract, minNewCollateral types.Currency
 	}
 
 	// calculate payouts
-	hostValidPayout := pt.ContractPrice.Add(basePrice).Add(baseCollateral).Add(newCollateral)
-	voidMissedPayout := basePrice.Add(baseCollateral)
+	hostValidPayout = pt.ContractPrice.Add(basePrice).Add(baseCollateral).Add(newCollateral)
+	voidMissedPayout = basePrice.Add(baseCollateral)
 	if hostValidPayout.Cmp(voidMissedPayout) < 0 {
 		return types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, types.ZeroCurrency, errors.New("host's settings are unsatisfiable")
 	}
-	hostMissedPayout := hostValidPayout.Sub(voidMissedPayout)
+	hostMissedPayout = hostValidPayout.Sub(voidMissedPayout)
 	return hostValidPayout, hostMissedPayout, voidMissedPayout, basePrice, nil
 }
 

--- a/rhp/v4/encoding.go
+++ b/rhp/v4/encoding.go
@@ -610,10 +610,10 @@ func (r *RPCReplenishAccountsRequest) maxLen() int {
 }
 
 func (r *RPCReplenishAccountsResponse) encodeTo(e *types.Encoder) {
-	types.V2Currency(r.Cost).EncodeTo(e)
+	types.EncodeSlice(e, r.Deposits)
 }
 func (r *RPCReplenishAccountsResponse) decodeFrom(d *types.Decoder) {
-	(*types.V2Currency)(&r.Cost).DecodeFrom(d)
+	types.DecodeSlice(d, &r.Deposits)
 }
 func (r *RPCReplenishAccountsResponse) maxLen() int {
 	return sizeofCurrency

--- a/rhp/v4/encoding.go
+++ b/rhp/v4/encoding.go
@@ -593,6 +593,52 @@ func (r *RPCAccountBalanceResponse) maxLen() int {
 	return sizeofCurrency
 }
 
+func (r *RPCReplenishAccountsRequest) encodeTo(e *types.Encoder) {
+	types.EncodeSlice(e, r.Accounts)
+	types.V2Currency(r.Target).EncodeTo(e)
+	r.ContractID.EncodeTo(e)
+	r.ChallengeSignature.EncodeTo(e)
+}
+func (r *RPCReplenishAccountsRequest) decodeFrom(d *types.Decoder) {
+	types.DecodeSlice(d, &r.Accounts)
+	(*types.V2Currency)(&r.Target).DecodeFrom(d)
+	r.ContractID.DecodeFrom(d)
+	r.ChallengeSignature.DecodeFrom(d)
+}
+func (r *RPCReplenishAccountsRequest) maxLen() int {
+	return reasonableObjectSize
+}
+
+func (r *RPCReplenishAccountsResponse) encodeTo(e *types.Encoder) {
+	types.V2Currency(r.Cost).EncodeTo(e)
+}
+func (r *RPCReplenishAccountsResponse) decodeFrom(d *types.Decoder) {
+	(*types.V2Currency)(&r.Cost).DecodeFrom(d)
+}
+func (r *RPCReplenishAccountsResponse) maxLen() int {
+	return sizeofCurrency
+}
+
+func (r *RPCReplenishAccountsSecondResponse) encodeTo(e *types.Encoder) {
+	r.RenterSignature.EncodeTo(e)
+}
+func (r *RPCReplenishAccountsSecondResponse) decodeFrom(d *types.Decoder) {
+	r.RenterSignature.DecodeFrom(d)
+}
+func (r *RPCReplenishAccountsSecondResponse) maxLen() int {
+	return sizeofSignature
+}
+
+func (r *RPCReplenishAccountsThirdResponse) encodeTo(e *types.Encoder) {
+	r.HostSignature.EncodeTo(e)
+}
+func (r *RPCReplenishAccountsThirdResponse) decodeFrom(d *types.Decoder) {
+	r.HostSignature.DecodeFrom(d)
+}
+func (r *RPCReplenishAccountsThirdResponse) maxLen() int {
+	return sizeofSignature
+}
+
 func (r *RPCFundAccountsRequest) encodeTo(e *types.Encoder) {
 	r.ContractID.EncodeTo(e)
 	types.EncodeSlice(e, r.Deposits)

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -474,7 +474,7 @@ type (
 	}
 	// RPCReplenishAccountsResponse is the response type for RPCReplenishAccounts.
 	RPCReplenishAccountsResponse struct {
-		Cost types.Currency `json:"cost"`
+		Deposits []AccountDeposit `json:"deposits"`
 	}
 	// RPCReplenishAccountsSecondResponse is the second response type for RPCReplenishAccounts.
 	RPCReplenishAccountsSecondResponse struct {
@@ -588,6 +588,14 @@ func (r *RPCReplenishAccountsRequest) ChallengeSigHash(revisionNumber uint64) ty
 // ValidChallengeSignature checks the challenge signature for validity.
 func (r *RPCReplenishAccountsRequest) ValidChallengeSignature(fc types.V2FileContract) bool {
 	return fc.RenterPublicKey.VerifyHash(r.ChallengeSigHash(fc.RevisionNumber), r.ChallengeSignature)
+}
+
+// TotalCost returns the total cost to the renter of the replenish RPC.
+func (r *RPCReplenishAccountsResponse) TotalCost() (total types.Currency) {
+	for _, deposit := range r.Deposits {
+		total = total.Add(deposit.Amount)
+	}
+	return
 }
 
 // NewContract creates a new file contract with the given settings.

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -25,6 +25,9 @@ const (
 	// number of sectors removed in a single RPC free call.
 	MaxSectorBatchSize = (1 << 40) / (SectorSize)
 
+	// MaxAccountBatchSize is the number of account operations that can be batched into a single RPC.
+	MaxAccountBatchSize = 1000
+
 	// SectorSize is the size of one sector in bytes.
 	SectorSize = 1 << 22 // 4 MiB
 )

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -251,6 +251,29 @@ func (req *RPCAppendSectorsRequest) Validate(pk types.PublicKey) error {
 }
 
 // Validate checks that the request is valid
+func (req *RPCFundAccountsRequest) Validate() error {
+	switch {
+	case req.ContractID == (types.FileContractID{}):
+		return errors.New("contract ID must be set")
+	case req.RenterSignature == (types.Signature{}):
+		return errors.New("renter signature must be set")
+	case len(req.Deposits) == 0:
+		return errors.New("no deposits to fund")
+	case len(req.Deposits) > MaxAccountBatchSize:
+		return fmt.Errorf("too many deposits to fund: %d > %d", len(req.Deposits), MaxAccountBatchSize)
+	}
+	for i, deposit := range req.Deposits {
+		switch {
+		case deposit.Account == (Account{}):
+			return fmt.Errorf("deposit %d has no account", i)
+		case deposit.Amount.IsZero():
+			return fmt.Errorf("deposit %d has no amount", i)
+		}
+	}
+	return nil
+}
+
+// Validate checks that the request is valid
 func (req *RPCReplenishAccountsRequest) Validate() error {
 	switch {
 	case len(req.Accounts) == 0:

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -276,12 +276,21 @@ func (req *RPCFundAccountsRequest) Validate() error {
 // Validate checks that the request is valid
 func (req *RPCReplenishAccountsRequest) Validate() error {
 	switch {
+	case req.ContractID == (types.FileContractID{}):
+		return errors.New("contract ID must be set")
+	case req.ChallengeSignature == (types.Signature{}):
+		return errors.New("challenge signature must be set")
 	case len(req.Accounts) == 0:
 		return errors.New("no accounts to replenish")
 	case len(req.Accounts) > MaxAccountBatchSize:
 		return fmt.Errorf("too many accounts to replenish: %d > %d", len(req.Accounts), MaxAccountBatchSize)
 	case req.Target.IsZero():
 		return errors.New("target must be greater than zero")
+	}
+	for i, account := range req.Accounts {
+		if account == (Account{}) {
+			return fmt.Errorf("account %d is empty", i)
+		}
 	}
 	return nil
 }

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -255,8 +255,8 @@ func (req *RPCReplenishAccountsRequest) Validate() error {
 	switch {
 	case len(req.Accounts) == 0:
 		return errors.New("no accounts to replenish")
-	case len(req.Accounts) > 100:
-		return fmt.Errorf("too many accounts to replenish: %d > %d", len(req.Accounts), 1000)
+	case len(req.Accounts) > MaxAccountBatchSize:
+		return fmt.Errorf("too many accounts to replenish: %d > %d", len(req.Accounts), MaxAccountBatchSize)
 	case req.Target.IsZero():
 		return errors.New("target must be greater than zero")
 	}

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -249,3 +249,16 @@ func (req *RPCAppendSectorsRequest) Validate(pk types.PublicKey) error {
 	}
 	return nil
 }
+
+// Validate checks that the request is valid
+func (req *RPCReplenishAccountsRequest) Validate() error {
+	switch {
+	case len(req.Accounts) == 0:
+		return errors.New("no accounts to replenish")
+	case len(req.Accounts) > 100:
+		return fmt.Errorf("too many accounts to replenish: %d > %d", len(req.Accounts), 1000)
+	case req.Target.IsZero():
+		return errors.New("target must be greater than zero")
+	}
+	return nil
+}


### PR DESCRIPTION
Adds an RPC to RHP4 that enables renters to set a target balance for all accounts instead of first fetching the current balances then funding the accounts with the difference. This is primarily to speed up account funding and reduce round trips when managing a large number of accounts.