### PR TITLE
Add RHP4 pool RPCs and types for shared balance pools

### DIFF
--- a/.changeset/add_rhp4_pool_rpcs_for_shared_balance_pools.md
+++ b/.changeset/add_rhp4_pool_rpcs_for_shared_balance_pools.md
@@ -1,0 +1,7 @@
+---
+default: major
+---
+
+# Add RHP4 pool RPCs and types for shared balance pools.
+
+Pools let a renter deposit once into a shared backing pool and have multiple accounts draw from it on demand, reducing the per-account allowance needed and the total capital tied up in idle balances. This is especially useful for multi-tenant setups where one party holds the funds and many account keypairs spend from them.

--- a/rhp/v4/encoding.go
+++ b/rhp/v4/encoding.go
@@ -124,6 +124,8 @@ var (
 	sizeofAccount        = sizeof(Account{})
 	sizeofAccountToken   = sizeof(types.EncoderFunc(AccountToken{}.encodeTo))
 	sizeofAccountDeposit = sizeof(AccountDeposit{})
+	sizeofPoolAttachment = sizeof(PoolAttachment{})
+	sizeofPoolDetachment = sizeof(PoolDetachment{})
 )
 
 // An Object can be sent or received via a Transport.
@@ -682,12 +684,72 @@ func (r *RPCFundAccountsResponse) encodeTo(e *types.Encoder) {
 	r.HostSignature.EncodeTo(e)
 }
 func (r *RPCFundAccountsResponse) decodeFrom(d *types.Decoder) {
-	types.DecodeSliceCast[types.V2Currency, types.Currency](d, &r.Balances)
+	types.DecodeSliceCast[types.V2Currency](d, &r.Balances)
 	r.HostSignature.DecodeFrom(d)
 }
 func (r *RPCFundAccountsResponse) maxLen() int {
 	return 8 + (sizeofCurrency * MaxAccountBatchSize) + sizeofSignature
 }
+
+// EncodeTo implements types.EncoderTo.
+func (a PoolAttachment) EncodeTo(e *types.Encoder) {
+	a.Account.EncodeTo(e)
+	a.Pool.EncodeTo(e)
+	e.WriteTime(a.ValidUntil)
+	a.Signature.EncodeTo(e)
+}
+
+// DecodeFrom implements types.DecoderFrom.
+func (a *PoolAttachment) DecodeFrom(d *types.Decoder) {
+	a.Account.DecodeFrom(d)
+	a.Pool.DecodeFrom(d)
+	a.ValidUntil = d.ReadTime()
+	a.Signature.DecodeFrom(d)
+}
+
+// EncodeTo implements types.EncoderTo.
+func (d PoolDetachment) EncodeTo(e *types.Encoder) {
+	d.Account.EncodeTo(e)
+	d.Pool.EncodeTo(e)
+	e.WriteTime(d.ValidUntil)
+	d.Signature.EncodeTo(e)
+}
+
+// DecodeFrom implements types.DecoderFrom.
+func (d *PoolDetachment) DecodeFrom(dec *types.Decoder) {
+	d.Account.DecodeFrom(dec)
+	d.Pool.DecodeFrom(dec)
+	d.ValidUntil = dec.ReadTime()
+	d.Signature.DecodeFrom(dec)
+}
+
+func (r *RPCAttachPoolsRequest) encodeTo(e *types.Encoder) {
+	types.EncodeSlice(e, r.Attachments)
+}
+func (r *RPCAttachPoolsRequest) decodeFrom(d *types.Decoder) {
+	types.DecodeSlice(d, &r.Attachments)
+}
+func (r *RPCAttachPoolsRequest) maxLen() int {
+	return 8 + sizeofPoolAttachment*MaxAccountBatchSize
+}
+
+func (r *RPCAttachPoolsResponse) encodeTo(*types.Encoder)   {}
+func (r *RPCAttachPoolsResponse) decodeFrom(*types.Decoder) {}
+func (r *RPCAttachPoolsResponse) maxLen() int               { return 0 }
+
+func (r *RPCDetachPoolsRequest) encodeTo(e *types.Encoder) {
+	types.EncodeSlice(e, r.Detachments)
+}
+func (r *RPCDetachPoolsRequest) decodeFrom(d *types.Decoder) {
+	types.DecodeSlice(d, &r.Detachments)
+}
+func (r *RPCDetachPoolsRequest) maxLen() int {
+	return 8 + sizeofPoolDetachment*MaxAccountBatchSize
+}
+
+func (r *RPCDetachPoolsResponse) encodeTo(*types.Encoder)   {}
+func (r *RPCDetachPoolsResponse) decodeFrom(*types.Decoder) {}
+func (r *RPCDetachPoolsResponse) maxLen() int               { return 0 }
 
 func (r *RPCVerifySectorRequest) encodeTo(e *types.Encoder) {
 	r.Prices.EncodeTo(e)

--- a/rhp/v4/encoding_test.go
+++ b/rhp/v4/encoding_test.go
@@ -46,4 +46,32 @@ func TestEncodingRoundtrip(t *testing.T) {
 		ValidUntil: time.Unix(int64(frand.Intn(math.MaxInt)), 0),
 		Signature:  types.Signature(frand.Bytes(64)),
 	}))
