### PR TITLE
ci: pin GitHub Actions to SHA-256 commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   test:
-    uses: SiaFoundation/workflows/.github/workflows/go-test.yml@master
+    uses: SiaFoundation/workflows/.github/workflows/go-test.yml@22e56c0750c0febb09784caa01c60021e0b5f111 # master
     with:
       try-build: false

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,14 +12,14 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'chore: prepare release')" # Skip merges from releases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Configure Git
         run: |
           git config --global user.name github-actions[bot]
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: knope-dev/action@1ba8f6acf146130c3f5b196465018aa9f553381a
+      - uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
       - run: knope prepare-release --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project-add.yml
+++ b/.github/workflows/project-add.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   add-to-project:
-    uses: SiaFoundation/workflows/.github/workflows/project-add.yml@master
+    uses: SiaFoundation/workflows/.github/workflows/project-add.yml@22e56c0750c0febb09784caa01c60021e0b5f111 # master
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       - name: Configure Git
         run: |
           git config --global user.name github-actions[bot]
           git config --global user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: knope-dev/action@1ba8f6acf146130c3f5b196465018aa9f553381a
+      - uses: knope-dev/action@19617851f9f13ab2f27a05989c55efb18aca3675 # v2.1.2
       - run: knope release --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Pin every `uses:` reference in workflows to a specific commit SHA
- Each pin is annotated with the corresponding version tag in a trailing comment
- Versions stay within the existing major (e.g. `@v4` → latest v4.x.y SHA) to avoid breaking changes

## Why
Mitigates supply-chain attacks where a tag could be retargeted to malicious code. Pinning to a SHA is the [recommended hardening practice](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

## Notes for reviewers
- Annotated tags resolve to the underlying commit SHA (not the tag object)
- For `SiaFoundation/workflows@master` and `dtolnay/rust-toolchain@stable|nightly` (which use a branch ref intentionally), the pin uses the current branch tip SHA — future updates will require a follow-up PR
- This PR was generated by tooling; please skim each workflow diff
