### PR TITLE
consensus: Change Commitment to a Merkle root

### DIFF
--- a/consensus/application_test.go
+++ b/consensus/application_test.go
@@ -835,7 +835,7 @@ func TestApplyRevertBlockV2(t *testing.T) {
 	}
 	addBlock := func(b *types.Block) (au ApplyUpdate, err error) {
 		if b.V2 != nil {
-			b.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(b.Transactions, b.V2Transactions()), b.MinerPayouts[0].Address)
+			b.V2.Commitment = cs.Commitment(b.MinerPayouts[0].Address, b.Transactions, b.V2Transactions())
 		}
 		findBlockNonce(cs, b)
 		if err = ValidateBlock(cs, *b, V1BlockSupplement{}); err != nil {
@@ -1192,7 +1192,7 @@ func TestSiafunds(t *testing.T) {
 		if len(v2txns) > 0 {
 			b.V2 = &types.V2BlockData{
 				Height:       cs.Index.Height + 1,
-				Commitment:   cs.Commitment(cs.TransactionsCommitment(txns, v2txns), b.MinerPayouts[0].Address),
+				Commitment:   cs.Commitment(b.MinerPayouts[0].Address, txns, v2txns),
 				Transactions: v2txns,
 			}
 		}
@@ -1318,7 +1318,7 @@ func TestFoundationSubsidy(t *testing.T) {
 			MinerPayouts: []types.SiacoinOutput{{Address: types.VoidAddress, Value: cs.BlockReward()}},
 			V2: &types.V2BlockData{
 				Height:       cs.Index.Height + 1,
-				Commitment:   cs.Commitment(cs.TransactionsCommitment(nil, txns), types.VoidAddress),
+				Commitment:   cs.Commitment(types.VoidAddress, nil, txns),
 				Transactions: txns,
 			},
 		}

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1,0 +1,57 @@
+package consensus
+
+import (
+	"testing"
+
+	"go.sia.tech/core/internal/blake2b"
+	"go.sia.tech/core/types"
+	"lukechampine.com/frand"
+)
+
+// TestStratumBlockMerkleRoot tests the merkle root logic for
+// stratum miners to ensure it is compatible with existing
+// hardware.
+func TestStratumBlockMerkleRoot(t *testing.T) {
+	n, genesis := testnet()
+	n.HardforkV2.AllowHeight = 0
+
+	_, cs := newConsensusDB(n, genesis)
+
+	txns := make([]types.Transaction, frand.Intn(100))
+	for i := range txns {
+		txns[i].ArbitraryData = [][]byte{frand.Bytes(16)}
+	}
+	v2Txns := make([]types.V2Transaction, frand.Intn(100))
+	for i := range v2Txns {
+		v2Txns[i].ArbitraryData = frand.Bytes(16)
+	}
+
+	// build the commitment tree manually, leaving out the coinbase transaction
+	var acc blake2b.Accumulator
+	acc.AddLeaf(hashAll(uint8(0), "commitment", cs.v2ReplayPrefix(), types.Hash256(hashAll(cs)), types.VoidAddress))
+	for _, txn := range txns {
+		acc.AddLeaf(txn.FullHash())
+	}
+	for _, txn := range v2Txns {
+		acc.AddLeaf(txn.FullHash())
+	}
+
+	var trees []types.Hash256
+	for i, root := range acc.Trees {
+		if acc.NumLeaves&(1<<i) != 0 {
+			trees = append(trees, root)
+		}
+	}
+	coinbaseTxn := types.V2Transaction{
+		ArbitraryData: []byte("hello, world!"),
+	}
+	root := coinbaseTxn.FullHash()
+	for _, tree := range trees {
+		root = blake2b.SumPair(tree, root)
+	}
+
+	expectedRoot := cs.Commitment(types.VoidAddress, txns, append(v2Txns, coinbaseTxn))
+	if root != expectedRoot {
+		t.Fatalf("expected %q, got %q", expectedRoot, types.Hash256(root))
+	}
+}

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -928,7 +928,7 @@ func ValidateBlock(s State, b types.Block, bs V1BlockSupplement) error {
 		return fmt.Errorf("block supplement is invalid: %w", err)
 	}
 	if b.V2 != nil {
-		if b.V2.Commitment != s.Commitment(s.TransactionsCommitment(b.Transactions, b.V2Transactions()), b.MinerPayouts[0].Address) {
+		if b.V2.Commitment != s.Commitment(b.MinerPayouts[0].Address, b.Transactions, b.V2Transactions()) {
 			return errors.New("commitment hash mismatch")
 		}
 	}

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -1010,7 +1010,7 @@ func TestValidateV2Block(t *testing.T) {
 		}},
 	}
 	signTxn(cs, &b.V2.Transactions[0])
-	b.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(b.Transactions, b.V2Transactions()), b.MinerPayouts[0].Address)
+	b.V2.Commitment = cs.Commitment(b.MinerPayouts[0].Address, b.Transactions, b.V2Transactions())
 	findBlockNonce(cs, &b)
 
 	// initial block should be valid