+	t.Run("RPCAttachPoolsRequest", testRoundtrip(&RPCAttachPoolsRequest{
+		Attachments: []PoolAttachment{
+			{
+				Account:    Account(frand.Entropy256()),
+				Pool:       Account(frand.Entropy256()),
+				ValidUntil: time.Unix(int64(frand.Intn(math.MaxInt)), 0),
+				Signature:  types.Signature(frand.Bytes(64)),
+			},
+			{
+				Account:    Account(frand.Entropy256()),
+				Pool:       Account(frand.Entropy256()),
+				ValidUntil: time.Unix(int64(frand.Intn(math.MaxInt)), 0),
+				Signature:  types.Signature(frand.Bytes(64)),
+			},
+		},
+	}))
+	t.Run("RPCAttachPoolsResponse", testRoundtrip(&RPCAttachPoolsResponse{}))
+	t.Run("RPCDetachPoolsRequest", testRoundtrip(&RPCDetachPoolsRequest{
+		Detachments: []PoolDetachment{
+			{
+				Account:    Account(frand.Entropy256()),
+				Pool:       Account(frand.Entropy256()),
+				ValidUntil: time.Unix(int64(frand.Intn(math.MaxInt)), 0),
+				Signature:  types.Signature(frand.Bytes(64)),
+			},
+		},
+	}))
+	t.Run("RPCDetachPoolsResponse", testRoundtrip(&RPCDetachPoolsResponse{}))
 }

