### PR TITLE
Error Code for client-side errors

### DIFF
--- a/.changeset/introduce_errorcodeclienterror_for_client_side_rpc_errorsg.md
+++ b/.changeset/introduce_errorcodeclienterror_for_client_side_rpc_errorsg.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# Introduce ErrorCodeClientError for client-side RPC errors.

--- a/rhp/v4/errors.go
+++ b/rhp/v4/errors.go
@@ -12,6 +12,7 @@ const (
 	ErrorCodeBadRequest
 	ErrorCodeDecoding
 	ErrorCodePayment
+	ErrorCodeClientError
 )
 
 // An RPCError pairs a human-readable error description with a status code.


### PR DESCRIPTION
This PR is a proposal to introduce a new error type used for errors that don't originate on the host side but are thrown by the client itself. Making it easier to distinguish that certain client side errors aren't actually transport errors since `ErrorCode` currently falls back to returning `ErrorCodeTransport` whenever an error isn't an `RPCError`. 