### PR TITLE
Add MaxHostCollateral

### DIFF
--- a/.changeset/add_maxhostcollateral_helper.md
+++ b/.changeset/add_maxhostcollateral_helper.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Add MaxHostCollateral helper

--- a/.changeset/removed_duration_parameter_from_minrenterallowance_helper.md
+++ b/.changeset/removed_duration_parameter_from_minrenterallowance_helper.md
@@ -1,0 +1,5 @@
+---
+default: major
+---
+
+# Removed `duration` parameter from MinRenterAllowance helper

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -773,6 +773,9 @@ func ReviseForReplenish(fc types.V2FileContract, amount types.Currency) (types.V
 // MinRenterAllowance returns the minimum allowance required to justify the given
 // host collateral.
 func MinRenterAllowance(hp HostPrices, collateral types.Currency) types.Currency {
+	if hp.Collateral.IsZero() {
+		return types.ZeroCurrency
+	}
 	maxCollateralBytes := collateral.Div(hp.Collateral)
 	return hp.StoragePrice.Mul(maxCollateralBytes)
 }
@@ -780,6 +783,9 @@ func MinRenterAllowance(hp HostPrices, collateral types.Currency) types.Currency
 // MaxHostCollateral returns the maximum amount of collateral a host can justify
 // to put into a contract for the given allowance.
 func MaxHostCollateral(hp HostPrices, allowance types.Currency) types.Currency {
+	if hp.StoragePrice.IsZero() {
+		return types.MaxCurrency
+	}
 	maxCollateralBytes := allowance.Div(hp.StoragePrice)
 	return hp.Collateral.Mul(maxCollateralBytes)
 }

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -772,9 +772,16 @@ func ReviseForReplenish(fc types.V2FileContract, amount types.Currency) (types.V
 
 // MinRenterAllowance returns the minimum allowance required to justify the given
 // host collateral.
-func MinRenterAllowance(hp HostPrices, duration uint64, collateral types.Currency) types.Currency {
-	maxCollateralBytes := collateral.Div(hp.Collateral).Div64(duration)
-	return hp.StoragePrice.Mul64(duration).Mul(maxCollateralBytes)
+func MinRenterAllowance(hp HostPrices, collateral types.Currency) types.Currency {
+	maxCollateralBytes := collateral.Div(hp.Collateral)
+	return hp.StoragePrice.Mul(maxCollateralBytes)
+}
+
+// MaxHostCollateral returns the maximum amount of collateral a host can justify
+// to put into a contract for the given allowance.
+func MaxHostCollateral(hp HostPrices, allowance types.Currency) types.Currency {
+	maxCollateralBytes := allowance.Div(hp.StoragePrice)
+	return hp.Collateral.Mul(maxCollateralBytes)
 }
 
 // RenewContract creates a contract renewal for the renew RPC

--- a/rhp/v4/rhp_test.go
+++ b/rhp/v4/rhp_test.go
@@ -9,17 +9,22 @@ import (
 	"lukechampine.com/frand"
 )
 
-func TestMinRenterAllowance(t *testing.T) {
+func TestMinRenterAllowanceMaxHostCollateral(t *testing.T) {
 	hp := HostPrices{
 		StoragePrice: types.NewCurrency64(1), // 1 H per byte per block
 		Collateral:   types.NewCurrency64(2), // 2 H per byte per block
 	}
 
 	collateral := types.Siacoins(2)
-	minAllowance := MinRenterAllowance(hp, 1, collateral)
+	minAllowance := MinRenterAllowance(hp, collateral)
 	expected := types.Siacoins(1)
 	if !minAllowance.Equals(expected) {
 		t.Fatalf("expected %v, got %v", expected, minAllowance)
+	}
+
+	maxCollateral := MaxHostCollateral(hp, minAllowance)
+	if !maxCollateral.Equals(collateral) {
+		t.Fatalf("expected %v, got %v", collateral, maxCollateral)
 	}
 }
 

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -127,9 +127,12 @@ func (req *RPCFormContractRequest) Validate(pk types.PublicKey, tip types.ChainI
 	// validate the contract fields
 	hp := req.Prices
 	expirationHeight := req.Contract.ProofHeight + ProofWindow
+	if expirationHeight < hp.TipHeight {
+		return errors.New("contract expiration height is in the past")
+	}
 	duration := expirationHeight - hp.TipHeight
 	// calculate the minimum allowance required for the contract based on the
-	// host's locked collateral and the contract duration
+	// host's locked collateral
 	minRenterAllowance := MinRenterAllowance(hp, req.Contract.Collateral)
 
 	switch {
@@ -167,6 +170,9 @@ func (req *RPCRenewContractRequest) Validate(pk types.PublicKey, tip types.Chain
 	// validate the contract fields
 	hp := req.Prices
 	expirationHeight := req.Renewal.ProofHeight + ProofWindow
+	if expirationHeight < hp.TipHeight {
+		return errors.New("contract expiration height is in the past")
+	}
 	duration := expirationHeight - hp.TipHeight
 	// calculate the minimum allowance required for the contract based on the
 	// host's locked collateral and the contract duration

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -130,7 +130,7 @@ func (req *RPCFormContractRequest) Validate(pk types.PublicKey, tip types.ChainI
 	duration := expirationHeight - hp.TipHeight
 	// calculate the minimum allowance required for the contract based on the
 	// host's locked collateral and the contract duration
-	minRenterAllowance := MinRenterAllowance(hp, duration, req.Contract.Collateral)
+	minRenterAllowance := MinRenterAllowance(hp, req.Contract.Collateral)
 
 	switch {
 	case expirationHeight <= tip.Height: // must be validated against tip instead of prices
@@ -170,7 +170,7 @@ func (req *RPCRenewContractRequest) Validate(pk types.PublicKey, tip types.Chain
 	duration := expirationHeight - hp.TipHeight
 	// calculate the minimum allowance required for the contract based on the
 	// host's locked collateral and the contract duration
-	minRenterAllowance := MinRenterAllowance(hp, duration, req.Renewal.Collateral)
+	minRenterAllowance := MinRenterAllowance(hp, req.Renewal.Collateral)
 	// collateral is risked for the entire contract duration
 	riskedCollateral := req.Prices.Collateral.Mul64(existingSize).Mul64(expirationHeight - req.Prices.TipHeight)
 	// renewals add collateral on top of the required risked collateral
@@ -216,7 +216,7 @@ func (req *RPCRefreshContractRequest) Validate(pk types.PublicKey, existingColla
 	// host's locked collateral and the contract duration
 	postRefreshAllowance := req.Refresh.Allowance.Add(existingAllowance)
 	postRefreshCollateral := req.Refresh.Collateral.Add(existingCollateral)
-	minRenterAllowance := MinRenterAllowance(hp, expirationHeight-req.Prices.TipHeight, postRefreshCollateral)
+	minRenterAllowance := MinRenterAllowance(hp, postRefreshCollateral)
 	// refreshes add collateral on top of the existing collateral
 	totalCollateral := req.Refresh.Collateral.Add(existingTotalCollateral)
 

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -127,9 +127,6 @@ func (req *RPCFormContractRequest) Validate(pk types.PublicKey, tip types.ChainI
 	// validate the contract fields
 	hp := req.Prices
 	expirationHeight := req.Contract.ProofHeight + ProofWindow
-	if expirationHeight < hp.TipHeight {
-		return errors.New("contract expiration height is in the past")
-	}
 	duration := expirationHeight - hp.TipHeight
 	// calculate the minimum allowance required for the contract based on the
 	// host's locked collateral
@@ -170,9 +167,6 @@ func (req *RPCRenewContractRequest) Validate(pk types.PublicKey, tip types.Chain
 	// validate the contract fields
 	hp := req.Prices
 	expirationHeight := req.Renewal.ProofHeight + ProofWindow
-	if expirationHeight < hp.TipHeight {
-		return errors.New("contract expiration height is in the past")
-	}
 	duration := expirationHeight - hp.TipHeight
 	// calculate the minimum allowance required for the contract based on the
 	// host's locked collateral and the contract duration


### PR DESCRIPTION
This PR adds `MaxHostCollateral` as a counterpart to `MinRenterAllowance`.

It also removes the `duration` since it doesn't affect the outcome of the functions since the ratio stays the same regardless of the duration.