### PR TITLE
Add address field

### DIFF
--- a/.changeset/adds_an_address_field_to_the_json_representation_of_siacoin_and_siafund_inputs.md
+++ b/.changeset/adds_an_address_field_to_the_json_representation_of_siacoin_and_siafund_inputs.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Adds an `address` field to the JSON representation of Siacoin and Siafund inputs.

--- a/types/types.go
+++ b/types/types.go
@@ -213,7 +213,9 @@ type SiacoinInput struct {
 	UnlockConditions UnlockConditions `json:"unlockConditions"`
 }
 
-// MarshalJSON implements json.Marshaller.
+// MarshalJSON implements json.Marshaler.
+//
+// For convenience, the input's address is also calculated and included. This field is ignored during unmarshalling.
 func (si SiacoinInput) MarshalJSON() ([]byte, error) {
 	type jsonSiacoinInput struct {
 		ParentID         SiacoinOutputID  `json:"parentID"`
@@ -259,7 +261,9 @@ type SiafundInput struct {
 	ClaimAddress     Address          `json:"claimAddress"`
 }
 
-// MarshalJSON implements json.Marshaller.
+// MarshalJSON implements json.Marshaler.
+//
+// For convenience, the input's address is also calculated and included. This field is ignored during unmarshalling.
 func (si SiafundInput) MarshalJSON() ([]byte, error) {
 	type jsonSiafundInput struct {
 		ParentID         SiafundOutputID  `json:"parentID"`
@@ -430,7 +434,7 @@ type Transaction struct {
 	Signatures            []TransactionSignature `json:"signatures,omitempty"`
 }
 
-// MarshalJSON implements json.Marshaller.
+// MarshalJSON implements json.Marshaler.
 //
 // For convenience, the transaction's ID is also calculated and included. This field is ignored during unmarshalling.
 func (txn Transaction) MarshalJSON() ([]byte, error) {
@@ -1265,7 +1269,7 @@ func (res *V2FileContractResolution) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// MarshalJSON implements json.Marshaller.
+// MarshalJSON implements json.Marshaler.
 //
 // For convenience, the transaction's ID is also calculated and included. This
 // field is ignored during unmarshalling.

--- a/types/types.go
+++ b/types/types.go
@@ -213,6 +213,20 @@ type SiacoinInput struct {
 	UnlockConditions UnlockConditions `json:"unlockConditions"`
 }
 
+// MarshalJSON implements json.Marshaller.
+func (si SiacoinInput) MarshalJSON() ([]byte, error) {
+	type jsonSiacoinInput struct {
+		ParentID         SiacoinOutputID  `json:"parentID"`
+		UnlockConditions UnlockConditions `json:"unlockConditions"`
+		Address          Address          `json:"address"`
+	}
+	return json.Marshal(jsonSiacoinInput{
+		ParentID:         si.ParentID,
+		UnlockConditions: si.UnlockConditions,
+		Address:          si.UnlockConditions.UnlockHash(),
+	})
+}
+
 // A SiafundOutput is the recipient of some of the siafunds spent in a
 // transaction.
 type SiafundOutput struct {
@@ -243,6 +257,22 @@ type SiafundInput struct {
 	ParentID         SiafundOutputID  `json:"parentID"`
 	UnlockConditions UnlockConditions `json:"unlockConditions"`
 	ClaimAddress     Address          `json:"claimAddress"`
+}
+
+// MarshalJSON implements json.Marshaller.
+func (si SiafundInput) MarshalJSON() ([]byte, error) {
+	type jsonSiafundInput struct {
+		ParentID         SiafundOutputID  `json:"parentID"`
+		UnlockConditions UnlockConditions `json:"unlockConditions"`
+		ClaimAddress     Address          `json:"claimAddress"`
+		Address          Address          `json:"address"`
+	}
+	return json.Marshal(jsonSiafundInput{
+		ParentID:         si.ParentID,
+		UnlockConditions: si.UnlockConditions,
+		Address:          si.UnlockConditions.UnlockHash(),
+		ClaimAddress:     si.ClaimAddress,
+	})
 }
 
 // A FileContract is a storage agreement between a renter and a host. It

--- a/types/types.go
+++ b/types/types.go
@@ -217,14 +217,12 @@ type SiacoinInput struct {
 //
 // For convenience, the input's address is also calculated and included. This field is ignored during unmarshalling.
 func (si SiacoinInput) MarshalJSON() ([]byte, error) {
-	type jsonSiacoinInput struct {
-		ParentID         SiacoinOutputID  `json:"parentID"`
-		UnlockConditions UnlockConditions `json:"unlockConditions"`
-		Address          Address          `json:"address"`
-	}
-	return json.Marshal(jsonSiacoinInput{
-		ParentID:         si.ParentID,
-		UnlockConditions: si.UnlockConditions,
+	type jsonSiacoinInput SiacoinInput // prevent recursion
+	return json.Marshal(struct {
+		jsonSiacoinInput
+		Address Address `json:"address"`
+	}{
+		jsonSiacoinInput: jsonSiacoinInput(si),
 		Address:          si.UnlockConditions.UnlockHash(),
 	})
 }
@@ -265,17 +263,13 @@ type SiafundInput struct {
 //
 // For convenience, the input's address is also calculated and included. This field is ignored during unmarshalling.
 func (si SiafundInput) MarshalJSON() ([]byte, error) {
-	type jsonSiafundInput struct {
-		ParentID         SiafundOutputID  `json:"parentID"`
-		UnlockConditions UnlockConditions `json:"unlockConditions"`
-		ClaimAddress     Address          `json:"claimAddress"`
-		Address          Address          `json:"address"`
-	}
-	return json.Marshal(jsonSiafundInput{
-		ParentID:         si.ParentID,
-		UnlockConditions: si.UnlockConditions,
+	type jsonSiafundInput SiafundInput // prevent recursion
+	return json.Marshal(struct {
+		jsonSiafundInput
+		Address Address `json:"address"`
+	}{
+		jsonSiafundInput: jsonSiafundInput(si),
 		Address:          si.UnlockConditions.UnlockHash(),
-		ClaimAddress:     si.ClaimAddress,
 	})
 }
 


### PR DESCRIPTION
Similar to the `id` field on Transactions, adds `address` to the json representation of Siacoin and Siafund inputs for ease of use in other languages.