### PR TITLE
`Account.Token` -> `NewToken`

### DIFF
--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -262,9 +262,9 @@ func (a *Account) UnmarshalText(b []byte) error {
 	return nil
 }
 
-// Token returns a signed account token authorizing spending from the account on the
-// host.
-func (a *Account) Token(renterKey types.PrivateKey, hostKey types.PublicKey) AccountToken {
+// NewToken returns a signed account token authorizing spending from the
+// account on the host.
+func NewToken(renterKey types.PrivateKey, hostKey types.PublicKey) AccountToken {
 	token := AccountToken{
 		HostKey:    hostKey,
 		Account:    Account(renterKey.PublicKey()),


### PR DESCRIPTION
This method does not use any of the fields on `Account`