### PR TITLE
Clean up validation

### DIFF
--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -705,7 +705,7 @@ func RefreshCost(cs consensus.State, p HostPrices, r types.V2FileContractRenewal
 	// because the existing renter and host outputs are rolled into the new contract to ensure the existing data
 	// is still covered by collateral.
 	renter = r.NewContract.RenterOutput.Value.Add(p.ContractPrice).Add(minerFee).Add(cs.V2FileContractTax(r.NewContract)).Sub(r.RenterRollover)
-	// new collateral = (existing revenue + contract price + existing revenue + new collateral + existing collateral) - contract price - (existing revenue + existing collateral)
+	// new collateral = (contract price + new collateral + existing revenue + existing collateral) - contract price - (existing revenue + existing collateral)
 	host = r.NewContract.HostOutput.Value.Sub(p.ContractPrice).Sub(r.HostRollover)
 	return
 }

--- a/rhp/v4/rhp_test.go
+++ b/rhp/v4/rhp_test.go
@@ -153,7 +153,7 @@ func TestRenewalCost(t *testing.T) {
 			prices.TipHeight = renewalHeight
 			renewal, _ := RenewContract(contract, prices, params)
 			tax := cs.V2FileContractTax(renewal.NewContract)
-			renter, host := RenewalCost(cs, prices, renewal, minerFee)
+			renter, host := RenewalCost(cs, renewal, minerFee)
 			if !renter.Equals(tc.RenterCost.Add(tax).Add(minerFee)) {
 				t.Errorf("expected renter cost %v, got %v", tc.RenterCost, renter.Sub(tax).Sub(minerFee))
 			} else if !host.Equals(tc.HostCost) {


### PR DESCRIPTION
Reverts #298 to the old behavior and removes unused params.

Looking at the original PR, #298, I think the logic change there is actually incorrect. It's not clear to me why a contract refresh would ever have plenty of allowance but not enough collateral since the funds always flow from the renter to the host. 

The subtest that got changed in https://github.com/SiaFoundation/coreutils/pull/215 should have been a valid state based on the intended behavior.

The desired behavior is that the host's total collateral locked is a consistent ratio with the renter's total spending. In the case of that subtest, the renter has locked `110 SC` total and the host has locked `220 SC` total. With the new logic, that is now considered a bad state because the renter spent `25 SC` of its allowance funding an account, giving it `85 SC` remaining allowance to `220 SC` collateral. The renter ends up needing to lock significantly more SC to compensate for the account spending.