### PR TITLE
increase size of RPCFormContractResponse

### DIFF
--- a/.changeset/increase_maxlen_for_request_and_responset_types_including_renterinputs_or_hostinputs.md
+++ b/.changeset/increase_maxlen_for_request_and_responset_types_including_renterinputs_or_hostinputs.md
@@ -2,4 +2,4 @@
 default: patch
 ---
 
-# Increase maxLen for request and responset types including RenterInputs or HostInputs.
+# Increase maxLen for request and response types including RenterInputs or HostInputs.

--- a/.changeset/increase_maxlen_for_request_and_responset_types_including_renterinputs_or_hostinputs.md
+++ b/.changeset/increase_maxlen_for_request_and_responset_types_including_renterinputs_or_hostinputs.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Increase maxLen for request and responset types including RenterInputs or HostInputs.

--- a/rhp/v4/encoding.go
+++ b/rhp/v4/encoding.go
@@ -191,7 +191,7 @@ func (r *RPCFormContractResponse) decodeFrom(d *types.Decoder) {
 	types.DecodeSlice(d, &r.HostInputs)
 }
 func (r *RPCFormContractResponse) maxLen() int {
-	return reasonableObjectSize
+	return reasonableTransactionSetSize
 }
 
 func (r *RPCFormContractSecondResponse) encodeTo(e *types.Encoder) {
@@ -261,7 +261,7 @@ func (r *RPCRenewContractResponse) decodeFrom(d *types.Decoder) {
 	types.DecodeSlice(d, &r.HostInputs)
 }
 func (r *RPCRenewContractResponse) maxLen() int {
-	return reasonableObjectSize
+	return reasonableTransactionSetSize
 }
 
 func (r *RPCRenewContractSecondResponse) encodeTo(e *types.Encoder) {
@@ -331,7 +331,7 @@ func (r *RPCRefreshContractResponse) decodeFrom(d *types.Decoder) {
 	types.DecodeSlice(d, &r.HostInputs)
 }
 func (r *RPCRefreshContractResponse) maxLen() int {
-	return reasonableObjectSize
+	return reasonableTransactionSetSize
 }
 
 func (r *RPCRefreshContractSecondResponse) encodeTo(e *types.Encoder) {


### PR DESCRIPTION
We have been inconsistent with the `maxLen` of request and response types including either `RenterInputs` or `HostInputs`. Most of them (well the requests) already used `reasonableTransactionSetSize` but some still used the smaller reasonableObjectSize`.

I found out because the indexer kept failing to renew a contract with a host due to `UnexpectedEOF` failures caused by the limit reader being limited to a size too small to contain the `RPCRenewContractResponse`.

After deploying a branch with an increased size the contract renewed successfully. 


NOTE: Alternatively we could also stop being fancy, remove `maxLen` and just use a default limit of 5MiB or so.