### PR TITLE
Update refresh validation to consider post refresh allowance and collateral

### DIFF
--- a/.changeset/consider_post_refresh_values_for_the_minrenterallowance_check_rather_than_the_additional_values.md
+++ b/.changeset/consider_post_refresh_values_for_the_minrenterallowance_check_rather_than_the_additional_values.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Consider post-refresh values for the minRenterAllowance check rather than the additional values.


### PR DESCRIPTION
I ran into a min allowance issue on Zen which made me reread this part of the code and I noticed that the current behavior for refreshing contracts is not necessarily what we want.

Before this PR, we make sure the ratio of newly added allowance and collateral is sane during a refresh. However, if a contract still has plenty of allowance left in it, this shouldn't affect our ability to refresh this contract without pouring more renter funds into it if the ratio is still sane *after* the refresh. 

So this PR changes the check to consider the ratio of unused collateral+allowance after the refresh rather than the one of the added values.