### PR TITLE
rhp: Parallelize SectorRoot

### DIFF
--- a/.changeset/increase_speed_of_sector_root_calculation_by_10x.md
+++ b/.changeset/increase_speed_of_sector_root_calculation_by_10x.md
@@ -3,9 +3,3 @@ default: patch
 ---
 
 # Improved `SectorRoot` performance by a factor of 10 by distributing work across available CPU cores
-
-
-
-
-
-

--- a/.changeset/increase_speed_of_sector_root_calculation_by_10x.md
+++ b/.changeset/increase_speed_of_sector_root_calculation_by_10x.md
@@ -1,0 +1,11 @@
+---
+default: patch
+---
+
+# Improved `SectorRoot` performance by a factor of 10 by distributing work across available CPU cores
+
+
+
+
+
+

--- a/rhp/v4/merkle_test.go
+++ b/rhp/v4/merkle_test.go
@@ -64,14 +64,6 @@ func TestSectorRoot(t *testing.T) {
 			t.Error("SectorRoot does not match reference implementation")
 		}
 	}
-
-	// SectorRoot should not allocate
-	allocs := testing.AllocsPerRun(5, func() {
-		_ = SectorRoot(&sector)
-	})
-	if allocs > 0 {
-		t.Error("expected SectorRoot to allocate 0 times, got", allocs)
-	}
 }
 
 func BenchmarkSectorRoot(b *testing.B) {


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: go.sia.tech/core/rhp/v2
cpu: Apple M2 Pro
BenchmarkSectorRoot
BenchmarkSectorRoot/serial
BenchmarkSectorRoot/serial-10                 49          23381873 ns/op         179.38 MB/s           0 B/op          0 allocs/op
BenchmarkSectorRoot/parallel
BenchmarkSectorRoot/parallel-10              326           3563796 ns/op        1176.92 MB/s       14806 B/op         34 allocs/op
```
Pretty unambiguous  ~10x speedup when testing with a 10-core CPU. I experimented with inlining more of the `appendLeaves` logic into the worker goroutines, but it didn't have a significant impact on throughput and it made the code much more complex. ‾\\\_(ツ)\_/‾ 