@@ -1345,7 +1345,7 @@ func TestValidateV2Block(t *testing.T) {
 			test.corrupt(&corruptBlock)
 			signTxn(cs, &corruptBlock.V2.Transactions[0])
 			if len(corruptBlock.MinerPayouts) > 0 {
-				corruptBlock.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(corruptBlock.Transactions, corruptBlock.V2Transactions()), corruptBlock.MinerPayouts[0].Address)
+				corruptBlock.V2.Commitment = cs.Commitment(corruptBlock.MinerPayouts[0].Address, corruptBlock.Transactions, corruptBlock.V2Transactions())
 			}
 			findBlockNonce(cs, &corruptBlock)
 
@@ -1388,7 +1388,7 @@ func TestValidateV2Block(t *testing.T) {
 				Value:   cs.BlockReward(),
 			}},
 		}
-		b.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(b.Transactions, b.V2Transactions()), b.MinerPayouts[0].Address)
+		b.V2.Commitment = cs.Commitment(b.MinerPayouts[0].Address, b.Transactions, b.V2Transactions())
 
 		findBlockNonce(cs, &b)
 		if err := ValidateBlock(cs, b, db.supplementTipBlock(b)); err != nil {
@@ -1436,7 +1436,7 @@ func TestValidateV2Block(t *testing.T) {
 	}
 
 	signTxn(cs, &b.V2.Transactions[0])
-	b.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(b.Transactions, b.V2Transactions()), b.MinerPayouts[0].Address)
+	b.V2.Commitment = cs.Commitment(b.MinerPayouts[0].Address, b.Transactions, b.V2Transactions())
 	findBlockNonce(cs, &validBlock)
 
 	// initial block should be valid
@@ -1551,7 +1551,7 @@ func TestValidateV2Block(t *testing.T) {
 			test.corrupt(&corruptBlock)
 			signTxn(cs, &corruptBlock.V2.Transactions[0])
 			if len(corruptBlock.MinerPayouts) > 0 {
-				corruptBlock.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(corruptBlock.Transactions, corruptBlock.V2Transactions()), corruptBlock.MinerPayouts[0].Address)
+				corruptBlock.V2.Commitment = cs.Commitment(corruptBlock.MinerPayouts[0].Address, corruptBlock.Transactions, corruptBlock.V2Transactions())
 			}
 			findBlockNonce(cs, &corruptBlock)
 
@@ -1587,7 +1587,7 @@ func TestV2ImmatureSiacoinOutput(t *testing.T) {
 				Height:       cs.Index.Height + 1,
 				Transactions: v2Txns,
 			}
-			b.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(b.Transactions, b.V2Transactions()), minerAddr)
+			b.V2.Commitment = cs.Commitment(minerAddr, b.Transactions, b.V2Transactions())
 		}
 
 		findBlockNonce(cs, &b)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -32,7 +32,7 @@ func TestBlockOutline(t *testing.T) {
 			}},
 		},
 	}
