### PR TITLE
all: Add Element memory management methods and linter

### DIFF
--- a/consensus/merkle.go
+++ b/consensus/merkle.go
@@ -354,6 +354,13 @@ func updateLeaves(leaves []elementLeaf) [64][]elementLeaf {
 // applyBlock applies the supplied leaves to the accumulator, modifying it and
 // producing an update.
 func (acc *ElementAccumulator) applyBlock(updated, added []elementLeaf) (eau elementApplyUpdate) {
+	for _, el := range updated {
+		_ = el.Move() // panics if element is shared
+	}
+	for _, el := range added {
+		_ = el.Move() // panics if element is shared
+	}
+
 	eau.updated = updateLeaves(updated)
 	for height, es := range eau.updated {
 		if len(es) > 0 {
@@ -373,6 +380,13 @@ func (acc *ElementAccumulator) applyBlock(updated, added []elementLeaf) (eau ele
 // under acc, which must be the accumulator prior to the application of those
 // elements. The accumulator itself is not modified.
 func (acc *ElementAccumulator) revertBlock(updated, added []elementLeaf) (eru elementRevertUpdate) {
+	for _, el := range updated {
+		_ = el.Move() // panics if element is shared
+	}
+	for _, el := range added {
+		_ = el.Move() // panics if element is shared
+	}
+
 	eru.updated = updateLeaves(updated)
 	eru.numLeaves = acc.NumLeaves
 	for i := range added {
@@ -414,6 +428,7 @@ type elementApplyUpdate struct {
 }
 
 func (eau *elementApplyUpdate) updateElementProof(e *types.StateElement) {
+	_ = e.Move() // panics if element is shared
 	if e.LeafIndex == types.UnassignedLeafIndex {
 		panic("cannot update an ephemeral element")
 	} else if e.LeafIndex >= eau.oldNumLeaves {
@@ -431,6 +446,7 @@ type elementRevertUpdate struct {
 }
 
 func (eru *elementRevertUpdate) updateElementProof(e *types.StateElement) {
+	_ = e.Move() // panics if element is shared
 	if e.LeafIndex == types.UnassignedLeafIndex {
 		panic("cannot update an ephemeral element")
 	} else if e.LeafIndex >= eru.numLeaves {

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -616,14 +616,15 @@ type FileContractElementDiff struct {
 }
 
 // RevisionElement returns the revision, if present, as a FileContractElement.
-// It returns a boolean indicating whether the revision exists or not.
+// It returns a boolean indicating whether the revision exists or not. The
+// element's memory is shared.
 func (diff FileContractElementDiff) RevisionElement() (types.FileContractElement, bool) {
 	if diff.Revision == nil {
 		return types.FileContractElement{}, false
 	}
 	return types.FileContractElement{
 		ID:           diff.FileContractElement.ID,
-		StateElement: diff.FileContractElement.StateElement,
+		StateElement: diff.FileContractElement.StateElement.Share(),
 		FileContract: *diff.Revision,
 	}, true
 }
@@ -643,15 +644,15 @@ type V2FileContractElementDiff struct {
 }
 
 // V2RevisionElement returns the revision, if present, as a
-// V2FileContractElement.  It returns a boolean indicating whether the revision
-// exists or not.
+// V2FileContractElement. It returns a boolean indicating whether the revision
+// exists or not. The element's memory is shared.
 func (diff V2FileContractElementDiff) V2RevisionElement() (types.V2FileContractElement, bool) {
 	if diff.Revision == nil {
 		return types.V2FileContractElement{}, false
 	}
 	return types.V2FileContractElement{
 		ID:             diff.V2FileContractElement.ID,
-		StateElement:   diff.V2FileContractElement.StateElement,
+		StateElement:   diff.V2FileContractElement.StateElement.Share(),
 		V2FileContract: *diff.Revision,
 	}, true
 }

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -53,50 +53,50 @@ type consensusDB struct {
 func (db *consensusDB) applyBlock(au ApplyUpdate) {
 	for id, sce := range db.sces {
 		au.UpdateElementProof(&sce.StateElement)
-		db.sces[id] = sce
+		db.sces[id] = sce.Move()
 	}
 	for id, sfe := range db.sfes {
 		au.UpdateElementProof(&sfe.StateElement)
-		db.sfes[id] = sfe
+		db.sfes[id] = sfe.Move()
 	}
 	for id, fce := range db.fces {
 		au.UpdateElementProof(&fce.StateElement)
-		db.fces[id] = fce
+		db.fces[id] = fce.Move()
 	}
 	for id, fce := range db.v2fces {
 		au.UpdateElementProof(&fce.StateElement)
-		db.v2fces[id] = fce
+		db.v2fces[id] = fce.Move()
 	}
 	for _, sce := range au.sces {
 		if sce.Spent {
 			delete(db.sces, sce.SiacoinElement.ID)
 		} else {
-			db.sces[sce.SiacoinElement.ID] = sce.SiacoinElement
+			db.sces[sce.SiacoinElement.ID] = sce.SiacoinElement.Copy()
 		}
 	}
 	for _, sfe := range au.sfes {
 		if sfe.Spent {
 			delete(db.sfes, sfe.SiafundElement.ID)
 		} else {
-			db.sfes[sfe.SiafundElement.ID] = sfe.SiafundElement
+			db.sfes[sfe.SiafundElement.ID] = sfe.SiafundElement.Copy()
 		}
 	}
 	for _, fce := range au.fces {
 		if fce.Created {
-			db.fces[fce.FileContractElement.ID] = fce.FileContractElement
+			db.fces[fce.FileContractElement.ID] = fce.FileContractElement.Copy()
 		} else if fce.Revision != nil {
 			fce.FileContractElement.FileContract = *fce.Revision
-			db.fces[fce.FileContractElement.ID] = fce.FileContractElement
+			db.fces[fce.FileContractElement.ID] = fce.FileContractElement.Copy()
 		} else if fce.Resolved {
 			delete(db.fces, fce.FileContractElement.ID)
 		}
 	}
 	for _, v2fce := range au.v2fces {
 		if v2fce.Created {
-			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement
+			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement.Copy()
 		} else if v2fce.Revision != nil {
 			v2fce.V2FileContractElement.V2FileContract = *v2fce.Revision
-			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement
+			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement.Copy()
 		} else if v2fce.Resolution != nil {
 			delete(db.v2fces, v2fce.V2FileContractElement.ID)
 		}
@@ -107,14 +107,14 @@ func (db *consensusDB) applyBlock(au ApplyUpdate) {
 func (db *consensusDB) revertBlock(ru RevertUpdate) {
 	for _, sce := range ru.sces {
 		if sce.Spent {
-			db.sces[sce.SiacoinElement.ID] = sce.SiacoinElement
+			db.sces[sce.SiacoinElement.ID] = sce.SiacoinElement.Copy()
 		} else {
 			delete(db.sces, sce.SiacoinElement.ID)
 		}
 	}
 	for _, sfe := range ru.sfes {
 		if sfe.Spent {
-			db.sfes[sfe.SiafundElement.ID] = sfe.SiafundElement
+			db.sfes[sfe.SiafundElement.ID] = sfe.SiafundElement.Copy()
 		} else {
 			delete(db.sfes, sfe.SiafundElement.ID)
 		}
@@ -123,36 +123,36 @@ func (db *consensusDB) revertBlock(ru RevertUpdate) {
 		if fce.Created {
 			delete(db.fces, fce.FileContractElement.ID)
 		} else if fce.Revision != nil {
-			db.fces[fce.FileContractElement.ID] = fce.FileContractElement
+			db.fces[fce.FileContractElement.ID] = fce.FileContractElement.Copy()
 		} else if fce.Resolved {
-			db.fces[fce.FileContractElement.ID] = fce.FileContractElement
+			db.fces[fce.FileContractElement.ID] = fce.FileContractElement.Copy()
 		}
 	}
 	for _, v2fce := range ru.v2fces {
 		if v2fce.Created {
 			delete(db.v2fces, v2fce.V2FileContractElement.ID)
 		} else if v2fce.Revision != nil {
-			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement
+			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement.Copy()
 		} else if v2fce.Resolution != nil {
-			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement
+			db.v2fces[v2fce.V2FileContractElement.ID] = v2fce.V2FileContractElement.Copy()
 		}
 	}
 
 	for id, sce := range db.sces {
 		ru.UpdateElementProof(&sce.StateElement)
-		db.sces[id] = sce
+		db.sces[id] = sce.Copy()
 	}
 	for id, sfe := range db.sfes {
 		ru.UpdateElementProof(&sfe.StateElement)
-		db.sfes[id] = sfe
+		db.sfes[id] = sfe.Copy()
 	}
 	for id, fce := range db.fces {
 		ru.UpdateElementProof(&fce.StateElement)
-		db.fces[id] = fce
+		db.fces[id] = fce.Copy()
 	}
 	for id, fce := range db.v2fces {
 		ru.UpdateElementProof(&fce.StateElement)
-		db.v2fces[id] = fce
+		db.v2fces[id] = fce.Copy()
 	}
 }
 
@@ -164,23 +164,23 @@ func (db *consensusDB) supplementTipBlock(b types.Block) (bs V1BlockSupplement) 
 		ts := &bs.Transactions[i]
 		for _, sci := range txn.SiacoinInputs {
 			if sce, ok := db.sces[sci.ParentID]; ok {
-				ts.SiacoinInputs = append(ts.SiacoinInputs, sce)
+				ts.SiacoinInputs = append(ts.SiacoinInputs, sce.Copy())
 			}
 		}
 		for _, sfi := range txn.SiafundInputs {
 			if sfe, ok := db.sfes[sfi.ParentID]; ok {
-				ts.SiafundInputs = append(ts.SiafundInputs, sfe)
+				ts.SiafundInputs = append(ts.SiafundInputs, sfe.Copy())
 			}
 		}
 		for _, fcr := range txn.FileContractRevisions {
 			if fce, ok := db.fces[fcr.ParentID]; ok {
-				ts.RevisedFileContracts = append(ts.RevisedFileContracts, fce)
+				ts.RevisedFileContracts = append(ts.RevisedFileContracts, fce.Copy())
 			}
 		}
 		for _, sp := range txn.StorageProofs {
 			if fce, ok := db.fces[sp.ParentID]; ok {
 				ts.StorageProofs = append(ts.StorageProofs, V1StorageProofSupplement{
-					FileContract: fce,
+					FileContract: fce.Copy(),
 					WindowID:     db.blockIDs[fce.FileContract.WindowStart],
 				})
 			}
@@ -955,15 +955,15 @@ func TestValidateV2Block(t *testing.T) {
 	checkApplyUpdate(t, cs, au)
 	sces := make([]types.SiacoinElement, len(au.SiacoinElementDiffs()))
 	for i := range sces {
-		sces[i] = au.SiacoinElementDiffs()[i].SiacoinElement
+		sces[i] = au.SiacoinElementDiffs()[i].SiacoinElement.Copy()
 	}
 	sfes := make([]types.SiafundElement, len(au.SiafundElementDiffs()))
 	for i := range sfes {
-		sfes[i] = au.SiafundElementDiffs()[i].SiafundElement
+		sfes[i] = au.SiafundElementDiffs()[i].SiafundElement.Copy()
 	}
 	fces := make([]types.V2FileContractElement, len(au.V2FileContractElementDiffs()))
 	for i := range fces {
-		fces[i] = au.V2FileContractElementDiffs()[i].V2FileContractElement
+		fces[i] = au.V2FileContractElementDiffs()[i].V2FileContractElement.Copy()
 	}
 	cies := []types.ChainIndexElement{au.ChainIndexElement()}
 
@@ -982,11 +982,11 @@ func TestValidateV2Block(t *testing.T) {
 			Height: 1,
 			Transactions: []types.V2Transaction{{
 				SiacoinInputs: []types.V2SiacoinInput{{
-					Parent:          sces[0],
+					Parent:          sces[0].Copy(),
 					SatisfiedPolicy: types.SatisfiedPolicy{Policy: giftPolicy},
 				}},
 				SiafundInputs: []types.V2SiafundInput{{
-					Parent:          sfes[0],
+					Parent:          sfes[0].Copy(),
 					ClaimAddress:    types.VoidAddress,
 					SatisfiedPolicy: types.SatisfiedPolicy{Policy: giftPolicy},
 				}},
@@ -999,7 +999,7 @@ func TestValidateV2Block(t *testing.T) {
 				},
 				FileContracts: []types.V2FileContract{fc},
 				FileContractRevisions: []types.V2FileContractRevision{
-					{Parent: au.V2FileContractElementDiffs()[0].V2FileContractElement, Revision: rev1},
+					{Parent: au.V2FileContractElementDiffs()[0].V2FileContractElement.Copy(), Revision: rev1},
 				},
 				MinerFee: minerFee,
 			}},
@@ -1317,7 +1317,7 @@ func TestValidateV2Block(t *testing.T) {
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
 					txn.FileContractResolutions = append(txn.FileContractResolutions, types.V2FileContractResolution{
-						Parent:     fces[0],
+						Parent:     fces[0].Copy(),
 						Resolution: &types.V2FileContractExpiration{},
 					})
 				},
@@ -1362,15 +1362,15 @@ func TestValidateV2Block(t *testing.T) {
 
 	testSces := make([]types.SiacoinElement, len(testAU.SiacoinElementDiffs()))
 	for i := range testSces {
-		testSces[i] = testAU.SiacoinElementDiffs()[i].SiacoinElement
+		testSces[i] = testAU.SiacoinElementDiffs()[i].SiacoinElement.Copy()
 	}
 	testSfes := make([]types.SiafundElement, len(testAU.SiafundElementDiffs()))
 	for i := range testSfes {
-		testSfes[i] = testAU.SiafundElementDiffs()[i].SiafundElement
+		testSfes[i] = testAU.SiafundElementDiffs()[i].SiafundElement.Copy()
 	}
 	testFces := make([]types.V2FileContractElement, len(testAU.V2FileContractElementDiffs()))
 	for i := range testFces {
-		testFces[i] = testAU.V2FileContractElementDiffs()[i].V2FileContractElement
+		testFces[i] = testAU.V2FileContractElementDiffs()[i].V2FileContractElement.Copy()
 	}
 	cies = append(cies, testAU.ChainIndexElement())
 
@@ -1412,9 +1412,9 @@ func TestValidateV2Block(t *testing.T) {
 			Transactions: []types.V2Transaction{
 				{
 					FileContractResolutions: []types.V2FileContractResolution{{
-						Parent: testFces[0],
+						Parent: testFces[0].Copy(),
 						Resolution: &types.V2StorageProof{
-							ProofIndex: cies[len(cies)-2],
+							ProofIndex: cies[len(cies)-2].Copy(),
 							Leaf:       [64]byte{1},
 							Proof:      []types.Hash256{cs.StorageProofLeafHash([]byte{2})},
 						},
@@ -1429,7 +1429,7 @@ func TestValidateV2Block(t *testing.T) {
 	}
 	if cs.StorageProofLeafIndex(testFces[0].V2FileContract.Filesize, cies[len(cies)-2].ChainIndex.ID, types.FileContractID(testFces[0].ID)) == 1 {
 		b.V2.Transactions[0].FileContractResolutions[0].Resolution = &types.V2StorageProof{
-			ProofIndex: cies[len(cies)-2],
+			ProofIndex: cies[len(cies)-2].Copy(),
 			Leaf:       [64]byte{2},
 			Proof:      []types.Hash256{cs.StorageProofLeafHash([]byte{1})},
 		}
@@ -1455,7 +1455,7 @@ func TestValidateV2Block(t *testing.T) {
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
 					txn.SiacoinInputs = append(txn.SiacoinInputs, types.V2SiacoinInput{
-						Parent:          testSces[0],
+						Parent:          testSces[0].Copy(),
 						SatisfiedPolicy: types.SatisfiedPolicy{Policy: giftPolicy},
 					})
 				},
@@ -1465,7 +1465,7 @@ func TestValidateV2Block(t *testing.T) {
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
 					txn.SiafundInputs = append(txn.SiafundInputs, types.V2SiafundInput{
-						Parent:          testSfes[0],
+						Parent:          testSfes[0].Copy(),
 						SatisfiedPolicy: types.SatisfiedPolicy{Policy: giftPolicy},
 					})
 				},
@@ -1477,7 +1477,7 @@ func TestValidateV2Block(t *testing.T) {
 					rev := testFces[0].V2FileContract
 					rev.RevisionNumber++
 					txn.FileContractRevisions = []types.V2FileContractRevision{{
-						Parent:   testFces[0],
+						Parent:   testFces[0].Copy(),
 						Revision: rev,
 					}}
 				},
@@ -1487,9 +1487,9 @@ func TestValidateV2Block(t *testing.T) {
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
 					txn.FileContractResolutions = []types.V2FileContractResolution{{
-						Parent: testFces[0],
+						Parent: testFces[0].Copy(),
 						Resolution: &types.V2StorageProof{
-							ProofIndex: cies[len(cies)-1],
+							ProofIndex: cies[len(cies)-1].Copy(),
 						},
 					}}
 				},
@@ -1499,7 +1499,7 @@ func TestValidateV2Block(t *testing.T) {
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
 					txn.FileContractResolutions = []types.V2FileContractResolution{{
-						Parent:     testFces[0],
+						Parent:     testFces[0].Copy(),
 						Resolution: &types.V2FileContractExpiration{},
 					}}
 				},
@@ -1509,7 +1509,7 @@ func TestValidateV2Block(t *testing.T) {
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
 					txn.SiacoinInputs = []types.V2SiacoinInput{{
-						Parent:          sces[1],
+						Parent:          sces[1].Copy(),
 						SatisfiedPolicy: types.SatisfiedPolicy{Policy: giftPolicy},
 					}}
 
@@ -1518,7 +1518,7 @@ func TestValidateV2Block(t *testing.T) {
 						NewContract:       testFces[0].V2FileContract,
 					}
 					txn.FileContractResolutions = []types.V2FileContractResolution{{
-						Parent:     testFces[0],
+						Parent:     testFces[0].Copy(),
 						Resolution: &resolution,
 					}}
 				},
@@ -1528,7 +1528,7 @@ func TestValidateV2Block(t *testing.T) {
 				func(b *types.Block) {
 					txn := &b.V2.Transactions[0]
 					txn.SiacoinInputs = []types.V2SiacoinInput{{
-						Parent:          sces[1],
+						Parent:          sces[1].Copy(),
 						SatisfiedPolicy: types.SatisfiedPolicy{Policy: giftPolicy},
 					}}
 
@@ -1540,7 +1540,7 @@ func TestValidateV2Block(t *testing.T) {
 						NewContract:       rev,
 					}
 					txn.FileContractResolutions = []types.V2FileContractResolution{{
-						Parent:     testFces[0],
+						Parent:     testFces[0].Copy(),
 						Resolution: &resolution,
 					}}
 				},
@@ -1600,15 +1600,15 @@ func TestV2ImmatureSiacoinOutput(t *testing.T) {
 		checkApplyUpdate(t, cs, cau)
 		for _, sce := range cau.SiacoinElementDiffs() {
 			if sce.Spent {
-				delete(utxos, types.SiacoinOutputID(sce.SiacoinElement.ID))
+				delete(utxos, sce.SiacoinElement.ID)
 			} else if sce.SiacoinElement.SiacoinOutput.Address == addr {
-				utxos[types.SiacoinOutputID(sce.SiacoinElement.ID)] = sce.SiacoinElement
+				utxos[sce.SiacoinElement.ID] = sce.SiacoinElement.Copy()
 			}
 		}
 
 		for id, sce := range utxos {
 			cau.UpdateElementProof(&sce.StateElement)
-			utxos[id] = sce
+			utxos[id] = sce.Move()
 		}
 
 		db.applyBlock(cau)
@@ -1632,9 +1632,7 @@ func TestV2ImmatureSiacoinOutput(t *testing.T) {
 	// construct a transaction using the immature miner payout utxo
 	txn := types.V2Transaction{
 		SiacoinInputs: []types.V2SiacoinInput{
-			{
-				Parent: sce,
-			},
+			{Parent: sce.Copy()},
 		},
 		SiacoinOutputs: []types.SiacoinOutput{
 			{Address: types.VoidAddress, Value: sce.SiacoinOutput.Value},
@@ -1764,16 +1762,16 @@ func TestV2RevisionApply(t *testing.T) {
 				delete(fces, fce.V2FileContractElement.ID)
 			case fce.Revision != nil:
 				fce.V2FileContractElement.V2FileContract = *fce.Revision
-				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
+				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement.Copy()
 			default:
-				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
+				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement.Copy()
 			}
 		}
 
 		// update proofs
 		for key, fce := range fces {
 			au.UpdateElementProof(&fce.StateElement)
-			fces[key] = fce
+			fces[key] = fce.Move()
 		}
 	}
 
@@ -1801,7 +1799,7 @@ func TestV2RevisionApply(t *testing.T) {
 
 	txn1 := types.V2Transaction{
 		FileContractRevisions: []types.V2FileContractRevision{
-			{Parent: fces[contractID], Revision: rev1},
+			{Parent: fces[contractID].Copy(), Revision: rev1},
 		},
 	}
 
@@ -1818,7 +1816,7 @@ func TestV2RevisionApply(t *testing.T) {
 
 	txn2 := types.V2Transaction{
 		FileContractRevisions: []types.V2FileContractRevision{
-			{Parent: fces[contractID], Revision: rev2},
+			{Parent: fces[contractID].Copy(), Revision: rev2},
 		},
 	}
 	if err := ValidateV2Transaction(ms, txn2); err == nil {
@@ -1887,14 +1885,14 @@ func TestV2RenewalResolution(t *testing.T) {
 				delete(fces, fce.V2FileContractElement.ID)
 			case fce.Revision != nil:
 				fce.V2FileContractElement.V2FileContract = *fce.Revision
-				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
+				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement.Copy()
 			default:
-				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement
+				fces[fce.V2FileContractElement.ID] = fce.V2FileContractElement.Copy()
 			}
 		}
 		for _, sce := range au.SiacoinElementDiffs() {
 			if sce.SiacoinElement.ID == genesisOutput.ID {
-				genesisOutput = sce.SiacoinElement
+				genesisOutput = sce.SiacoinElement.Copy()
 				break
 			}
 		}
@@ -1903,7 +1901,7 @@ func TestV2RenewalResolution(t *testing.T) {
 		au.UpdateElementProof(&genesisOutput.StateElement)
 		for key, fce := range fces {
 			au.UpdateElementProof(&fce.StateElement)
-			fces[key] = fce
+			fces[key] = fce.Move()
 		}
 	}
 
@@ -2134,7 +2132,7 @@ func TestV2RenewalResolution(t *testing.T) {
 
 			renewTxn := types.V2Transaction{
 				FileContractResolutions: []types.V2FileContractResolution{{
-					Parent: fces[contractID],
+					Parent: fces[contractID].Copy(),
 					Resolution: &types.V2FileContractRenewal{
 						FinalRenterOutput: types.SiacoinOutput{Address: fc.RenterOutput.Address, Value: types.ZeroCurrency},
 						FinalHostOutput:   types.SiacoinOutput{Address: fc.HostOutput.Address, Value: types.ZeroCurrency},
@@ -2144,7 +2142,7 @@ func TestV2RenewalResolution(t *testing.T) {
 					},
 				}},
 				SiacoinInputs: []types.V2SiacoinInput{{
-					Parent: genesisOutput,
+					Parent: genesisOutput.Copy(),
 					SatisfiedPolicy: types.SatisfiedPolicy{
 						Policy: types.AnyoneCanSpend(),
 					},

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,9 @@ require (
 	golang.org/x/sys v0.31.0
 	lukechampine.com/frand v1.5.1
 )
+
+require (
+	golang.org/x/mod v0.24.0 // indirect
+	golang.org/x/sync v0.12.0 // indirect
+	golang.org/x/tools v0.31.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,16 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 go.sia.tech/mux v1.4.0 h1:LgsLHtn7l+25MwrgaPaUCaS8f2W2/tfvHIdXps04sVo=
 go.sia.tech/mux v1.4.0/go.mod h1:iNFi9ifFb2XhuD+LF4t2HBb4Mvgq/zIPKqwXU/NlqHA=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/tools v0.31.0 h1:0EedkvKDbh+qistFTd0Bcwe/YLh4vHwWEkiI0toFIBU=
+golang.org/x/tools v0.31.0/go.mod h1:naFTU+Cev749tSJRXJlna0T3WxKvb1kWEx15xA4SdmQ=
 lukechampine.com/frand v1.5.1 h1:fg0eRtdmGFIxhP5zQJzM1lFDbD6CUfu/f+7WgAZd5/w=
 lukechampine.com/frand v1.5.1/go.mod h1:4VstaWc2plN4Mjr10chUD46RAVGWhpkZ5Nja8+Azp0Q=

--- a/internal/lint/cmd/elmo/main.go
+++ b/internal/lint/cmd/elmo/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"go/ast"
+	"go/token"
+	"go/types"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/analysis/singlechecker"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+func run(pass *analysis.Pass) (any, error) {
+	check := func(e ast.Expr) {
+		switch e.(type) {
+		case *ast.CallExpr, *ast.CompositeLit:
+			return
+		}
+		if named, ok := pass.TypesInfo.TypeOf(e).(*types.Named); ok {
+			if obj := named.Obj(); obj.Pkg() != nil && obj.Pkg().Path() == "go.sia.tech/core/types" {
+				switch name := obj.Name(); name {
+				case "StateElement", "ChainIndexElement", "SiacoinElement", "SiafundElement",
+					"FileContractElement", "V2FileContractElement", "AttestationElement":
+					pass.Reportf(e.Pos(), "shallow copy of %s; use Move, Share, or Copy", name)
+				}
+			}
+		}
+	}
+
+	nodeFilter := []ast.Node{
+		(*ast.AssignStmt)(nil),
+		(*ast.CallExpr)(nil),
+		(*ast.CompositeLit)(nil),
+	}
+	inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	inspect.Preorder(nodeFilter, func(n ast.Node) {
+		switch node := n.(type) {
+		case *ast.AssignStmt:
+			if node.Tok == token.ASSIGN || node.Tok == token.DEFINE {
+				for i := range min(len(node.Lhs), len(node.Rhs)) {
+					check(node.Rhs[i])
+				}
+			}
+		case *ast.CallExpr:
+			for _, arg := range node.Args {
+				check(arg)
+			}
+		case *ast.CompositeLit:
+			for _, elt := range node.Elts {
+				if kve, ok := elt.(*ast.KeyValueExpr); ok {
+					check(kve.Value)
+				}
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+func main() {
+	singlechecker.Main(&analysis.Analyzer{
+		Name:     "elmo",
+		Doc:      "reports implicit StateElement memory management",
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Run:      run,
+	})
+}

--- a/types/multiproof_test.go
+++ b/types/multiproof_test.go
@@ -38,15 +38,15 @@ func multiproofTxns(numTxns int, numElems int) []types.V2Transaction {
 	cs, cau := consensus.ApplyBlock(cs, b, consensus.V1BlockSupplement{}, time.Time{})
 	sces := make([]types.SiacoinElement, len(cau.SiacoinElementDiffs()))
 	for i := range sces {
-		sces[i] = cau.SiacoinElementDiffs()[i].SiacoinElement
+		sces[i] = cau.SiacoinElementDiffs()[i].SiacoinElement.Copy()
 	}
 	sfes := make([]types.SiafundElement, len(cau.SiafundElementDiffs()))
 	for i := range sfes {
-		sfes[i] = cau.SiafundElementDiffs()[i].SiafundElement
+		sfes[i] = cau.SiafundElementDiffs()[i].SiafundElement.Copy()
 	}
 	fces := make([]types.V2FileContractElement, len(cau.V2FileContractElementDiffs()))
 	for i := range fces {
-		fces[i] = cau.V2FileContractElementDiffs()[i].V2FileContractElement
+		fces[i] = cau.V2FileContractElementDiffs()[i].V2FileContractElement.Copy()
 	}
 
 	// select randomly
@@ -64,21 +64,21 @@ func multiproofTxns(numTxns int, numElems int) []types.V2Transaction {
 			switch j % 4 {
 			case 0:
 				txn.SiacoinInputs, sces = append(txn.SiacoinInputs, types.V2SiacoinInput{
-					Parent:          sces[0],
+					Parent:          sces[0].Copy(),
 					SatisfiedPolicy: sp,
 				}), sces[1:]
 			case 1:
 				txn.SiafundInputs, sfes = append(txn.SiafundInputs, types.V2SiafundInput{
-					Parent:          sfes[0],
+					Parent:          sfes[0].Copy(),
 					SatisfiedPolicy: sp,
 				}), sfes[1:]
 			case 2:
 				txn.FileContractRevisions, fces = append(txn.FileContractRevisions, types.V2FileContractRevision{
-					Parent: fces[0],
+					Parent: fces[0].Copy(),
 				}), fces[1:]
 			case 3:
 				txn.FileContractResolutions, fces = append(txn.FileContractResolutions, types.V2FileContractResolution{
-					Parent:     fces[0],
+					Parent:     fces[0].Copy(),
 					Resolution: &types.V2FileContractExpiration{},
 				}), fces[1:]
 			}


### PR DESCRIPTION
This should go a long way towards catching memory aliasing bugs like https://github.com/SiaFoundation/core/pull/290. I should have done this ages ago. 😬 Basically, the linter flags anything like:
```go
sce := txn.SiacoinInputs[0].Parent // "shallow copy of SiacoinElement; use Move, Share, or Copy"
cau.UpdateElementProof(&sce)
```
To silence it, you annotate each copy with one of those ownership methods, and then we panic if you try to call `UpdateElementProof` on an element that you don't exclusively own.

Annotating every copy is kind of annoying, but it wasn't too onerous to churn through them once the linter was working. In case it's not clear, the idea is:
- Default to `Copy`.
- If you're not going to retain the element (e.g. if you're a function that just inspects elements and returns them), you can use `Share`. Putting the element inside of a struct (like a transaction) counts as retaining it! Usually, it's okay to use `Share` when passing an element to a function (and consequently, if you're a function that takes an element, you should treat it as shared).
- If you "own" the element and you just need to tweak it for whatever reason, you can use `Move`. This is most common when calling `UpdateElementProof` on each element in a map (since can't get a pointer to map values, you need to make a temporary copy, update that, then store it back in the map). `Move` is like `Share`, except you "retain ownership" so you're still allowed to update the proof.

One nice thing about this approach is that it's opt-in. If you're importing `core`, you don't *need* to be aware of any of this stuff, even if you're directly touching elements. But you are *encouraged* to run the linter on your code and annotate all your copies. I've done this with `coreutils` and it was pretty easy.

The biggest shortcoming is that this won't detect shallow copies of structs containing an element. For example, if you copy a transaction without `.DeepCopy`, it won't complain. Flagging every such copy would be impractical, since you would need to add `Copy`/`Share`/`Move` methods to *every* type containing an element.

Lastly -- yes, this is (to paraphrase Greenspun) "an ad hoc, informally-specified, bug-ridden, slow implementation of half of Rust."