--- a/rhp/v4/errors.go
+++ b/rhp/v4/errors.go
@@ -53,6 +53,13 @@ var (
 	// accepting new RPCs.
 	ErrHostShuttingDown = NewRPCError(ErrorCodeHostError, "host is shutting down")
 
+	// ErrPoolNotFound is returned when the host has no record of a pool
+	// referenced by a pool RPC.
+	ErrPoolNotFound = NewRPCError(ErrorCodeHostError, "pool not found")
+	// ErrPoolExpired is returned when a PoolAttachment or PoolDetachment's
+	// ValidUntil is in the past.
+	ErrPoolExpired = NewRPCError(ErrorCodeBadRequest, "pool token expired")
+
 	// ErrHostInternalError is a catch-all for any error that occurs on the host
 	// side and is not the client's fault.
 	ErrHostInternalError = NewRPCError(ErrorCodeHostError, "internal error")

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -653,6 +653,7 @@ type (
 	RPCAttachPoolsRequest struct {
 		Attachments []PoolAttachment `json:"attachments"`
 	}
+	// RPCAttachPoolsResponse an empty success response
 	RPCAttachPoolsResponse struct{}
 
 	// RPCDetachPoolsRequest batches one or more detachments. Applied
@@ -660,6 +661,7 @@ type (
 	RPCDetachPoolsRequest struct {
 		Detachments []PoolDetachment `json:"detachments"`
 	}
+	// RPCDetachPoolsResponse an empty success response
 	RPCDetachPoolsResponse struct{}
 )
 

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -58,6 +58,11 @@ var (
 	RPCWriteSectorID  = types.NewSpecifier("WriteSector")
 	RPCVerifySectorID = types.NewSpecifier("VerifySector")
 	RPCSettingsID     = types.NewSpecifier("Settings")
+
+	RPCFundPoolsID      = types.NewSpecifier("FundPools")
+	RPCReplenishPoolsID = types.NewSpecifier("ReplPools")
+	RPCAttachPoolsID    = types.NewSpecifier("AttachPools")
+	RPCDetachPoolsID    = types.NewSpecifier("DetachPools")
 )
 
 func round4KiB(n uint64) uint64 {
@@ -622,6 +627,40 @@ type (
 		Balances      []types.Currency `json:"balances"`
 		HostSignature types.Signature  `json:"hostSignature"`
 	}
+
+	// PoolAttachment authorizes attaching a single account to a pool. The
+	// signature is by the pool's private key, since the pool holds funds at
+	// risk. Each entry is independently signed so a batch can mix pools owned
+	// by different parties.
+	PoolAttachment struct {
+		Account    Account         `json:"account"`
+		Pool       Account         `json:"pool"`
+		ValidUntil time.Time       `json:"validUntil"`
+		Signature  types.Signature `json:"signature"`
+	}
+
+	// PoolDetachment authorizes detaching a single account from a pool.
+	// Either the account's or the pool's private key may sign.
+	PoolDetachment struct {
+		Account    Account         `json:"account"`
+		Pool       Account         `json:"pool"`
+		ValidUntil time.Time       `json:"validUntil"`
+		Signature  types.Signature `json:"signature"`
+	}
+
+	// RPCAttachPoolsRequest batches one or more attachments. The host applies
+	// them atomically: any structural or signature failure rejects the batch.
+	RPCAttachPoolsRequest struct {
+		Attachments []PoolAttachment `json:"attachments"`
+	}
+	RPCAttachPoolsResponse struct{}
+
+	// RPCDetachPoolsRequest batches one or more detachments. Applied
+	// atomically.
+	RPCDetachPoolsRequest struct {
+		Detachments []PoolDetachment `json:"detachments"`
+	}
+	RPCDetachPoolsResponse struct{}
 )
 
 // ChallengeSigHash returns the hash of the challenge signature used for
@@ -702,6 +741,40 @@ func (r *RPCReplenishAccountsResponse) TotalCost() (total types.Currency) {
 		total = total.Add(deposit.Amount)
 	}
 	return
+}
+
+// SigHash returns the hash of the attachment fields the pool's private key
+// must sign.
+func (a *PoolAttachment) SigHash() types.Hash256 {
+	h := types.NewHasher()
+	a.Account.EncodeTo(h.E)
+	a.Pool.EncodeTo(h.E)
+	h.E.WriteTime(a.ValidUntil)
+	return h.Sum()
+}
+
+// ValidSignature checks that the signature was produced by the pool's
+// private key.
+func (a *PoolAttachment) ValidSignature() bool {
+	return types.PublicKey(a.Pool).VerifyHash(a.SigHash(), a.Signature)
+}
+
+// SigHash returns the hash of the detachment fields that either the
+// account's or the pool's private key may sign.
+func (d *PoolDetachment) SigHash() types.Hash256 {
+	h := types.NewHasher()
+	d.Account.EncodeTo(h.E)
+	d.Pool.EncodeTo(h.E)
+	h.E.WriteTime(d.ValidUntil)
+	return h.Sum()
+}
+
+// ValidSignature checks that the signature was produced by either the
+// account's or the pool's private key.
+func (d *PoolDetachment) ValidSignature() bool {
+	sigHash := d.SigHash()
+	return types.PublicKey(d.Pool).VerifyHash(sigHash, d.Signature) ||
+		types.PublicKey(d.Account).VerifyHash(sigHash, d.Signature)
 }
 
 // NewContract creates a new file contract with the given settings.

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -746,9 +746,13 @@ func (r *RPCReplenishAccountsResponse) TotalCost() (total types.Currency) {
 }
 
 // SigHash returns the hash of the attachment fields the pool's private key
-// must sign.
-func (a *PoolAttachment) SigHash() types.Hash256 {
+// must sign. The host's public key is mixed in to prevent cross-host replay,
+// and RPCAttachPoolsID is mixed in as a domain separator so an attachment
+// signature cannot be replayed as a detachment authorization.
+func (a *PoolAttachment) SigHash(hostKey types.PublicKey) types.Hash256 {
 	h := types.NewHasher()
+	RPCAttachPoolsID.EncodeTo(h.E)
+	hostKey.EncodeTo(h.E)
 	a.Account.EncodeTo(h.E)
 	a.Pool.EncodeTo(h.E)
 	h.E.WriteTime(a.ValidUntil)
@@ -756,15 +760,19 @@ func (a *PoolAttachment) SigHash() types.Hash256 {
 }
 
 // ValidSignature checks that the signature was produced by the pool's
-// private key.
-func (a *PoolAttachment) ValidSignature() bool {
-	return types.PublicKey(a.Pool).VerifyHash(a.SigHash(), a.Signature)
+// private key against this host's public key.
+func (a *PoolAttachment) ValidSignature(hostKey types.PublicKey) bool {
+	return types.PublicKey(a.Pool).VerifyHash(a.SigHash(hostKey), a.Signature)
 }
 
 // SigHash returns the hash of the detachment fields that either the
-// account's or the pool's private key may sign.
-func (d *PoolDetachment) SigHash() types.Hash256 {
+// account's or the pool's private key may sign. The host's public key is
+// mixed in to prevent cross-host replay, and RPCDetachPoolsID is mixed in
+// as a domain separator distinct from the attach sighash.
+func (d *PoolDetachment) SigHash(hostKey types.PublicKey) types.Hash256 {
 	h := types.NewHasher()
+	RPCDetachPoolsID.EncodeTo(h.E)
+	hostKey.EncodeTo(h.E)
 	d.Account.EncodeTo(h.E)
 	d.Pool.EncodeTo(h.E)
 	h.E.WriteTime(d.ValidUntil)
@@ -772,9 +780,9 @@ func (d *PoolDetachment) SigHash() types.Hash256 {
 }
 
 // ValidSignature checks that the signature was produced by either the
-// account's or the pool's private key.
-func (d *PoolDetachment) ValidSignature() bool {
-	sigHash := d.SigHash()
+// account's or the pool's private key against this host's public key.
+func (d *PoolDetachment) ValidSignature(hostKey types.PublicKey) bool {
+	sigHash := d.SigHash(hostKey)
 	return types.PublicKey(d.Pool).VerifyHash(sigHash, d.Signature) ||
 		types.PublicKey(d.Account).VerifyHash(sigHash, d.Signature)
 }

--- a/rhp/v4/rhp.go
+++ b/rhp/v4/rhp.go
@@ -59,7 +59,6 @@ var (
 	RPCVerifySectorID = types.NewSpecifier("VerifySector")
 	RPCSettingsID     = types.NewSpecifier("Settings")
 
-	RPCFundPoolsID      = types.NewSpecifier("FundPools")
 	RPCReplenishPoolsID = types.NewSpecifier("ReplPools")
 	RPCAttachPoolsID    = types.NewSpecifier("AttachPools")
 	RPCDetachPoolsID    = types.NewSpecifier("DetachPools")

--- a/rhp/v4/rhp_test.go
+++ b/rhp/v4/rhp_test.go
@@ -3,6 +3,7 @@ package rhp
 import (
 	"math"
 	"testing"
+	"time"
 
 	"go.sia.tech/core/consensus"
 	"go.sia.tech/core/types"
@@ -476,6 +477,104 @@ func TestRefreshPartialRolloverCost(t *testing.T) {
 				t.Fatalf("expected contract capacity %d, got %d", contract.Capacity, refresh.NewContract.Capacity)
 			}
 		})
+	}
+}
+
+func TestPoolAttachmentSignature(t *testing.T) {
+	hostKey := types.GeneratePrivateKey()
+	otherHostKey := types.GeneratePrivateKey()
+	poolKey := types.GeneratePrivateKey()
+	accountKey := types.GeneratePrivateKey()
+
+	attachment := PoolAttachment{
+		Account:    Account(accountKey.PublicKey()),
+		Pool:       Account(poolKey.PublicKey()),
+		ValidUntil: time.Now().Add(5 * time.Minute),
+	}
+	attachment.Signature = poolKey.SignHash(attachment.SigHash(hostKey.PublicKey()))
+
+	if !attachment.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected valid signature")
+	}
+
+	if attachment.ValidSignature(otherHostKey.PublicKey()) {
+		t.Fatal("expected signature to be invalid for a different host")
+	}
+
+	// only the pool may authorize an attachment; the account key must not.
+	wrongSigner := attachment
+	wrongSigner.Signature = accountKey.SignHash(wrongSigner.SigHash(hostKey.PublicKey()))
+	if wrongSigner.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected signature from non-pool key to be invalid")
+	}
+
+	tampered := attachment
+	tampered.ValidUntil = tampered.ValidUntil.Add(time.Second)
+	if tampered.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected tampered attachment to be invalid")
+	}
+
+	detachment := PoolDetachment{
+		Account:    attachment.Account,
+		Pool:       attachment.Pool,
+		ValidUntil: attachment.ValidUntil,
+		Signature:  attachment.Signature,
+	}
+	if detachment.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected attach signature to be invalid as a detach signature")
+	}
+}
+
+func TestPoolDetachmentSignature(t *testing.T) {
+	hostKey := types.GeneratePrivateKey()
+	otherHostKey := types.GeneratePrivateKey()
+	poolKey := types.GeneratePrivateKey()
+	accountKey := types.GeneratePrivateKey()
+	unrelatedKey := types.GeneratePrivateKey()
+
+	base := PoolDetachment{
+		Account:    Account(accountKey.PublicKey()),
+		Pool:       Account(poolKey.PublicKey()),
+		ValidUntil: time.Now().Add(5 * time.Minute),
+	}
+
+	// either the pool's or the account's private key may authorize a detachment.
+	signedByPool := base
+	signedByPool.Signature = poolKey.SignHash(signedByPool.SigHash(hostKey.PublicKey()))
+	if !signedByPool.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected pool-signed detachment to be valid")
+	}
+
+	signedByAccount := base
+	signedByAccount.Signature = accountKey.SignHash(signedByAccount.SigHash(hostKey.PublicKey()))
+	if !signedByAccount.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected account-signed detachment to be valid")
+	}
+
+	signedByOther := base
+	signedByOther.Signature = unrelatedKey.SignHash(signedByOther.SigHash(hostKey.PublicKey()))
+	if signedByOther.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected detachment signed by unrelated key to be invalid")
+	}
+
+	if signedByPool.ValidSignature(otherHostKey.PublicKey()) {
+		t.Fatal("expected signature to be invalid for a different host")
+	}
+
+	tampered := signedByPool
+	tampered.ValidUntil = tampered.ValidUntil.Add(time.Second)
+	if tampered.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected tampered detachment to be invalid")
+	}
+
+	attachment := PoolAttachment{
+		Account:    base.Account,
+		Pool:       base.Pool,
+		ValidUntil: base.ValidUntil,
+		Signature:  signedByPool.Signature,
+	}
+	if attachment.ValidSignature(hostKey.PublicKey()) {
+		t.Fatal("expected detach signature to be invalid as an attach signature")
 	}
 }
 

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -313,6 +313,58 @@ func (req *RPCReplenishAccountsRequest) Validate() error {
 	return nil
 }
 
