### PR TITLE
Fix overflow bug in Currency.MulWithOverflow

### DIFF
--- a/.changeset/fix_overflow_bug_in_currencymulwithoverflow.md
+++ b/.changeset/fix_overflow_bug_in_currencymulwithoverflow.md
@@ -1,0 +1,5 @@
+---
+default: patch
+---
+
+# Fix overflow bug in Currency.MulWithOverflow

--- a/types/currency.go
+++ b/types/currency.go
@@ -132,8 +132,8 @@ func (c Currency) MulWithOverflow(v Currency) (Currency, bool) {
 	p0, p1 := bits.Mul64(c.Hi, v.Lo)
 	p2, p3 := bits.Mul64(c.Lo, v.Hi)
 	hi, c0 := bits.Add64(hi, p1, 0)
-	hi, c1 := bits.Add64(hi, p3, c0)
-	return Currency{lo, hi}, (c.Hi != 0 && v.Hi != 0) || p0 != 0 || p2 != 0 || c1 != 0
+	hi, c1 := bits.Add64(hi, p3, 0)
+	return Currency{lo, hi}, (c.Hi != 0 && v.Hi != 0) || p0 != 0 || p2 != 0 || c0 != 0 || c1 != 0
 }
 
 // Mul64 returns c*v. If the result would overflow, Mul64 panics.

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"math"
+	"math/big"
 	"strings"
 	"testing"
 
@@ -390,6 +391,14 @@ func TestCurrencyMulWithOverflow(t *testing.T) {
 			NewCurrency(1, 0),
 			true,
 		},
+		{
+			// carry out of the middle-word addition (product is 129 bits): the
+			// overflow must be reported and the low 128 bits must be correct
+			NewCurrency(0x38651f13a91604f7, 1),
+			NewCurrency(0xffffffffffffffff, 0),
+			NewCurrency(0xc79ae0ec56e9fb09, 0x38651f13a91604f5),
+			true,
+		},
 	}
 	for _, tt := range tests {
 		got, overflows := tt.a.MulWithOverflow(tt.b)
@@ -397,6 +406,21 @@ func TestCurrencyMulWithOverflow(t *testing.T) {
 			t.Errorf("Currency.MulWithOverflow(%d, %d) overflow %t, want %t", tt.a, tt.b, overflows, tt.overflows)
 		} else if !got.Equals(tt.want) {
 			t.Errorf("Currency.MulWithOverflow(%d, %d) expected = %v, got %v", tt.a, tt.b, tt.want, got)
+		}
+	}
+}
+
+func TestCurrencyMulWithOverflowFuzz(t *testing.T) {
+	max128 := new(big.Int).Lsh(big.NewInt(1), 128)
+	for i := 0; i < 1e6; i++ {
+		a := NewCurrency(frand.Uint64n(math.MaxUint64), uint64(frand.Intn(256)))
+		b := NewCurrency(frand.Uint64n(math.MaxUint64), uint64(frand.Intn(256)))
+		got, overflows := a.MulWithOverflow(b)
+		prod := new(big.Int).Mul(a.Big(), b.Big())
+		if want := prod.Cmp(max128) >= 0; overflows != want {
+			t.Fatalf("MulWithOverflow(%d, %d) overflow %t, want %t", a, b, overflows, want)
+		} else if !want && got.Big().Cmp(prod) != 0 {
+			t.Fatalf("MulWithOverflow(%d, %d) = %v, want %v", a, b, got, prod)
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes an overflow bug in `Currency.MulWithOverflow`. It was passing the carry from the first high-word add into the second add instead of counting it as overflow, so when that carry hit and the second one didn’t, it reported no overflow on a 129-bit product and returned a result off by 2^64. Net effect: Mul would silently wrap instead of panicking.