-	b.V2.Commitment = cs.Commitment(cs.TransactionsCommitment(b.Transactions, b.V2Transactions()), b.MinerPayouts[0].Address)
+	b.V2.Commitment = cs.Commitment(b.MinerPayouts[0].Address, b.Transactions, b.V2Transactions())
 
 	bo := OutlineBlock(b, b.Transactions, b.V2Transactions())
 	if bo.ID(cs) != b.ID() {

--- a/gateway/outline.go
+++ b/gateway/outline.go
@@ -29,11 +29,23 @@ type V2BlockOutline struct {
 }
 
 func (bo V2BlockOutline) commitment(cs consensus.State) types.Hash256 {
+	h := types.NewHasher()
+	cs.EncodeTo(h.E)
+	stateHash := h.Sum()
+	h.Reset()
+	h.E.WriteUint8(0) // leafHashPrefix
+	h.WriteDistinguisher("commitment")
+	h.E.WriteUint8(2) // v2ReplayPrefix
+	stateHash.EncodeTo(h.E)
+	bo.MinerAddress.EncodeTo(h.E)
+	initLeaf := h.Sum()
+
 	var acc blake2b.Accumulator
+	acc.AddLeaf(initLeaf)
 	for _, txn := range bo.Transactions {
 		acc.AddLeaf(txn.Hash)
 	}
-	return cs.Commitment(acc.Root(), bo.MinerAddress)
+	return acc.Root()
 }
 
 // ID returns a hash that uniquely identifies the block.

--- a/types/hash_test.go
+++ b/types/hash_test.go
@@ -1,0 +1,63 @@
+package types
+
+import (
+	"testing"
+
+	"go.sia.tech/core/internal/blake2b"
+	"lukechampine.com/frand"
+)
+
+// TestStratumBlockMerkleRoot tests the merkle root logic for
+// stratum miners to ensure it is compatible with existing
+// hardware.
+func TestStratumBlockMerkleRoot(t *testing.T) {
+	minerPayouts := make([]SiacoinOutput, frand.Intn(100))
+	txns := make([]Transaction, frand.Intn(100))
+	for i := range minerPayouts {
+		minerPayouts[i].Address = frand.Entropy256()
+		minerPayouts[i].Value = NewCurrency64(frand.Uint64n(100))
+	}
+	for i := range txns {
+		txns[i].ArbitraryData = [][]byte{frand.Bytes(32)}
+	}
+
+	h := hasherPool.Get().(*Hasher)
+	defer hasherPool.Put(h)
+	var acc blake2b.Accumulator
+	for _, mp := range minerPayouts {
+		h.Reset()
+		h.E.WriteUint8(leafHashPrefix)
+		V1SiacoinOutput(mp).EncodeTo(h.E)
+		acc.AddLeaf(h.Sum())
+	}
+	for _, txn := range txns {
+		h.Reset()
+		h.E.WriteUint8(leafHashPrefix)
+		txn.EncodeTo(h.E)
+		acc.AddLeaf(h.Sum())
+	}
+
+	var trees []Hash256
+	for i, root := range acc.Trees {
+		if acc.NumLeaves&(1<<i) != 0 {
+			trees = append(trees, root)
+		}
+	}
+
+	coinbaseTxn := Transaction{
+		ArbitraryData: [][]byte{[]byte("hello, world!")},
+	}
+	h.Reset()
+	h.E.WriteUint8(0x00)
+	coinbaseTxn.EncodeTo(h.E)
+	root := h.Sum()
+
+	for _, tree := range trees {
+		root = blake2b.SumPair(tree, root)
+	}
+
+	expectedRoot := blockMerkleRoot(minerPayouts, append(txns, coinbaseTxn))
+	if root != expectedRoot {
+		t.Fatalf("expected %x, got %x", expectedRoot, root)
+	}
+}


### PR DESCRIPTION
This restores compatibility with the Stratum mining protocol. Stratum servers simply need to include an additional leaf hash when computing the Merkle tree:
```go
hashAll(uint8(0), "commitment", s.v2ReplayPrefix(), types.Hash256(hashAll(s)), minerAddr)
```

Of course, once the RequireHeight is reached and v1 transactions are no longer allowed, they will also need to adjust the `Coinbase1` and `Coinbase2` values they send, to account for the different encoding of v2 transactions.