### PR TITLE
Add version to RPCs

### DIFF
--- a/rhp/v4/encoding.go
+++ b/rhp/v4/encoding.go
@@ -6,16 +6,6 @@ import (
 	"go.sia.tech/core/types"
 )
 
-func (h *RPCHeader) encodeTo(e *types.Encoder) {
-	e.Write(h.ID[:])
-	e.WriteUint8(h.Version)
-}
-
-func (h *RPCHeader) decodeFrom(d *types.Decoder) {
-	d.Read(h.ID[:])
-	h.Version = d.ReadUint8()
-}
-
 // EncodeTo implements types.EncoderTo.
 func (ad AccountDeposit) EncodeTo(e *types.Encoder) {
 	ad.Account.EncodeTo(e)

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -38,55 +38,50 @@ const (
 )
 
 // An RPCSpecifier uniquely identifies an RPC.
-type RPCSpecifier [15]byte
-
-// An RPCHeader pairs an RPC's specifier with a version number.
-type RPCHeader struct {
-	ID      RPCSpecifier
-	Version uint8
-}
+type RPCSpecifier types.Specifier
 
 // String implements fmt.Stringer.
-func (rh RPCHeader) String() string {
-	b := string(bytes.TrimRight(rh.ID[:], "\x00"))
+func (rs RPCSpecifier) String() string {
+	b := string(bytes.TrimRight(rs[:15], "\x00"))
 	for _, c := range b {
 		if !(('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9')) {
 			return strconv.Quote(b)
 		}
 	}
-	return fmt.Sprintf("%s.%d", b, rh.Version)
+	return fmt.Sprintf("%s.%d", b, rs[15])
+}
+
+func rpcSpecifier(name string, version uint8) (s RPCSpecifier) {
+	// last byte is the version, ensure the name is at most 15 bytes
+	if len(name) > len(s)-1 {
+		panic(fmt.Sprintf("ID too long: len(%q) > 15", name))
+	}
+	copy(s[:15], name)
+	s[15] = version
+	return
 }
 
 // RPC identifiers.
 var (
-	RPCAccountBalanceID    = rpcSpecifier("AccountBalance")
-	RPCFundAccountsID      = rpcSpecifier("FundAccounts")
-	RPCReplenishAccountsID = rpcSpecifier("ReplAccounts")
+	RPCAccountBalanceID    = rpcSpecifier("AccountBalance", 0)
+	RPCFundAccountsID      = rpcSpecifier("FundAccounts", 0)
+	RPCReplenishAccountsID = rpcSpecifier("ReplAccounts", 0)
 
-	RPCAppendSectorsID = rpcSpecifier("AppendSectors")
-	RPCFreeSectorsID   = rpcSpecifier("FreeSectors")
-	RPCSectorRootsID   = rpcSpecifier("SectorRoots")
+	RPCAppendSectorsID = rpcSpecifier("AppendSectors", 0)
+	RPCFreeSectorsID   = rpcSpecifier("FreeSectors", 0)
+	RPCSectorRootsID   = rpcSpecifier("SectorRoots", 0)
 
-	RPCFormContractID        = rpcSpecifier("FormContract")
-	RPCLatestRevisionID      = rpcSpecifier("LatestRevision")
-	RPCRefreshContractID     = rpcSpecifier("RefreshContract")
-	RPCRefreshContractRev1ID = rpcSpecifier("RefreshContract")
-	RPCRenewContractID       = rpcSpecifier("RenewContract")
+	RPCFormContractID        = rpcSpecifier("FormContract", 0)
+	RPCLatestRevisionID      = rpcSpecifier("LatestRevision", 0)
+	RPCRefreshContractID     = rpcSpecifier("RefreshContract", 0)
+	RPCRefreshContractRev1ID = rpcSpecifier("RefreshContract", 1)
+	RPCRenewContractID       = rpcSpecifier("RenewContract", 0)
 
-	RPCReadSectorID   = rpcSpecifier("ReadSector")
-	RPCWriteSectorID  = rpcSpecifier("WriteSector")
-	RPCVerifySectorID = rpcSpecifier("VerifySector")
-	RPCSettingsID     = rpcSpecifier("Settings")
+	RPCReadSectorID   = rpcSpecifier("ReadSector", 0)
+	RPCWriteSectorID  = rpcSpecifier("WriteSector", 0)
+	RPCVerifySectorID = rpcSpecifier("VerifySector", 0)
+	RPCSettingsID     = rpcSpecifier("Settings", 0)
 )
-
-func rpcSpecifier(name string) (s RPCSpecifier) {
-	// last byte is the version, ensure the name is at most 15 bytes
-	if len(name) > len(s) {
-		panic(fmt.Sprintf("ID too long: len(%q) > 15", name))
-	}
-	copy(s[:], name)
-	return
-}
 
 func round4KiB(n uint64) uint64 {
 	return (n + (1<<12 - 1)) &^ (1<<12 - 1)

--- a/rhp/v4/transport.go
+++ b/rhp/v4/transport.go
@@ -18,16 +18,16 @@ func withDecoder(r io.Reader, maxLen int, fn func(*types.Decoder)) error {
 	return d.Err()
 }
 
-// ReadHeader reads an RPC header from the stream.
-func ReadHeader(r io.Reader) (id RPCHeader, err error) {
-	err = withDecoder(r, 16, id.decodeFrom)
+// ReadID reads an RPC header from the stream.
+func ReadID(r io.Reader) (id RPCSpecifier, err error) {
+	err = withDecoder(r, 16, (*types.Specifier)(&id).DecodeFrom)
 	return
 }
 
 // WriteRequest writes a request to the stream.
-func WriteRequest(w io.Writer, header RPCHeader, o Object) error {
+func WriteRequest(w io.Writer, id RPCSpecifier, o Object) error {
 	return withEncoder(w, func(e *types.Encoder) {
-		header.encodeTo(e)
+		types.Specifier(id).EncodeTo(e)
 		if o == nil {
 			return
 		}


### PR DESCRIPTION
Changes the last byte of the RPC ID to a version byte. Preserves backwards compatibility since existing RPCs already have 0.

The reason for the change is a desire to change the renter rollover logic of RPCRefresh. Currently, we add the allowance on top of the remaining allowance and roll everything into the new contract. This is different from renewals and formations where the `Allowance` param is the value the renter wants for their allowance.

We could add a new specifier instead, but this felt better than the potential of having a bunch of `types.NewSpecifier("RPCRefresh2").