### PR TITLE
Fix RangeProofVerifier.ReadFrom not returning the actual bytes read from reader

### DIFF
--- a/.changeset/update_rangeproofverifierreadfrom_to_return_actual_bytes_read_from_ioreader_rather_than_multiple_of_subtree_size.md
+++ b/.changeset/update_rangeproofverifierreadfrom_to_return_actual_bytes_read_from_ioreader_rather_than_multiple_of_subtree_size.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Update RangeProofVerifier.ReadFrom to return actual bytes read from io.Reader rather than multiple of subtree size.

--- a/rhp/v2/merkle.go
+++ b/rhp/v2/merkle.go
@@ -394,10 +394,10 @@ func (rpv *RangeProofVerifier) ReadFrom(r io.Reader) (int64, error) {
 		maxSize := int64(subtreeSize * LeafSize)
 		lr := &io.LimitedReader{R: r, N: maxSize}
 		root, err := ReaderRoot(lr)
+		total += maxSize - lr.N
 		if err != nil {
 			return total, err
 		}
-		total += maxSize - lr.N
 		rpv.roots = append(rpv.roots, root)
 		i += subtreeSize
 	}

--- a/rhp/v2/merkle.go
+++ b/rhp/v2/merkle.go
@@ -391,12 +391,13 @@ func (rpv *RangeProofVerifier) ReadFrom(r io.Reader) (int64, error) {
 	i, j := rpv.start, rpv.end
 	for i < j {
 		subtreeSize := nextSubtreeSize(i, j)
-		n := int64(subtreeSize * LeafSize)
-		root, err := ReaderRoot(io.LimitReader(r, n))
+		maxSize := int64(subtreeSize * LeafSize)
+		lr := &io.LimitedReader{R: r, N: maxSize}
+		root, err := ReaderRoot(lr)
 		if err != nil {
 			return total, err
 		}
-		total += n
+		total += maxSize - lr.N
 		rpv.roots = append(rpv.roots, root)
 		i += subtreeSize
 	}

--- a/rhp/v2/merkle_test.go
+++ b/rhp/v2/merkle_test.go
@@ -226,6 +226,34 @@ func TestReadSector(t *testing.T) {
 	}
 }
 
+func TestRangeProofVerifierReadFrom(t *testing.T) {
+	tests := []struct {
+		name            string
+		start, end      uint64
+		availableLeaves uint64
+	}{
+		{"full data, single subtree", 0, 8, 8},
+		{"short reader, single subtree", 0, 8, 4},
+		{"full data, multiple subtrees", 0, 10, 10},
+		{"short reader, multiple subtrees", 0, 10, 9},
+		{"empty reader", 0, 8, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := frand.Bytes(int(tt.availableLeaves) * LeafSize)
+			rpv := NewRangeProofVerifier(tt.start, tt.end)
+			n, err := rpv.ReadFrom(bytes.NewReader(data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if n != int64(len(data)) {
+				t.Fatalf("expected %d bytes read, got %d", len(data), n)
+			}
+		})
+	}
+}
+
 func BenchmarkReadSector(b *testing.B) {
 	buf := bytes.NewBuffer(nil)
 	buf.Grow(SectorSize)

--- a/rhp/v4/merkle_test.go
+++ b/rhp/v4/merkle_test.go
@@ -108,6 +108,7 @@ func TestBuildSectorProof(t *testing.T) {
 		{0, 130},
 		{130, 194},
 		{0, 129},
+		{0, LeavesPerSector},
 		{0, LeavesPerSector / 2},
 		{LeavesPerSector - 1, LeavesPerSector},
 		{LeavesPerSector/2 - 1, LeavesPerSector},
@@ -125,10 +126,13 @@ func TestBuildSectorProof(t *testing.T) {
 		proof := BuildSectorProof(segment, start, end, subtrees)
 
 		rpv := NewRangeProofVerifier(start, end)
-		if _, err := rpv.ReadFrom(bytes.NewReader(sector[start*LeafSize : end*LeafSize])); err != nil {
+		buf := bytes.NewReader(sector[start*LeafSize : end*LeafSize])
+		if n, err := rpv.ReadFrom(buf); err != nil {
 			t.Fatal(err)
 		} else if !rpv.Verify(proof, root) {
 			t.Fatalf("invalid proof for range [%d, %d)", start, end)
+		} else if n != buf.Size() {
+			t.Fatalf("unexpected number of bytes read: got %d, want %d", n, buf.Size())
 		}
 	}
 }


### PR DESCRIPTION
This PR makes sure the `RangeProofVerifier` actually returns the number of bytes read rather than a multiple of the subtree size.

The `RangeProofReader` correctly ignores `EOF` as per the `io.ReaderFrom` interface spec but doesn't return the bytes read from the `io.Reader`. This leads to some issues further down the road.

In `RPCReadSector` we perform the following checks:
```go
	if n, err := rpv.ReadFrom(io.TeeReader(io.LimitReader(s, int64(resp.DataLength)), w)); err != nil {
		return RPCReadSectorResult{}, fmt.Errorf("failed to read data: %w", err)
	} else if !rpv.Verify(resp.Proof, root) {
		return RPCReadSectorResult{}, ErrInvalidProof
	} else if n != int64(resp.DataLength) {
		return RPCReadSectorResult{}, io.ErrUnexpectedEOF
	}
```

This looks pretty sane but the way `ReadFrom` is implemented right now, there is a chance the stream gets closed by the host and returns `io.EOF`. Which causes `ReadFrom` to return without an error and `rpv.Verify` to fail. Even though what we actually want is for `n != resp.DataLength` to be checked first so that we get the `io.ErrUnexpectedEOF` instead. 