### PR TITLE
Add mul to Usage

### DIFF
--- a/.changeset/add_mul_helper_to_usage_type.md
+++ b/.changeset/add_mul_helper_to_usage_type.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Add Mul helper to Usage type

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -89,6 +89,18 @@ func (u Usage) Add(b Usage) Usage {
 	}
 }
 
+// Mul returns the product of a Usage and a scalar.
+func (u Usage) Mul(n uint64) Usage {
+	return Usage{
+		RPC:              u.RPC.Mul64(n),
+		Storage:          u.Storage.Mul64(n),
+		Egress:           u.Egress.Mul64(n),
+		Ingress:          u.Ingress.Mul64(n),
+		AccountFunding:   u.AccountFunding.Mul64(n),
+		RiskedCollateral: u.RiskedCollateral.Mul64(n),
+	}
+}
+
 // HostPrices specify a time-bound set of parameters used to calculate the cost
 // of various RPCs.
 type HostPrices struct {


### PR DESCRIPTION
This adds a useful helper to `Usage`. e.g. when computing how much funds to put into a contract it's nice to be able to do `RPCAppendSectorCost.Mul(sectorsPerTiB)` or whatever. 