### PR TITLE
v2: The Final Cut

### DIFF
--- a/.changeset/v2-the-final-cut.md
+++ b/.changeset/v2-the-final-cut.md
@@ -1,0 +1,15 @@
+---
+default: major
+---
+
+# Add FinalCut difficulty adjustment
+
+The v2 difficulty adjustment algorithm is buggy, leading to higher variance in observed block times. We've fixed the algorithm and confirmed that it exhibits the correct behavior in simulations.
+
+# Add (State).PowTarget and deprecate v1 fields
+
+The `consensus.State` type contains several redundant and unused PoW-related fields. However, since these fields were included in the Commitment hash, nodes still had to update them correctly. These fields are now zeroed after the hardfork height, so that the Commitment hash can hard-code them if desired.
+
+# Allow empty miner payout after FinalCut
+
+A remnant of the old v1 `types.Currency` encoding persists in the `Block.MinerPayouts` field. In v2, only a single miner payout is allowed, so its value is fully determined by the sum of the block reward and miner fees. We can therefore omit the value entirely, eliminating a redundant source of truth. It was decided that *requiring* the value to be omitted was too onerous, as it would compel all miners to update. Making the omission optional allows us to enforce it as a hard requirement at some later time, after all miners have updated.

--- a/consensus/application.go
+++ b/consensus/application.go
@@ -388,6 +388,12 @@ func ApplyHeader(s State, bh types.BlockHeader, targetTimestamp time.Time) State
 	}
 	next.PrevTimestamps[0] = bh.Timestamp
 	copy(next.PrevTimestamps[1:], s.PrevTimestamps[:])
+
+	// zero out deprecated fields
+	if next.Index.Height >= next.Network.HardforkV2.FinalCutHeight {
+		next.Depth, next.ChildTarget, next.OakTarget = types.BlockID{}, types.BlockID{}, types.BlockID{}
+	}
+
 	return next
 }
 

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -123,13 +123,13 @@ type State struct {
 
 	Index             types.ChainIndex `json:"index"`
 	PrevTimestamps    [11]time.Time    `json:"prevTimestamps"` // newest -> oldest
-	Depth             types.BlockID    `json:"depth"`
-	ChildTarget       types.BlockID    `json:"childTarget"`
+	Depth             types.BlockID    `json:"depth"`          // DEPRECATED: use TotalWork
+	ChildTarget       types.BlockID    `json:"childTarget"`    // DEPRECATED: use PoWTarget or Difficulty
 	SiafundTaxRevenue types.Currency   `json:"siafundTaxRevenue"`
 
 	// Oak hardfork state
 	OakTime   time.Duration `json:"oakTime"`
-	OakTarget types.BlockID `json:"oakTarget"`
+	OakTarget types.BlockID `json:"oakTarget"` // DEPRECATED: use OakWork
 	// Foundation hardfork state
 	FoundationSubsidyAddress    types.Address `json:"foundationSubsidyAddress"`
 	FoundationManagementAddress types.Address `json:"foundationManagementAddress"`
@@ -247,6 +247,14 @@ func (s State) BlockReward() types.Currency {
 		return s.Network.MinimumCoinbase
 	}
 	return r
+}
+
+// PoWTarget returns the proof-of-work target for the child block.
+func (s State) PoWTarget() types.BlockID {
+	if s.childHeight() < s.Network.HardforkV2.FinalCutHeight {
+		return s.ChildTarget
+	}
+	return invTarget(s.Difficulty.n)
 }
 
 // MaturityHeight is the height at which various outputs created in the child

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -90,8 +90,9 @@ type Network struct {
 		FailsafeAddress types.Address `json:"failsafeAddress"`
 	} `json:"hardforkFoundation"`
 	HardforkV2 struct {
-		AllowHeight   uint64 `json:"allowHeight"`
-		RequireHeight uint64 `json:"requireHeight"`
+		AllowHeight    uint64 `json:"allowHeight"`
+		RequireHeight  uint64 `json:"requireHeight"`
+		FinalCutHeight uint64 `json:"finalCutHeight"`
 	} `json:"hardforkV2"`
 }
 

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -22,7 +22,7 @@ func ValidateHeader(s State, bh types.BlockHeader) error {
 		return errors.New("timestamp too far in the past")
 	} else if bh.Nonce%s.NonceFactor() != 0 {
 		return errors.New("nonce not divisible by required factor")
-	} else if bh.ID().CmpWork(s.ChildTarget) < 0 {
+	} else if bh.ID().CmpWork(s.PoWTarget()) < 0 {
 		return errors.New("insufficient work")
 	}
 	return nil

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -211,7 +211,7 @@ func findBlockNonce(cs State, b *types.Block) {
 	for b.Nonce%cs.NonceFactor() != 0 {
 		b.Nonce++
 	}
-	for b.ID().CmpWork(cs.ChildTarget) < 0 {
+	for b.ID().CmpWork(cs.PoWTarget()) < 0 {
 		b.Nonce += cs.NonceFactor()
 	}
 }

--- a/consensus/validation_test.go
+++ b/consensus/validation_test.go
@@ -38,6 +38,7 @@ func testnet() (*Network, types.Block) {
 	n.HardforkFoundation.FailsafeAddress = types.VoidAddress
 	n.HardforkV2.AllowHeight = 1000
 	n.HardforkV2.RequireHeight = 2000
+	n.HardforkV2.FinalCutHeight = 3000
 	b := types.Block{Timestamp: n.HardforkOak.GenesisTimestamp}
 	return n, b
 }


### PR DESCRIPTION
The difficulty adjustment algorithm in v2 was intended to be a straight port of v1, merely swapping "target" for "difficulty" and cleaning up some historic cruft. Unfortunately, it also introduced a bug, which has led to increased variance in block times. This caused the v2 require height to be reached earlier than expected. Block times have slowly normalized, but until the bug is fixed, there is no guarantee they will remain normal.

After reviewing the v1 algorithm, I have opted to change the squared error term to a proportional error, with the same target of "10,000 seconds of drift = 10 seconds of shift." Squaring the error means that, when approaching zero, the adjustment shrinks faster than the error does, meaning we never quite reach zero error. It also does not correct large errors more quickly, as the 0.4% limit precludes any large adjustments anyway.

I have run a thorough suite of simulations on the three adjustment algorithms, and this one is the clear winner. It smoothly corrects the existing drift, without triggering large spikes or dips in difficulty, and it fully attenuates to zero instead of asymptotically approaching it.

Changing the algorithm requires a hardfork, so I decided to include two other small fixes alongside this one. First, v2 blocks no longer include the value of their miner payout. v2 blocks are already restricted to a single payout, and there is only one legal value for that payout: the block reward plus the sum of the transaction fees. It is good practice to remove multiple sources of truth; there is one less piece of information to verify. Second, the commitment hash no longer includes deprecated State fields, namely `Depth`, `ChildTarget`, and `OakTarget` (which are equivalent to `TotalWork`, `Difficulty`, and `OakWork`, respectively). Covering these fields meant that all nodes had to accurately maintain them, for no reason. These changes mainly benefit v2-native nodes; it allows them to use different representations of the `Block` and `State` types.

We can decide on the mainnet `FinalCutHeight` in the subsequent coreutils PR. I think 60 days is reasonable, but due to high block time variance, I'll need to run more simulations to accurately map that duration to a block height.