+// Validate checks that the request is structurally valid. It does not verify
+// signatures; callers must check ValidSignature on each entry separately.
+func (req *RPCAttachPoolsRequest) Validate() error {
+	if len(req.Attachments) == 0 {
+		return rpcBadRequestError("no attachments")
+	} else if uint64(len(req.Attachments)) > MaxAccountBatchSize {
+		return rpcBadRequestError("too many attachments: %d > %d", len(req.Attachments), MaxAccountBatchSize)
+	}
+	now := time.Now()
+	for i, a := range req.Attachments {
+		switch {
+		case a.Account == (Account{}):
+			return rpcBadRequestError("attachment %d: account must be set", i)
+		case a.Pool == (Account{}):
+			return rpcBadRequestError("attachment %d: pool must be set", i)
+		case a.Account == a.Pool:
+			return rpcBadRequestError("attachment %d: account and pool must differ", i)
+		case now.After(a.ValidUntil):
+			return rpcBadRequestError("attachment %d: expired", i)
+		case a.Signature == (types.Signature{}):
+			return rpcBadRequestError("attachment %d: signature must be set", i)
+		}
+	}
+	return nil
+}
+
+// Validate checks that the request is structurally valid. It does not verify
+// signatures; callers must check ValidSignature on each entry separately.
+func (req *RPCDetachPoolsRequest) Validate() error {
+	if len(req.Detachments) == 0 {
+		return rpcBadRequestError("no detachments")
+	} else if uint64(len(req.Detachments)) > MaxAccountBatchSize {
+		return rpcBadRequestError("too many detachments: %d > %d", len(req.Detachments), MaxAccountBatchSize)
+	}
+	now := time.Now()
+	for i, d := range req.Detachments {
+		switch {
+		case d.Account == (Account{}):
+			return rpcBadRequestError("detachment %d: account must be set", i)
+		case d.Pool == (Account{}):
+			return rpcBadRequestError("detachment %d: pool must be set", i)
+		case d.Account == d.Pool:
+			return rpcBadRequestError("detachment %d: account and pool must differ", i)
+		case now.After(d.ValidUntil):
+			return rpcBadRequestError("detachment %d: expired", i)
+		case d.Signature == (types.Signature{}):
+			return rpcBadRequestError("detachment %d: signature must be set", i)
+		}
+	}
+	return nil
+}
+
 // minProofHeight returns the minimum proof height necessary for a
 // host to accept a contract. This is to ensure the contract
 // has enough time to be confirmed before the proof window begins.

