### PR TITLE
Always return bad requests from validation functions

### DIFF
--- a/.changeset/fixed_issue_with_rpc_validation_functions_not_returning_rpc_errors.md
+++ b/.changeset/fixed_issue_with_rpc_validation_functions_not_returning_rpc_errors.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fixed issue with RPC validation functions not returning RPC errors.

--- a/rhp/v4/errors.go
+++ b/rhp/v4/errors.go
@@ -21,6 +21,9 @@ type RPCError struct {
 }
 
 var (
+	// ErrHostKeyMismatch is returned when the host key in an account token does
+	// not match the public key of the host.
+	ErrHostKeyMismatch = NewRPCError(ErrorCodeBadRequest, "host key mismatch")
 	// ErrTokenExpired is returned when an account token has expired.
 	ErrTokenExpired = NewRPCError(ErrorCodeBadRequest, "account token expired")
 	// ErrPricesExpired is returned when the host's prices have expired.


### PR DESCRIPTION
Noticed one of my hosts returning internal errors on my renter node. Checked the host's log and found that the RPC was failing due to an invalid request from the renter. This PR ensures all the existing `Validate` code paths return a RPC error instead of a naked error.