### PR TITLE
Update `knope` config

### DIFF
--- a/knope.toml
+++ b/knope.toml
@@ -18,6 +18,7 @@ command = "git switch -c release"
 
 [[workflows.steps]]
 type = "PrepareRelease"
+ignore_conventional_commits = true
 
 [[workflows.steps]]
 type = "Command"


### PR DESCRIPTION
https://github.com/SiaFoundation/core/pull/284 did not have a changeset entry, but that was done on purpose. I looked through recently merged core PRs and noticed we don't always add it, figured that fix did not really need one per se either. I updated the `knope` config to be consistent with all other repos. 