### PR TITLE
Fix `maxLen`

### DIFF
--- a/rhp/v4/encoding.go
+++ b/rhp/v4/encoding.go
@@ -180,7 +180,7 @@ func (r *RPCFormContractRequest) decodeFrom(d *types.Decoder) {
 	types.DecodeSlice(d, &r.RenterParents)
 }
 func (r *RPCFormContractRequest) maxLen() int {
-	return reasonableObjectSize
+	return reasonableTransactionSetSize
 }
 
 func (r *RPCFormContractResponse) encodeTo(e *types.Encoder) {
@@ -251,7 +251,7 @@ func (r *RPCRenewContractRequest) decodeFrom(d *types.Decoder) {
 	r.ChallengeSignature.DecodeFrom(d)
 }
 func (r *RPCRenewContractRequest) maxLen() int {
-	return reasonableObjectSize
+	return reasonableTransactionSetSize
 }
 
 func (r *RPCRenewContractResponse) encodeTo(e *types.Encoder) {
@@ -321,7 +321,7 @@ func (r *RPCRefreshContractRequest) decodeFrom(d *types.Decoder) {
 	r.ChallengeSignature.DecodeFrom(d)
 }
 func (r *RPCRefreshContractRequest) maxLen() int {
-	return reasonableObjectSize
+	return reasonableTransactionSetSize
 }
 
 func (r *RPCRefreshContractResponse) encodeTo(e *types.Encoder) {
@@ -529,7 +529,7 @@ func (r *RPCWriteSectorRequest) decodeFrom(d *types.Decoder) {
 	r.DataLength = d.ReadUint64()
 }
 func (r *RPCWriteSectorRequest) maxLen() int {
-	return sizeofPrices + sizeofAccountToken + 8 + 8
+	return sizeofPrices + sizeofAccountToken + 8
 }
 
 func (r *RPCWriteSectorResponse) encodeTo(e *types.Encoder) {
@@ -557,7 +557,7 @@ func (r *RPCSectorRootsRequest) decodeFrom(d *types.Decoder) {
 	r.Length = d.ReadUint64()
 }
 func (r *RPCSectorRootsRequest) maxLen() int {
-	return sizeofPrices + 32 + sizeofSignature + 8 + 8
+	return sizeofPrices + sizeofHash + sizeofSignature + 8 + 8
 }
 
 func (r *RPCSectorRootsResponse) encodeTo(e *types.Encoder) {
@@ -679,7 +679,7 @@ func (r *RPCVerifySectorRequest) decodeFrom(d *types.Decoder) {
 	r.LeafIndex = d.ReadUint64()
 }
 func (r *RPCVerifySectorRequest) maxLen() int {
-	return 1024
+	return sizeofPrices + sizeofAccountToken + sizeofHash + 8
 }
 
 func (r *RPCVerifySectorResponse) encodeTo(e *types.Encoder) {


### PR DESCRIPTION
There are several instances where `maxLen` returns a size that doesn't take into account a transaction being part of the request. While updating I noticed some values diverged from their impl probably due to changes being made to the request/response structs over time. I took them along with me but the important ones are the `reasonableTransactionSetSize` ones of course.

I found out because my v2 migration on my node, which was chugging along nicely, halted all of a sudden. Contracts were no longer being refreshed, resulting in empty accounts, resulting in failed migrations. One thing that's puzzling me a bit though is the error message: "couldn't renew/refresh contract: host responded with error: failed to read host inputs response: failed to read request: EOF ". That error message seems impossible, I double checked and I still can't explain how you could ever get failed to read response, failed to read request.