--- a/rhp/v4/validation.go
+++ b/rhp/v4/validation.go
@@ -331,7 +331,7 @@ func (req *RPCAttachPoolsRequest) Validate() error {
 		case a.Account == a.Pool:
 			return rpcBadRequestError("attachment %d: account and pool must differ", i)
 		case now.After(a.ValidUntil):
-			return rpcBadRequestError("attachment %d: expired", i)
+			return ErrPoolExpired
 		case a.Signature == (types.Signature{}):
 			return rpcBadRequestError("attachment %d: signature must be set", i)
 		}
@@ -357,7 +357,7 @@ func (req *RPCDetachPoolsRequest) Validate() error {
 		case d.Account == d.Pool:
 			return rpcBadRequestError("detachment %d: account and pool must differ", i)
 		case now.After(d.ValidUntil):
-			return rpcBadRequestError("detachment %d: expired", i)
+			return ErrPoolExpired
 		case d.Signature == (types.Signature{}):
 			return rpcBadRequestError("detachment %d: signature must be set", i)
 		}


### PR DESCRIPTION
Pools let a renter deposit once into a shared backing pool and have multiple accounts draw from it on demand, reducing the per-account allowance needed and the total capital tied up in idle balances. This is especially useful for multi-tenant setups where one party holds the funds and many account keypairs spend from them.