### PR TITLE
Timestamp-based fork experiment

### DIFF
--- a/consensus/application.go
+++ b/consensus/application.go
@@ -357,7 +357,7 @@ func adjustDifficulty(s State, blockTimestamp time.Time, targetTimestamp time.Ti
 	case s.childHeight() < s.Network.HardforkV2.AllowHeight:
 		target := adjustTarget(s, blockTimestamp, targetTimestamp)
 		return Work{invTarget(target)}, target
-	case s.childHeight() < s.Network.HardforkV2.FinalCutHeight:
+	case !s.medianTimestamp().After(s.Network.HardforkV2.FinalCutTime):
 		difficulty := adjustDifficultyV2(s, blockTimestamp)
 		return difficulty, invTarget(difficulty.n)
 	default:
@@ -390,7 +390,7 @@ func ApplyHeader(s State, bh types.BlockHeader, targetTimestamp time.Time) State
 	copy(next.PrevTimestamps[1:], s.PrevTimestamps[:])
 
 	// zero out deprecated fields
-	if next.Index.Height >= next.Network.HardforkV2.FinalCutHeight {
+	if next.medianTimestamp().After(next.Network.HardforkV2.FinalCutTime) {
 		next.Depth, next.ChildTarget, next.OakTarget = types.BlockID{}, types.BlockID{}, types.BlockID{}
 	}
 

--- a/consensus/application_test.go
+++ b/consensus/application_test.go
@@ -1415,7 +1415,13 @@ func TestAdjustDifficulty(t *testing.T) {
 	n, _ := testnet()
 	n.BlockInterval = 10 * time.Minute
 	cs := n.GenesisState()
-	cs.Index.Height = n.HardforkV2.FinalCutHeight
+	cs.Index.Height = n.HardforkV2.RequireHeight + 100
+
+	// ensure median timestamp is above final cut time
+	for i := range cs.PrevTimestamps {
+		cs.PrevTimestamps[i] = n.HardforkV2.FinalCutTime.Add(time.Second)
+	}
+
 	cs.Difficulty.UnmarshalText([]byte("18000000000"))
 	cs.ChildTarget = invTarget(cs.Difficulty.n)
 	cs.OakTime = n.BlockInterval

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -90,9 +90,9 @@ type Network struct {
 		FailsafeAddress types.Address `json:"failsafeAddress"`
 	} `json:"hardforkFoundation"`
 	HardforkV2 struct {
-		AllowHeight    uint64 `json:"allowHeight"`
-		RequireHeight  uint64 `json:"requireHeight"`
-		FinalCutHeight uint64 `json:"finalCutHeight"`
+		AllowHeight   uint64    `json:"allowHeight"`
+		RequireHeight uint64    `json:"requireHeight"`
+		FinalCutTime  time.Time `json:"finalCutTime"`
 	} `json:"hardforkV2"`
 }
 
@@ -251,7 +251,7 @@ func (s State) BlockReward() types.Currency {
 
 // PoWTarget returns the proof-of-work target for the child block.
 func (s State) PoWTarget() types.BlockID {
-	if s.childHeight() < s.Network.HardforkV2.FinalCutHeight {
+	if !s.medianTimestamp().After(s.Network.HardforkV2.FinalCutTime) {
 		return s.ChildTarget
 	}
 	return invTarget(s.Difficulty.n)

--- a/consensus/validation.go
+++ b/consensus/validation.go
@@ -63,7 +63,7 @@ func validateMinerPayouts(s State, b types.Block) error {
 			return errors.New("block must have exactly one miner payout")
 		}
 		// after the final cut, the miner payout value may be omitted
-		if s.childHeight() >= s.Network.HardforkV2.FinalCutHeight && b.MinerPayouts[0].Value.IsZero() {
+		if s.medianTimestamp().After(s.Network.HardforkV2.FinalCutTime) && b.MinerPayouts[0].Value.IsZero() {
 			return nil
 		}
 	}


### PR DESCRIPTION
There's been some internal discussion of timestamp-based forks, so I figured I'd see what it looks like in code and write up some thoughts.

When block times are stable, there is little reason to use timestamp-based forking: just pick the desired timestamp and divide by the block time, and the hardfork should activate within a few hours of the target. But when block times are volatile, this strategy is not so reliable. The v2 hardfork, for example, activated significantly earlier than intended. This is problematic because certain exchanges require e.g. 60 days advance warning of hardforks, which we would be unable to guarantee. There is also the risk of a hardfork activating during a major holiday, or when key team members are out of office. And of course, the further out we schedule a hardfork, the more uncertainty there is about when it will actually activate.

Timestamp-based forks seek to address these problems. Essentially, instead of the hardfork rule being `cs.Index.Height > X`, it's `cs.medianTimestamp() > X`. That way, the fork can be truly "scheduled" in the sense that it will occur with an hour or so of the target time, no matter how rapidly or slowly blocks are being mined.

There are, of course, some downsides. The biggest one for me is that, if we have a mix of height- and timestamp-based hardforks, then (at least in principle) there is no way to guarantee the order in which they will activate. This is especially pernicious in automated testing and testnets, where time is a fuzzier thing than it is on mainnet. It becomes harder to ensure which hardforks are active unless both the height _and_ timestamps are carefully managed.

Other annoyances include the subtlety of when to use `(time.Time{}).Before` vs `(time.Time{}).After` (the temporal equivalent of how the opposite of `<` is `>=`, not `>`) and the fact that `cs.medianTimestamp()` is currently unexported. Third-party code would be the most impacted here, since it would have to manually recompute the median, which is error-prone.

Overall, my view is that timestamp-based forks should only be used as a last resort, when block times are so unstable that height-based activations cannot be scheduled to any useful degree of accuracy. Thankfully, we are not in that position.