### PR TITLE
ProtocolVersion type

### DIFF
--- a/.changeset/add_dedicated_protocolversion_type_for_rhp_version.md
+++ b/.changeset/add_dedicated_protocolversion_type_for_rhp_version.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Add dedicated ProtocolVersion type for RHP version.

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -302,16 +302,6 @@ func GenerateAccount() (types.PrivateKey, Account) {
 // version supported by the RHP server.
 type ProtocolVersion [3]uint8
 
-var (
-	// ProtocolVersionV4 describes the initial version of the RHP4 protocol
-	// introduced with the Sia v2 hardfork.
-	ProtocolVersionV4 = ProtocolVersion{4, 0, 0}
-
-	// ProtocolVersionV5 is the version of the RHP4 protocol that introduced the
-	// 'RefreshContractPartialRollover' RPC.
-	ProtocolVersionV5 = ProtocolVersion{5, 0, 0}
-)
-
 // Cmp compares two ProtocolVersions and returns -1 if v is smaller than other,
 // +1 if it is greater and 0 otherwise.
 func (v *ProtocolVersion) Cmp(other ProtocolVersion) int {

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -302,6 +302,16 @@ func GenerateAccount() (types.PrivateKey, Account) {
 // version supported by the RHP server.
 type ProtocolVersion [3]uint8
 
+var (
+	// ProtocolVersionV4 describes the initial version of the RHP4 protocol
+	// introduced with the Sia v2 hardfork.
+	ProtocolVersionV4 = ProtocolVersion{4, 0, 0}
+
+	// ProtocolVersionV5 is the version of the RHP4 protocol that introduced the
+	// 'RefreshContractPartialRollover' RPC.
+	ProtocolVersionV5 = ProtocolVersion{5, 0, 0}
+)
+
 // Cmp compares two ProtocolVersions and returns -1 if v is smaller than other,
 // +1 if it is greater and 0 otherwise.
 func (v *ProtocolVersion) Cmp(other ProtocolVersion) int {

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -214,7 +214,7 @@ func (hp HostPrices) SigHash() types.Hash256 {
 // HostSettings specify the settings of a host.
 type HostSettings struct {
 	// ProtocolVersion is the version of RHP4 the host supports
-	ProtocolVersion [3]uint8 `json:"protocolVersion"`
+	ProtocolVersion ProtocolVersion `json:"protocolVersion"`
 	// Release identifies the software release of the host
 	Release string `json:"release"`
 	// WalletAddress is the address the host uses to receive payments.
@@ -296,6 +296,29 @@ func (at *AccountToken) SigHash() types.Hash256 {
 func GenerateAccount() (types.PrivateKey, Account) {
 	sk := types.GeneratePrivateKey()
 	return sk, Account(sk.PublicKey())
+}
+
+// ProtocolVersion is a 3-byte version number used to identify the protocol
+// version supported by the RHP server.
+type ProtocolVersion [3]uint8
+
+// Cmp compares two ProtocolVersions and returns -1 if v is smaller than other,
+// +1 if it is greater and 0 otherwise.
+func (v *ProtocolVersion) Cmp(other ProtocolVersion) int {
+	for i := range v {
+		if v[i] < other[i] {
+			return -1
+		} else if v[i] > other[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// String implements the fmt.Stringer interface for easier logging of
+// ProtocolVersion.
+func (v *ProtocolVersion) String() string {
+	return fmt.Sprintf("%d.%d.%d", v[0], v[1], v[2])
 }
 
 type (

--- a/rhp/v4/rhp_test.go
+++ b/rhp/v4/rhp_test.go
@@ -466,3 +466,26 @@ func TestRefreshPartialRolloverCost(t *testing.T) {
 		})
 	}
 }
+
+func TestProtocolVersionCmp(t *testing.T) {
+	for i := range 3 {
+		v1 := ProtocolVersion{1, 1, 1}
+		v2 := ProtocolVersion{1, 1, 1}
+
+		// both should be equal
+		if v1.Cmp(v2) != 0 {
+			t.Error("expected versions to be equal")
+		} else if v2.Cmp(v1) != 0 {
+			t.Error("expected versions to be equal")
+		}
+
+		// update one of the version bytes and make sure that's no longer the
+		// case
+		v1[i] = 2
+		if v1.Cmp(v2) != 1 {
+			t.Errorf("expected %v to be greater than %v", v1, v2)
+		} else if v2.Cmp(v1) != -1 {
+			t.Errorf("expected %v to be less than %v", v2, v1)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a type for the RHP `ProtocolVersion`. That makes it a bit more convenient to check for a specific protocol version by introducing a helper method for comparing versions as well as a `Stringer` implementation for more convenient logging.