### PR TITLE
Document `V2FileContract` type and add useful helpers for revenue calculations

### DIFF
--- a/.changeset/expose_helper_methods_to_compute_the_remaining_allowance_collateral_risked_collateral_and_risked_revenue_on_the_v2filecontract_type.md
+++ b/.changeset/expose_helper_methods_to_compute_the_remaining_allowance_collateral_risked_collateral_and_risked_revenue_on_the_v2filecontract_type.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Expose helper methods to compute the remaining allowance, collateral, risked collateral and risked revenue on the V2FileContract type.

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -858,7 +858,7 @@ func RenewContract(fc types.V2FileContract, prices HostPrices, rp RPCRenewContra
 	return renewal, Usage{
 		RPC:              prices.ContractPrice,
 		Storage:          renewal.NewContract.HostOutput.Value.Sub(renewal.NewContract.TotalCollateral).Sub(prices.ContractPrice),
-		RiskedCollateral: renewal.NewContract.TotalCollateral.Sub(renewal.NewContract.MissedHostValue),
+		RiskedCollateral: renewal.NewContract.RiskedCollateral(),
 	}
 }
 
@@ -877,8 +877,8 @@ func RefreshContractPartialRollover(fc types.V2FileContract, prices HostPrices, 
 	// the host output needs to cover the existing risked collateral,
 	// existing revenue, and the new collateral to ensure the existing data
 	// is still protected.
-	hostRevenueRisked := fc.HostOutput.Value.Sub(fc.MissedHostValue)
-	hostRiskedCollateral := fc.TotalCollateral.Sub(fc.MissedHostValue)
+	hostRevenueRisked := fc.RiskedHostRevenue()
+	hostRiskedCollateral := fc.RiskedCollateral()
 	// the valid output is the sum of the existing revenue, existing risked collateral,
 	// the new collateral, and the contract price.
 	renewal.NewContract.HostOutput.Value = hostRevenueRisked.Add(rp.Collateral).Add(prices.ContractPrice)
@@ -944,6 +944,6 @@ func RefreshContractFullRollover(fc types.V2FileContract, prices HostPrices, rp 
 	return renewal, Usage{
 		// Refresh usage is only the contract price since duration is not increased
 		RPC:              prices.ContractPrice,
-		RiskedCollateral: renewal.NewContract.TotalCollateral.Sub(renewal.NewContract.MissedHostValue),
+		RiskedCollateral: renewal.NewContract.RiskedCollateral(),
 	}
 }

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -877,8 +877,8 @@ func RefreshContractPartialRollover(fc types.V2FileContract, prices HostPrices, 
 	// the host output needs to cover the existing risked collateral,
 	// existing revenue, and the new collateral to ensure the existing data
 	// is still protected.
-	hostRevenueRisked := fc.RiskedHostRevenue()
 	hostRiskedCollateral := fc.RiskedCollateral()
+	hostRevenueRisked := fc.RiskedHostRevenue().Add(hostRiskedCollateral)
 	// the valid output is the sum of the existing revenue, existing risked collateral,
 	// the new collateral, and the contract price.
 	renewal.NewContract.HostOutput.Value = hostRevenueRisked.Add(rp.Collateral).Add(prices.ContractPrice)

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -877,17 +877,15 @@ func RefreshContractPartialRollover(fc types.V2FileContract, prices HostPrices, 
 	// the host output needs to cover the existing risked collateral,
 	// existing revenue, and the new collateral to ensure the existing data
 	// is still protected.
-	hostRiskedCollateral := fc.RiskedCollateral()
-	hostRevenueRisked := fc.RiskedHostRevenue().Add(hostRiskedCollateral)
-	// the valid output is the sum of the existing revenue, existing risked collateral,
-	// the new collateral, and the contract price.
-	renewal.NewContract.HostOutput.Value = hostRevenueRisked.Add(rp.Collateral).Add(prices.ContractPrice)
+	// so the valid output is the sum of the existing revenue, existing risked
+	// collateral, the new collateral, and the contract price.
+	renewal.NewContract.HostOutput.Value = fc.RiskedHostRevenue().Add(fc.RiskedCollateral()).Add(rp.Collateral).Add(prices.ContractPrice)
 	// the missed host value only returns the new collateral since the
 	// existing risked collateral and revenue should be burned on failure.
 	renewal.NewContract.MissedHostValue = rp.Collateral
 	// total collateral is the sum of the existing risked collateral and
 	// the new locked collateral.
-	renewal.NewContract.TotalCollateral = hostRiskedCollateral.Add(rp.Collateral)
+	renewal.NewContract.TotalCollateral = fc.RiskedCollateral().Add(rp.Collateral)
 
 	// if the existing host output is greater than the new contract's lock up,
 	// only roll over the new required collateral. Otherwise, roll over the
@@ -915,7 +913,7 @@ func RefreshContractPartialRollover(fc types.V2FileContract, prices HostPrices, 
 	return renewal, Usage{
 		// Refresh usage is only the contract price since duration is not increased
 		RPC:              prices.ContractPrice,
-		RiskedCollateral: hostRiskedCollateral,
+		RiskedCollateral: renewal.NewContract.RiskedCollateral(),
 	}
 }
 

--- a/rhp/v4/rhp_test.go
+++ b/rhp/v4/rhp_test.go
@@ -434,8 +434,8 @@ func TestRefreshPartialRolloverCost(t *testing.T) {
 				t.Fatalf("expected ingress usage to be zero, got %v", usage.Ingress)
 			} else if !usage.Egress.IsZero() {
 				t.Fatalf("expected egress usage to be zero, got %v", usage.Egress)
-			} else if !usage.RiskedCollateral.Equals(contract.TotalCollateral.Sub(contract.MissedHostValue)) {
-				t.Fatalf("expected risked collateral %v, got %v", contract.TotalCollateral.Sub(contract.MissedHostValue), usage.RiskedCollateral)
+			} else if !usage.RiskedCollateral.Equals(contract.RiskedCollateral()) {
+				t.Fatalf("expected risked collateral %v, got %v", contract.RiskedCollateral(), usage.RiskedCollateral)
 			} else if refresh.HostSignature != (types.Signature{}) {
 				t.Fatal("expected host signature to be unset")
 			} else if refresh.RenterSignature != (types.Signature{}) {

--- a/types/types.go
+++ b/types/types.go
@@ -616,7 +616,7 @@ func (fc V2FileContract) RiskedCollateral() Currency {
 // RiskedHostRevenue is the amount of revenue that a host gets if the contract
 // resolves successfully via storage proof or renewal.
 func (fc V2FileContract) RiskedHostRevenue() Currency {
-	return fc.HostOutput.Value.Sub(fc.MissedHostValue)
+	return fc.HostOutput.Value.Sub(fc.TotalCollateral)
 }
 
 // A V2SiacoinInput spends an unspent SiacoinElement in the state accumulator by

--- a/types/types.go
+++ b/types/types.go
@@ -581,7 +581,7 @@ type V2FileContract struct {
 	// previous revisions.
 	RevisionNumber uint64 `json:"revisionNumber"`
 
-	// The signatures cover above fields.
+	// Signatures cover above fields
 	RenterSignature Signature `json:"renterSignature"`
 	HostSignature   Signature `json:"hostSignature"`
 }


### PR DESCRIPTION
Since the revenue related contract fields are not the easiest to wrap you head around I added some documentation on the `V2FileContract` type as well as helpers for some frequently done math. 

I also added `RemainingAllowance` and `RemainingCollateral` which are more or less just aliases but imo they still make contracts nicer to use. The fields `MissedHostValue` and `RenterOutput` are technically correct but make more sense when looked at in the context of the consensus code and the methods `RemainingCollateral` and `RemainingAllowance` feel more intuitive when used in the context of the RHP.